### PR TITLE
Use `TitleContainer` for json texture path

### DIFF
--- a/CutTheRope/Framework/Core/ResourceMgr.cs
+++ b/CutTheRope/Framework/Core/ResourceMgr.cs
@@ -286,6 +286,7 @@ namespace CutTheRope.Framework.Core
             string json = LoadContentText(atlasPath);
             if (string.IsNullOrEmpty(json))
             {
+                Console.WriteLine($"TexturePacker atlas \"{atlasPath}\" could not be loaded (missing file or empty content).");
                 return null;
             }
 

--- a/CutTheRope/GameMain/CTRResourceMgr.cs
+++ b/CutTheRope/GameMain/CTRResourceMgr.cs
@@ -7,6 +7,8 @@ using CutTheRope.Framework;
 using CutTheRope.Framework.Core;
 using CutTheRope.Helpers;
 
+using Microsoft.Xna.Framework;
+
 namespace CutTheRope.GameMain
 {
     /// <summary>
@@ -103,12 +105,13 @@ namespace CutTheRope.GameMain
             try
             {
                 string registryPath = ContentPaths.GetTexturePackerRegistryPath();
-                if (!File.Exists(registryPath))
+                string json = TryReadContentText(registryPath);
+                if (string.IsNullOrEmpty(json))
                 {
+                    Console.WriteLine($"TexturePackerRegistry not found at \"{registryPath}\". TexturePacker atlases will fall back to legacy XML data.");
                     return result; // Return empty dict if no registry file
                 }
 
-                string json = File.ReadAllText(registryPath);
                 using JsonDocument doc = JsonDocument.Parse(json);
 
                 if (!doc.RootElement.TryGetProperty("textures", out JsonElement texturesElement) ||
@@ -179,6 +182,21 @@ namespace CutTheRope.GameMain
             }
 
             return result.Count > 0 ? [.. result] : null;
+        }
+
+        private static string TryReadContentText(string relativePath)
+        {
+            try
+            {
+                using Stream stream = TitleContainer.OpenStream(relativePath);
+                using StreamReader reader = new(stream);
+                return reader.ReadToEnd();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to open \"{relativePath}\": {ex.Message}");
+                return null;
+            }
         }
 
     }


### PR DESCRIPTION
## Description

- Load `TexturePackerRegistry.json` via [`TitleContainer.OpenStream`](https://docs.monogame.net/api/Microsoft.Xna.Framework.TitleContainer.html), making atlas parsing work in other platforms where the working directory differs.
- Add a warning when a TexturePacker atlas JSON can't be loaded to avoid silent fallback to legacy XML quads.