### PR TITLE
Exclude MGCB building for CI environment

### DIFF
--- a/CutTheRope/CutTheRope.csproj
+++ b/CutTheRope/CutTheRope.csproj
@@ -38,6 +38,12 @@
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
     <TieredCompilation>false</TieredCompilation>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+
+    <!-- Default: build content -->
+    <RunMGCB>true</RunMGCB>
+
+    <!-- Auto-disable in CI (GitHub Actions, GitLab, Azure, etc. set CI=true) -->
+    <RunMGCB Condition="'$(CI)' == 'true'">false</RunMGCB>
   </PropertyGroup>
 
   <!-- DesktopGL publish defaults (macOS / Linux) -->
@@ -152,7 +158,7 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(RunMGCB)' == 'true'">
     <MonoGameContentReference Include="..\content\content.mgcb" />
   </ItemGroup>
 


### PR DESCRIPTION
## Description

Added a `.csproj` condition to make build testing faster by skipping the MonoGame content pipeline. This is especially useful for CI environments (e.g. GitHub Actions) where only code compilation and validation are needed, without waiting for MGCB to run.

You can also build with `dotnet build -p:RunMGCB=false` to perform a quick code-only build check.