### PR TITLE
fix: 14-23 Impossible to 3 obtain 3 stars

### DIFF
--- a/content/maps/14_23.xml
+++ b/content/maps/14_23.xml
@@ -6,7 +6,7 @@
     </layer>
     <layer name="Objects">
         <steamTube x="272" y="344" angle="0" />
-        <bouncer1 x="64" y="229" angle="0" size="1" path="210,0" moveSpeed="50" />
+        <bouncer1 x="64" y="229" angle="0" size="1" path="210,0" moveSpeed="38" />
         <lantern x="278" y="120" candyCaptured="false" />
         <lantern x="206" y="119" candyCaptured="false" />
         <lantern x="130" y="119" candyCaptured="false" />
@@ -16,7 +16,7 @@
         <target x="59" y="342" />
         <steamTube x="205" y="344" angle="0" />
         <steamTube x="133" y="344" angle="0" />
-        <star x="61" y="267" timeout="14" />
+        <star x="61" y="267" timeout="18" />
         <lantern x="50" y="117" candyCaptured="false" />
         <hiddenElement x="273" y="432" radius="30" />
     </layer>


### PR DESCRIPTION
Slightly modifies the level to make it possible to 3 star. The bouncer was made 0.75x slower to compensate for the slower PC physics, andthe timing of the timed star slightly was made slightly more forgiving.