### PR TITLE
Fix result text not appearing, fix latter box selection does not play tap sound

### DIFF
--- a/CutTheRope/GameMain/GameController.cs
+++ b/CutTheRope/GameMain/GameController.cs
@@ -214,7 +214,14 @@ namespace CutTheRope.GameMain
             image.SetDrawQuad(gameScene.starsCollected > 0 ? 13 : 14);
             image2.SetDrawQuad(gameScene.starsCollected > 1 ? 13 : 14);
             image3.SetDrawQuad(gameScene.starsCollected > 2 ? 13 : 14);
-            ((Text)boxOpenClose.result.GetChildWithName("passText")).SetString(Application.GetString(STR_MENU_LEVEL_CLEARED1 + gameScene.starsCollected));
+            string clearText = gameScene.starsCollected switch
+            {
+                1 => STR_MENU_LEVEL_CLEARED2,
+                2 => STR_MENU_LEVEL_CLEARED3,
+                3 => STR_MENU_LEVEL_CLEARED4,
+                _ => STR_MENU_LEVEL_CLEARED1
+            };
+            ((Text)boxOpenClose.result.GetChildWithName("passText")).SetString(Application.GetString(clearText));
             boxOpenClose.time = gameScene.time;
             boxOpenClose.starBonus = gameScene.starBonus;
             boxOpenClose.timeBonus = gameScene.timeBonus;

--- a/CutTheRope/GameMain/MenuController.cs
+++ b/CutTheRope/GameMain/MenuController.cs
@@ -1236,7 +1236,7 @@ namespace CutTheRope.GameMain
 
         public void OnButtonPressed(int n)
         {
-            if (n is not (-1) and not 34)
+            if (n is not (-1))
             {
                 CTRSoundMgr.PlaySound(9);
             }

--- a/CutTheRope/GameMain/ResDataPhoneFull.cs
+++ b/CutTheRope/GameMain/ResDataPhoneFull.cs
@@ -837,11 +837,11 @@ namespace CutTheRope.GameMain
 
         internal const string STR_MENU_LEVEL_CLEARED1 = "LEVEL_CLEARED1";
 
-        internal const int STR_MENU_LEVEL_CLEARED2 = 655373;
+        internal const string STR_MENU_LEVEL_CLEARED2 = "LEVEL_CLEARED2";
 
-        internal const int STR_MENU_LEVEL_CLEARED3 = 655374;
+        internal const string STR_MENU_LEVEL_CLEARED3 = "LEVEL_CLEARED3";
 
-        internal const int STR_MENU_LEVEL_CLEARED4 = 655375;
+        internal const string STR_MENU_LEVEL_CLEARED4 = "LEVEL_CLEARED4";
 
         internal const string STR_MENU_LEVEL_SELECT = "LEVEL_SELECT";
 


### PR DESCRIPTION
## Description

- Uses a proper switch expression to choose the correct string constant based on stars collected. Due to the switch to explicit string from XML, the old concatenation method does not work. Fix result text not appearing at the end of the level.
- Fix 12th and latter box pack selection not playing sound