### PR TITLE
Refactor special tutorial trigger logic

### DIFF
--- a/CutTheRope/GameMain/GameScene.Update.cs
+++ b/CutTheRope/GameMain/GameScene.Update.cs
@@ -643,41 +643,8 @@ namespace CutTheRope.GameMain
                     }
                     dd.CallObjectSelectorParamafterDelay(new DelayedDispatcher.DispatchFunc(lantern.CaptureCandyFromDispatcher), star, 0.05);
 
-                    // Handle special tutorial for lantern
-                    if (special == 3)
-                    {
-                        special = 0;
-                        foreach (object obj16 in tutorials)
-                        {
-                            TutorialText tutorialText = (TutorialText)obj16;
-                            if (tutorialText.special == 3)
-                            {
-                                tutorialText.PlayTimeline(0);
-                            }
-                            else
-                            {
-                                Timeline currentTimeline = tutorialText.GetCurrentTimeline();
-                                currentTimeline?.JumpToTrackKeyFrame(3, 2);
-                                tutorialText.color = RGBAColor.transparentRGBA;
-                                currentTimeline?.StopTimeline();
-                            }
-                        }
-                        foreach (object obj17 in tutorialImages)
-                        {
-                            GameObjectSpecial tutorialImage = (GameObjectSpecial)obj17;
-                            if (tutorialImage.special == 3)
-                            {
-                                tutorialImage.PlayTimeline(0);
-                            }
-                            else
-                            {
-                                Timeline currentTimeline2 = tutorialImage.GetCurrentTimeline();
-                                currentTimeline2?.JumpToTrackKeyFrame(3, 2);
-                                tutorialImage.color = RGBAColor.transparentRGBA;
-                                currentTimeline2?.StopTimeline();
-                            }
-                        }
-                    }
+                    // Trigger special tutorial for lantern
+                    TriggerSpecialTutorial(3);
                 }
             }
             RotatedCircle rotatedCircle6 = null;
@@ -1183,6 +1150,52 @@ namespace CutTheRope.GameMain
                     return;
                 }
                 restartState = -1;
+            }
+        }
+
+        /// <summary>
+        /// Handle special tutorial IDs
+        /// </summary>
+        /// <param name="tutorialId"></param>
+        private void TriggerSpecialTutorial(int tutorialId)
+        {
+            if (special != tutorialId)
+            {
+                return;
+            }
+
+            special = 0;
+
+            foreach (object tutorial in tutorials)
+            {
+                TutorialText tutorialText = (TutorialText)tutorial;
+                if (tutorialText.special == tutorialId)
+                {
+                    tutorialText.PlayTimeline(0);
+                }
+                else
+                {
+                    Timeline currentTimeline = tutorialText.GetCurrentTimeline();
+                    currentTimeline?.JumpToTrackKeyFrame(3, 2);
+                    tutorialText.color = RGBAColor.transparentRGBA;
+                    currentTimeline?.StopTimeline();
+                }
+            }
+
+            foreach (object tutorialImageObj in tutorialImages)
+            {
+                GameObjectSpecial tutorialImage = (GameObjectSpecial)tutorialImageObj;
+                if (tutorialImage.special == tutorialId)
+                {
+                    tutorialImage.PlayTimeline(0);
+                }
+                else
+                {
+                    Timeline currentTimeline = tutorialImage.GetCurrentTimeline();
+                    currentTimeline?.JumpToTrackKeyFrame(3, 2);
+                    tutorialImage.color = RGBAColor.transparentRGBA;
+                    currentTimeline?.StopTimeline();
+                }
             }
         }
     }

--- a/CutTheRope/GameMain/LoadObjects/LoadTutorials.cs
+++ b/CutTheRope/GameMain/LoadObjects/LoadTutorials.cs
@@ -85,7 +85,7 @@ namespace CutTheRope.GameMain
                 {
                     gameObjectSpecial.PlayTimeline(0);
                 }
-                if (gameObjectSpecial.special is 2 or 4)
+                if (gameObjectSpecial.special is 2)
                 {
                     Timeline timeline5 = new Timeline().InitWithMaxKeyFramesOnTrack(12);
                     for (int j = 0; j < 2; j++)


### PR DESCRIPTION
## Description

- Decouple special tutorial handling into a new `TriggerSpecialTutorial` method for better code reuse and clarity.
- Updated `LoadTutorials` to only check for special value 2 instead of 2 or 4.