### PR TITLE
Hotfix: prevent freeze when next/replay clicked quickly after winning

### DIFF
--- a/CutTheRope/GameMain/GameController.cs
+++ b/CutTheRope/GameMain/GameController.cs
@@ -278,7 +278,14 @@ namespace CutTheRope.GameMain
             {
                 // Freeze the game scene a bit after the door closing animation finishes
                 TimerManager.RegisterDelayedObjectCall(
-                    (_) => gameScene.updateable = false,
+                    (_) =>
+                    {
+                        // Only freeze if still in result screen (not when replaying/moving to next level)
+                        if (isGamePaused)
+                        {
+                            gameScene.updateable = false;
+                        }
+                    },
                     gameScene,
                     0.5);
             };


### PR DESCRIPTION
## Description

Fix edge case where quickly clicking "Next" or "Replay" on the result screen would freeze the next level. Addresses issue in #55.