### PR TITLE
Rename `OpenGL` to `OpenGLRenderer`

### DIFF
--- a/CutTheRope/Commons/CtrRenderer.cs
+++ b/CutTheRope/Commons/CtrRenderer.cs
@@ -147,8 +147,8 @@ namespace CutTheRope.Commons
             {
                 try
                 {
-                    OpenGL.GlClearColor(Color.Black);
-                    OpenGL.GlClear(0);
+                    OpenGLRenderer.GlClearColor(Color.Black);
+                    OpenGLRenderer.GlClear(0);
                 }
                 catch (Exception)
                 {
@@ -245,8 +245,8 @@ namespace CutTheRope.Commons
 
         public static void Java_com_zeptolab_ctr_CtrRenderer_nativeRender()
         {
-            OpenGL.GlClearColor(Color.Black);
-            OpenGL.GlClear(0);
+            OpenGLRenderer.GlClearColor(Color.Black);
+            OpenGLRenderer.GlClear(0);
             if (gApp != null)
             {
                 Application.SharedRootController().PerformDraw();

--- a/CutTheRope/Commons/Popup.cs
+++ b/CutTheRope/Commons/Popup.cs
@@ -89,15 +89,15 @@ namespace CutTheRope.Commons
 
         public override void Draw()
         {
-            OpenGL.GlEnable(OpenGL.GL_BLEND);
-            OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_BLEND);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
             GLDrawer.DrawSolidRectWOBorder(0f, 0f, SCREEN_WIDTH, SCREEN_HEIGHT, RGBAColor.MakeRGBA(0.0, 0.0, 0.0, 0.5));
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlColor4f(Color.White);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlColor4f(Color.White);
             PreDraw();
             PostDraw();
-            OpenGL.GlDisable(OpenGL.GL_BLEND);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_BLEND);
         }
 
         private bool isShow;

--- a/CutTheRope/Desktop/OpenGLRenderer.cs
+++ b/CutTheRope/Desktop/OpenGLRenderer.cs
@@ -14,7 +14,7 @@ namespace CutTheRope.Desktop
     /// This class translates legacy OpenGL-style API calls to modern MonoGame primitives,
     /// using vertex buffers for efficient GPU rendering.
     /// </summary>
-    internal sealed class OpenGL
+    internal sealed class OpenGLRenderer
     {
         #region OpenGL State Constants
         /// <summary>

--- a/CutTheRope/Framework/Core/RootController.cs
+++ b/CutTheRope/Framework/Core/RootController.cs
@@ -38,7 +38,7 @@ namespace CutTheRope.Framework.Core
                 return;
             }
             Application.SharedCanvas().BeforeRender();
-            OpenGL.GlPushMatrix();
+            OpenGLRenderer.GlPushMatrix();
             ApplyLandscape();
             if (transitionTime == -1f)
             {
@@ -56,7 +56,7 @@ namespace CutTheRope.Framework.Core
                     nextScreenImage = null;
                 }
             }
-            OpenGL.GlPopMatrix();
+            OpenGLRenderer.GlPopMatrix();
             GLCanvas.AfterRender();
         }
 
@@ -71,10 +71,10 @@ namespace CutTheRope.Framework.Core
 
         private void DrawViewTransition()
         {
-            OpenGL.GlColor4f(Color.White);
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlEnable(OpenGL.GL_BLEND);
-            OpenGL.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlColor4f(Color.White);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_BLEND);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
             Application.SharedCanvas().SetDefaultRealProjection();
             int num2 = viewTransition;
             if (num2 - 4 <= 1)
@@ -86,51 +86,51 @@ namespace CutTheRope.Framework.Core
                     {
                         RGBAColor fill = viewTransition == 4 ? RGBAColor.MakeRGBA(0.0, 0.0, 0.0, (double)num * 2.0) : RGBAColor.MakeRGBA(1.0, 1.0, 1.0, (double)num * 2.0);
                         Grabber.DrawGrabbedImage(prevScreenImage, 0, 0);
-                        OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
-                        OpenGL.GlEnable(OpenGL.GL_BLEND);
-                        OpenGL.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
+                        OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
+                        OpenGLRenderer.GlEnable(OpenGLRenderer.GL_BLEND);
+                        OpenGLRenderer.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
                         GLDrawer.DrawSolidRectWOBorder(0f, 0f, SCREEN_WIDTH, SCREEN_HEIGHT, fill);
-                        OpenGL.GlDisable(OpenGL.GL_BLEND);
+                        OpenGLRenderer.GlDisable(OpenGLRenderer.GL_BLEND);
                     }
                     else
                     {
                         if (viewTransition == 4)
                         {
-                            OpenGL.GlClearColor(Color.Black);
+                            OpenGLRenderer.GlClearColor(Color.Black);
                         }
                         else
                         {
-                            OpenGL.GlClearColor(Color.White);
+                            OpenGLRenderer.GlClearColor(Color.White);
                         }
-                        OpenGL.GlClear(0);
+                        OpenGLRenderer.GlClear(0);
                     }
                 }
                 else if (nextScreenImage != null)
                 {
                     RGBAColor fill2 = viewTransition == 4 ? RGBAColor.MakeRGBA(0.0, 0.0, 0.0, 2.0 - ((double)num * 2.0)) : RGBAColor.MakeRGBA(1.0, 1.0, 1.0, 2.0 - ((double)num * 2.0));
                     Grabber.DrawGrabbedImage(nextScreenImage, 0, 0);
-                    OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
-                    OpenGL.GlEnable(OpenGL.GL_BLEND);
-                    OpenGL.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
+                    OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
+                    OpenGLRenderer.GlEnable(OpenGLRenderer.GL_BLEND);
+                    OpenGLRenderer.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
                     GLDrawer.DrawSolidRectWOBorder(0f, 0f, SCREEN_WIDTH, SCREEN_HEIGHT, fill2);
-                    OpenGL.GlDisable(OpenGL.GL_BLEND);
+                    OpenGLRenderer.GlDisable(OpenGLRenderer.GL_BLEND);
                 }
                 else
                 {
                     if (viewTransition == 4)
                     {
-                        OpenGL.GlClearColor(Color.Black);
+                        OpenGLRenderer.GlClearColor(Color.Black);
                     }
                     else
                     {
-                        OpenGL.GlClearColor(Color.White);
+                        OpenGLRenderer.GlClearColor(Color.White);
                     }
-                    OpenGL.GlClear(0);
+                    OpenGLRenderer.GlClear(0);
                 }
             }
             ApplyLandscape();
-            OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlDisable(OpenGL.GL_BLEND);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_BLEND);
         }
 
         public override void Activate()
@@ -168,14 +168,14 @@ namespace CutTheRope.Framework.Core
             if (viewTransition != -1 && previousView != null)
             {
                 Application.SharedCanvas().SetDefaultProjection();
-                OpenGL.GlClearColor(Color.Black);
-                OpenGL.GlClear(0);
+                OpenGLRenderer.GlClearColor(Color.Black);
+                OpenGLRenderer.GlClear(0);
                 transitionTime = lastTime + transitionDelay;
                 ApplyLandscape();
                 currentController.ActiveView().Draw();
                 nextScreenImage?.xnaTexture_.Dispose();
                 nextScreenImage = Grabber.Grab();
-                OpenGL.GlLoadIdentity();
+                OpenGLRenderer.GlLoadIdentity();
             }
         }
 
@@ -185,13 +185,13 @@ namespace CutTheRope.Framework.Core
             if (viewTransition != -1 && previousView != null)
             {
                 Application.SharedCanvas().SetDefaultProjection();
-                OpenGL.GlClearColor(Color.Black);
-                OpenGL.GlClear(0);
+                OpenGLRenderer.GlClearColor(Color.Black);
+                OpenGLRenderer.GlClear(0);
                 ApplyLandscape();
                 previousView.Draw();
                 prevScreenImage?.xnaTexture_.Dispose();
                 prevScreenImage = Grabber.Grab();
-                OpenGL.GlLoadIdentity();
+                OpenGLRenderer.GlLoadIdentity();
             }
         }
 

--- a/CutTheRope/Framework/Core/View.cs
+++ b/CutTheRope/Framework/Core/View.cs
@@ -15,14 +15,14 @@ namespace CutTheRope.Framework.Core
 
         public override void Draw()
         {
-            OpenGL.GlColor4f(Color.White);
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlEnable(OpenGL.GL_BLEND);
-            OpenGL.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlColor4f(Color.White);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_BLEND);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
             base.PreDraw();
             base.PostDraw();
-            OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlDisable(OpenGL.GL_BLEND);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_BLEND);
         }
     }
 }

--- a/CutTheRope/Framework/Helpers/Camera2D.cs
+++ b/CutTheRope/Framework/Helpers/Camera2D.cs
@@ -47,12 +47,12 @@ namespace CutTheRope.Framework.Helpers
 
         public void ApplyCameraTransformation()
         {
-            OpenGL.GlTranslatef((double)(0f - pos.X), (double)(0f - pos.Y), 0.0);
+            OpenGLRenderer.GlTranslatef((double)(0f - pos.X), (double)(0f - pos.Y), 0.0);
         }
 
         public void CancelCameraTransformation()
         {
-            OpenGL.GlTranslatef(pos.X, pos.Y, 0.0);
+            OpenGLRenderer.GlTranslatef(pos.X, pos.Y, 0.0);
         }
 
         public CAMERATYPE type;

--- a/CutTheRope/Framework/Helpers/GameObject.cs
+++ b/CutTheRope/Framework/Helpers/GameObject.cs
@@ -181,20 +181,20 @@ namespace CutTheRope.Framework.Helpers
 
         public virtual void DrawBB()
         {
-            OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
             if (rotatedBB)
             {
-                OpenGL.DrawSegment(drawX + rbb.tlX, drawY + rbb.tlY, drawX + rbb.trX, drawY + rbb.trY, RGBAColor.redRGBA);
-                OpenGL.DrawSegment(drawX + rbb.trX, drawY + rbb.trY, drawX + rbb.brX, drawY + rbb.brY, RGBAColor.redRGBA);
-                OpenGL.DrawSegment(drawX + rbb.brX, drawY + rbb.brY, drawX + rbb.blX, drawY + rbb.blY, RGBAColor.redRGBA);
-                OpenGL.DrawSegment(drawX + rbb.blX, drawY + rbb.blY, drawX + rbb.tlX, drawY + rbb.tlY, RGBAColor.redRGBA);
+                OpenGLRenderer.DrawSegment(drawX + rbb.tlX, drawY + rbb.tlY, drawX + rbb.trX, drawY + rbb.trY, RGBAColor.redRGBA);
+                OpenGLRenderer.DrawSegment(drawX + rbb.trX, drawY + rbb.trY, drawX + rbb.brX, drawY + rbb.brY, RGBAColor.redRGBA);
+                OpenGLRenderer.DrawSegment(drawX + rbb.brX, drawY + rbb.brY, drawX + rbb.blX, drawY + rbb.blY, RGBAColor.redRGBA);
+                OpenGLRenderer.DrawSegment(drawX + rbb.blX, drawY + rbb.blY, drawX + rbb.tlX, drawY + rbb.tlY, RGBAColor.redRGBA);
             }
             else
             {
                 GLDrawer.DrawRect(drawX + bb.x, drawY + bb.y, bb.w, bb.h, RGBAColor.redRGBA);
             }
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlColor4f(Color.White);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlColor4f(Color.White);
         }
 
         public static bool ObjectsIntersect(GameObject o1, GameObject o2)

--- a/CutTheRope/Framework/Platform/GLCanvas.cs
+++ b/CutTheRope/Framework/Platform/GLCanvas.cs
@@ -49,15 +49,15 @@ namespace CutTheRope.Framework.Platform
             {
                 string @string = fps.ToString("F1", CultureInfo.InvariantCulture);
                 fpsText.SetString(@string);
-                OpenGL.GlColor4f(Color.White);
-                OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-                OpenGL.GlEnable(OpenGL.GL_BLEND);
-                OpenGL.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
+                OpenGLRenderer.GlColor4f(Color.White);
+                OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+                OpenGLRenderer.GlEnable(OpenGLRenderer.GL_BLEND);
+                OpenGLRenderer.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
                 fpsText.x = 5f;
                 fpsText.y = 5f;
                 fpsText.Draw();
-                OpenGL.GlDisable(OpenGL.GL_BLEND);
-                OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
+                OpenGLRenderer.GlDisable(OpenGLRenderer.GL_BLEND);
+                OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
             }
         }
 
@@ -84,12 +84,12 @@ namespace CutTheRope.Framework.Platform
                 xOffsetScaled = 0;
                 isFullscreen = false;
             }
-            OpenGL.GlViewport(xOffset, yOffset, backingWidth, backingHeight);
-            OpenGL.GlMatrixMode(15);
-            OpenGL.GlLoadIdentity();
-            OpenGL.GlOrthof(0.0, origWidth, origHeight, 0.0, -1.0, 1.0);
-            OpenGL.GlMatrixMode(14);
-            OpenGL.GlLoadIdentity();
+            OpenGLRenderer.GlViewport(xOffset, yOffset, backingWidth, backingHeight);
+            OpenGLRenderer.GlMatrixMode(15);
+            OpenGLRenderer.GlLoadIdentity();
+            OpenGLRenderer.GlOrthof(0.0, origWidth, origHeight, 0.0, -1.0, 1.0);
+            OpenGLRenderer.GlMatrixMode(14);
+            OpenGLRenderer.GlLoadIdentity();
         }
 
         public static void DrawRect()
@@ -165,7 +165,7 @@ namespace CutTheRope.Framework.Platform
         public void BeforeRender()
         {
             SetDefaultProjection();
-            OpenGL.GlDisable(OpenGL.GL_BLEND);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_BLEND);
         }
 
         public static void AfterRender()

--- a/CutTheRope/Framework/Visual/BaseElement.cs
+++ b/CutTheRope/Framework/Visual/BaseElement.cs
@@ -89,7 +89,7 @@ namespace CutTheRope.Framework.Visual
         {
             if (t.pushM || t.rotation != 0.0 || t.scaleX != 1.0 || t.scaleY != 1.0 || t.translateX != 0.0 || t.translateY != 0.0)
             {
-                OpenGL.GlPopMatrix();
+                OpenGLRenderer.GlPopMatrix();
                 t.pushM = false;
             }
         }
@@ -98,7 +98,7 @@ namespace CutTheRope.Framework.Visual
         {
             if (!RGBAColor.RGBAEqual(t.color, RGBAColor.solidOpaqueRGBA))
             {
-                OpenGL.GlColor4f(RGBAColor.solidOpaqueRGBAXna);
+                OpenGLRenderer.GlColor4f(RGBAColor.solidOpaqueRGBAXna);
             }
         }
 
@@ -143,44 +143,44 @@ namespace CutTheRope.Framework.Visual
             bool flag3 = translateX != 0.0 || translateY != 0.0;
             if (flag || flag2 || flag3)
             {
-                OpenGL.GlPushMatrix();
+                OpenGLRenderer.GlPushMatrix();
                 pushM = true;
                 if (flag || flag2)
                 {
                     float num = drawX + (width >> 1) + rotationCenterX;
                     float num2 = drawY + (height >> 1) + rotationCenterY;
-                    OpenGL.GlTranslatef(num, num2, 0f);
+                    OpenGLRenderer.GlTranslatef(num, num2, 0f);
                     if (flag2)
                     {
-                        OpenGL.GlRotatef(rotation, 0f, 0f, 1f);
+                        OpenGLRenderer.GlRotatef(rotation, 0f, 0f, 1f);
                     }
                     if (flag)
                     {
-                        OpenGL.GlScalef(scaleX, scaleY, 1f);
+                        OpenGLRenderer.GlScalef(scaleX, scaleY, 1f);
                     }
-                    OpenGL.GlTranslatef(0f - num, 0f - num2, 0f);
+                    OpenGLRenderer.GlTranslatef(0f - num, 0f - num2, 0f);
                 }
                 if (flag3)
                 {
-                    OpenGL.GlTranslatef(translateX, translateY, 0f);
+                    OpenGLRenderer.GlTranslatef(translateX, translateY, 0f);
                 }
             }
             if (!RGBAColor.RGBAEqual(color, RGBAColor.solidOpaqueRGBA))
             {
-                OpenGL.GlColor4f(color.ToWhiteAlphaXNA());
+                OpenGLRenderer.GlColor4f(color.ToWhiteAlphaXNA());
             }
             if (blendingMode != -1)
             {
                 switch (blendingMode)
                 {
                     case 0:
-                        OpenGL.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
+                        OpenGLRenderer.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
                         return;
                     case 1:
-                        OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+                        OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
                         return;
                     case 2:
-                        OpenGL.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONE);
+                        OpenGLRenderer.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONE);
                         break;
                     default:
                         return;

--- a/CutTheRope/Framework/Visual/CTRTexture2D.cs
+++ b/CutTheRope/Framework/Visual/CTRTexture2D.cs
@@ -14,12 +14,12 @@ namespace CutTheRope.Framework.Visual
             float texTop = t._invHeight * rect.y;
             float texRight = texLeft + (t._invWidth * rect.w);
             float texBottom = texTop + (t._invHeight * rect.h);
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlBindTexture(t.Name());
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlBindTexture(t.Name());
             VertexPositionNormalTexture[] vertices = QuadVertexCache.GetTexturedQuad(
                 point.X, point.Y, rect.w, rect.h,
                 texLeft, texTop, texRight, texBottom);
-            OpenGL.DrawTriangleStrip(vertices);
+            OpenGLRenderer.DrawTriangleStrip(vertices);
         }
 
         public CTRTexture2D Name()
@@ -64,22 +64,22 @@ namespace CutTheRope.Framework.Visual
             Quad2D quad2D = t.quads[q];
             float w = t.quadRects[q].w;
             float h = t.quadRects[q].h;
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlBindTexture(t.Name());
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlBindTexture(t.Name());
             VertexPositionNormalTexture[] vertices = QuadVertexCache.GetTexturedQuad(
                 point.X, point.Y, w, h,
                 quad2D.tlX, quad2D.tlY, quad2D.brX, quad2D.brY);
-            OpenGL.DrawTriangleStrip(vertices);
+            OpenGLRenderer.DrawTriangleStrip(vertices);
         }
 
         public static void DrawAtPoint(CTRTexture2D t, Vector point)
         {
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlBindTexture(t.Name());
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlBindTexture(t.Name());
             VertexPositionNormalTexture[] vertices = QuadVertexCache.GetTexturedQuad(
                 point.X, point.Y, t._realWidth, t._realHeight,
                 0f, 0f, t._maxS, t._maxT);
-            OpenGL.DrawTriangleStrip(vertices);
+            OpenGLRenderer.DrawTriangleStrip(vertices);
         }
 
         public void CalculateForQuickDrawing()
@@ -218,7 +218,7 @@ namespace CutTheRope.Framework.Visual
             if (Global.ScreenSizeManager.IsFullScreen)
             {
                 CtrRenderer.OnDrawFrame();
-                renderTarget = OpenGL.DetachRenderTarget();
+                renderTarget = OpenGLRenderer.DetachRenderTarget();
             }
             else
             {

--- a/CutTheRope/Framework/Visual/CircleElement.cs
+++ b/CutTheRope/Framework/Visual/CircleElement.cs
@@ -15,10 +15,10 @@ namespace CutTheRope.Framework.Visual
         public override void Draw()
         {
             PreDraw();
-            OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
             _ = MIN(width, height);
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlColor4f(Color.White);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlColor4f(Color.White);
             PostDraw();
         }
 

--- a/CutTheRope/Framework/Visual/GLDrawer.cs
+++ b/CutTheRope/Framework/Visual/GLDrawer.cs
@@ -250,7 +250,7 @@ namespace CutTheRope.Framework.Visual
             array6[((vertexCount - 1) * 6) + 1] = RGBAColor.transparentRGBA;
             int stripVertexCount = ((vertexCount - 1) * 6) + 2;
             VertexPositionColor[] vertices = BuildColoredVertices(array, array6, stripVertexCount);
-            OpenGL.DrawTriangleStrip(vertices, stripVertexCount);
+            OpenGLRenderer.DrawTriangleStrip(vertices, stripVertexCount);
         }
 
         private static void CalcCurve(float cx, float cy, float radius, float startAngle, float endAngle, int vertexCount, float[] glVertices)
@@ -350,7 +350,7 @@ namespace CutTheRope.Framework.Visual
             s_rectVertices[1] = new VertexPositionColor(new Vector3(x + w, y, 0f), color);
             s_rectVertices[2] = new VertexPositionColor(new Vector3(x, y + h, 0f), color);
             s_rectVertices[3] = new VertexPositionColor(new Vector3(x + w, y + h, 0f), color);
-            OpenGL.DrawTriangleStrip(s_rectVertices, 4);
+            OpenGLRenderer.DrawTriangleStrip(s_rectVertices, 4);
         }
 
         // Cached vertex array for rectangle drawing
@@ -359,21 +359,21 @@ namespace CutTheRope.Framework.Visual
         public static void DrawPolygon(float[] vertices, int vertexCount, RGBAColor color)
         {
             VertexPositionColor[] lineVertices = BuildClosedLineVertices(vertices, vertexCount, color.ToXNA());
-            OpenGL.DrawLineStrip(lineVertices, vertexCount + 1);
+            OpenGLRenderer.DrawLineStrip(lineVertices, vertexCount + 1);
         }
 
         public static void DrawSolidPolygon(float[] vertices, int vertexCount, RGBAColor border, RGBAColor fill)
         {
             VertexPositionColor[] fillVertices = BuildColoredVertices(vertices, vertexCount, fill.ToXNA());
-            OpenGL.DrawTriangleStrip(fillVertices, vertexCount);
+            OpenGLRenderer.DrawTriangleStrip(fillVertices, vertexCount);
             VertexPositionColor[] lineVertices = BuildClosedLineVertices(vertices, vertexCount, border.ToXNA());
-            OpenGL.DrawLineStrip(lineVertices, vertexCount + 1);
+            OpenGLRenderer.DrawLineStrip(lineVertices, vertexCount + 1);
         }
 
         public static void DrawSolidPolygonWOBorder(float[] vertices, int vertexCount, RGBAColor fill)
         {
             VertexPositionColor[] fillVertices = BuildColoredVertices(vertices, vertexCount, fill.ToXNA());
-            OpenGL.DrawTriangleStrip(fillVertices, vertexCount);
+            OpenGLRenderer.DrawTriangleStrip(fillVertices, vertexCount);
         }
 
         private static VertexPositionColor[] BuildColoredVertices(float[] positions, RGBAColor[] colors, int vertexCount)

--- a/CutTheRope/Framework/Visual/Grabber.cs
+++ b/CutTheRope/Framework/Visual/Grabber.cs
@@ -15,12 +15,12 @@ namespace CutTheRope.Framework.Visual
         {
             if (t != null)
             {
-                OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-                OpenGL.GlBindTexture(t.Name());
+                OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+                OpenGLRenderer.GlBindTexture(t.Name());
                 VertexPositionNormalTexture[] vertices = QuadVertexCache.GetTexturedQuad(
                     x, y, t._realWidth, t._realHeight,
                     0f, 0f, t._maxS, t._maxT);
-                OpenGL.DrawTriangleStrip(vertices);
+                OpenGLRenderer.DrawTriangleStrip(vertices);
             }
         }
     }

--- a/CutTheRope/Framework/Visual/Image.cs
+++ b/CutTheRope/Framework/Visual/Image.cs
@@ -268,12 +268,12 @@ namespace CutTheRope.Framework.Visual
                 y += texture.quadOffsets[n].Y;
             }
             Quad2D quad = texture.quads[n];
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlBindTexture(texture.Name());
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlBindTexture(texture.Name());
             VertexPositionNormalTexture[] vertices = QuadVertexCache.GetTexturedQuad(
                 x, y, w, h,
                 quad.tlX, quad.tlY, quad.brX, quad.brY);
-            OpenGL.DrawTriangleStrip(vertices);
+            OpenGLRenderer.DrawTriangleStrip(vertices);
         }
 
         public override bool HandleAction(ActionData a)

--- a/CutTheRope/Framework/Visual/ImageMultiDrawer.cs
+++ b/CutTheRope/Framework/Visual/ImageMultiDrawer.cs
@@ -71,11 +71,11 @@ namespace CutTheRope.Framework.Visual
 
         private void DrawNumberOfQuads(int n)
         {
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlBindTexture(image.texture.Name());
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlBindTexture(image.texture.Name());
             VertexPositionNormalTexture[] quadVertices = GetVertexBuffer(n * 4);
-            OpenGL.FillTexturedVertices(vertices, texCoordinates, quadVertices, n);
-            OpenGL.DrawTriangleList(quadVertices, indices, n * 6);
+            OpenGLRenderer.FillTexturedVertices(vertices, texCoordinates, quadVertices, n);
+            OpenGLRenderer.DrawTriangleList(quadVertices, indices, n * 6);
         }
 
         public void Optimize(VertexPositionNormalTexture[] v)
@@ -93,15 +93,15 @@ namespace CutTheRope.Framework.Visual
                 DrawNumberOfQuads(totalQuads);
                 return;
             }
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlBindTexture(image.texture.Name());
-            OpenGL.DrawTriangleList(verticesOptimized, indices);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlBindTexture(image.texture.Name());
+            OpenGLRenderer.DrawTriangleList(verticesOptimized, indices);
         }
 
         public override void Draw()
         {
             PreDraw();
-            OpenGL.GlTranslatef(drawX, drawY, 0f);
+            OpenGLRenderer.GlTranslatef(drawX, drawY, 0f);
             if (numberOfQuadsToDraw == -1)
             {
                 DrawAllQuads();
@@ -110,7 +110,7 @@ namespace CutTheRope.Framework.Visual
             {
                 DrawNumberOfQuads(numberOfQuadsToDraw);
             }
-            OpenGL.GlTranslatef(0f - drawX, 0f - drawY, 0f);
+            OpenGLRenderer.GlTranslatef(0f - drawX, 0f - drawY, 0f);
             PostDraw();
         }
 

--- a/CutTheRope/Framework/Visual/MultiParticles.cs
+++ b/CutTheRope/Framework/Visual/MultiParticles.cs
@@ -112,22 +112,22 @@ namespace CutTheRope.Framework.Visual
             PreDraw();
             if (blendAdditive)
             {
-                OpenGL.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONE);
+                OpenGLRenderer.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONE);
             }
             else
             {
-                OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+                OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
             }
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlBindTexture(drawer.image.texture.Name());
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlBindTexture(drawer.image.texture.Name());
             int quadCount = particleIdx;
             if (quadCount > 0)
             {
                 VertexPositionColorTexture[] vertexBuffer = GetVertexBuffer(quadCount * 4);
-                OpenGL.FillTexturedColoredVertices(drawer.vertices, drawer.texCoordinates, colors, vertexBuffer, quadCount);
-                OpenGL.DrawTriangleList(vertexBuffer, drawer.indices, quadCount * 6);
+                OpenGLRenderer.FillTexturedColoredVertices(drawer.vertices, drawer.texCoordinates, colors, vertexBuffer, quadCount);
+                OpenGLRenderer.DrawTriangleList(vertexBuffer, drawer.indices, quadCount * 6);
             }
-            OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
             PostDraw();
         }
 

--- a/CutTheRope/Framework/Visual/RectangleElement.cs
+++ b/CutTheRope/Framework/Visual/RectangleElement.cs
@@ -14,7 +14,7 @@ namespace CutTheRope.Framework.Visual
         public override void Draw()
         {
             base.PreDraw();
-            OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
             if (solid)
             {
                 GLDrawer.DrawSolidRectWOBorder(drawX, drawY, width, height, color);
@@ -23,8 +23,8 @@ namespace CutTheRope.Framework.Visual
             {
                 GLDrawer.DrawRect(drawX, drawY, width, height, color);
             }
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlColor4f(Color.White);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlColor4f(Color.White);
             base.PostDraw();
         }
 

--- a/CutTheRope/Framework/Visual/ScrollableContainer.cs
+++ b/CutTheRope/Framework/Visual/ScrollableContainer.cs
@@ -54,10 +54,10 @@ namespace CutTheRope.Framework.Visual
         public override void Draw()
         {
             PreDraw();
-            OpenGL.GlEnable(OpenGL.GL_SCISSOR_TEST);
-            OpenGL.SetScissorRectangle(drawX, drawY, width, height);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_SCISSOR_TEST);
+            OpenGLRenderer.SetScissorRectangle(drawX, drawY, width, height);
             PostDraw();
-            OpenGL.GlDisable(OpenGL.GL_SCISSOR_TEST);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_SCISSOR_TEST);
         }
 
         public override void PostDraw()

--- a/CutTheRope/Framework/Visual/Text.cs
+++ b/CutTheRope/Framework/Visual/Text.cs
@@ -221,7 +221,7 @@ namespace CutTheRope.Framework.Visual
         public override void Draw()
         {
             // Capture inherited color before we apply this element's own modulation in PreDraw
-            Color inheritedColor = OpenGL.GetCurrentColor();
+            Color inheritedColor = OpenGLRenderer.GetCurrentColor();
 
             PreDraw();
 
@@ -233,7 +233,7 @@ namespace CutTheRope.Framework.Visual
             else if (stringLength > 0)
             {
                 // Legacy sprite font rendering
-                OpenGL.GlTranslatef(drawX, drawY, 0f);
+                OpenGLRenderer.GlTranslatef(drawX, drawY, 0f);
                 int i = 0;
                 int count = multiDrawers.Count;
                 while (i < count)
@@ -242,11 +242,11 @@ namespace CutTheRope.Framework.Visual
                     if (imageMultiDrawer != null)
                     {
                         imageMultiDrawer.DrawAllQuads();
-                        imageMultiDrawer.Optimize(OpenGL.GetLastVertices_PositionNormalTexture());
+                        imageMultiDrawer.Optimize(OpenGLRenderer.GetLastVertices_PositionNormalTexture());
                     }
                     i++;
                 }
-                OpenGL.GlTranslatef(0f - drawX, 0f - drawY, 0f);
+                OpenGLRenderer.GlTranslatef(0f - drawX, 0f - drawY, 0f);
             }
 
             PostDraw();
@@ -254,7 +254,7 @@ namespace CutTheRope.Framework.Visual
 
         private void DrawFontStashText(FontStashFont fontStashFont, Color parentColor)
         {
-            SpriteBatch spriteBatch = OpenGL.GetSpriteBatch();
+            SpriteBatch spriteBatch = OpenGLRenderer.GetSpriteBatch();
             if (spriteBatch == null)
             {
                 Debug.WriteLine("FontStash: SpriteBatch is null");
@@ -357,7 +357,7 @@ namespace CutTheRope.Framework.Visual
 
             // Respect the current OpenGL emulation transform (including parent timelines/animations)
             Matrix transformMatrix =
-                OpenGL.GetModelViewMatrix() *
+                OpenGLRenderer.GetModelViewMatrix() *
                 Matrix.CreateScale(viewportScaleX, viewportScaleY, 1f);
 
             // Begin SpriteBatch for text rendering with proper scaling

--- a/CutTheRope/Game1.cs
+++ b/CutTheRope/Game1.cs
@@ -126,7 +126,7 @@ namespace CutTheRope
             // Initialize FontManager for FontStashSharp fonts
             Framework.Visual.FontManager.Initialize(GraphicsDevice);
 
-            OpenGL.Init();
+            OpenGLRenderer.Init();
             Global.MouseCursor.Load(Content);
             Window.AllowUserResizing = UseWindowMode_TODO_ChangeFullScreenResolution || true;
             Preferences.LoadPreferences();
@@ -266,7 +266,7 @@ namespace CutTheRope
             }
             else if (!_DrawMovie)
             {
-                OpenGL.CopyFromRenderTargetToScreen();
+                OpenGLRenderer.CopyFromRenderTargetToScreen();
             }
             base.Draw(gameTime);
             bFirstFrame = false;

--- a/CutTheRope/GameMain/Bungee.cs
+++ b/CutTheRope/GameMain/Bungee.cs
@@ -101,13 +101,13 @@ namespace CutTheRope.GameMain
                 ccolors2[7] = color;
                 if (highlighted)
                 {
-                    OpenGL.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONE);
+                    OpenGLRenderer.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONE);
                     VertexPositionColor[] highlightVertices = BuildColoredVertices(pointer, ccolors, 8);
-                    OpenGL.DrawTriangleStrip(highlightVertices, 8);
+                    OpenGLRenderer.DrawTriangleStrip(highlightVertices, 8);
                 }
-                OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+                OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
                 VertexPositionColor[] mainVertices = BuildColoredVertices(pointer2, ccolors2, 10);
-                OpenGL.DrawTriangleStrip(mainVertices, 10);
+                OpenGLRenderer.DrawTriangleStrip(mainVertices, 10);
             }
         }
 
@@ -243,7 +243,7 @@ namespace CutTheRope.GameMain
                 if (num8 >= 8 || (double)num7 == 1.0)
                 {
                     RGBAColor color = b.forceWhite ? RGBAColor.whiteRGBA : !flag ? rgbaColor6 : rgbaColor5;
-                    OpenGL.GlColor4f(color.ToXNA());
+                    OpenGLRenderer.GlColor4f(color.ToXNA());
                     int num17 = num8 >> 1;
                     for (int i = 0; i < num17 - 1; i++)
                     {
@@ -516,7 +516,7 @@ namespace CutTheRope.GameMain
         public override void Draw()
         {
             int count = parts.Count;
-            OpenGL.GlColor4f(s_Color1);
+            OpenGLRenderer.GlColor4f(s_Color1);
             if (cut == -1)
             {
                 Vector[] array = new Vector[count];
@@ -632,7 +632,7 @@ namespace CutTheRope.GameMain
             {
                 color.AlphaChannel = alpha;
             }
-            OpenGL.GlColor4f(color.ToXNA());
+            OpenGLRenderer.GlColor4f(color.ToXNA());
 
             // Initialize random seed for consistent light color selection across frames
             // This seed remains the same for the lifetime of the rope
@@ -687,7 +687,7 @@ namespace CutTheRope.GameMain
             }
 
             // Reset drawing color to default
-            OpenGL.GlColor4f(RGBAColor.whiteRGBA.ToXNA());
+            OpenGLRenderer.GlColor4f(RGBAColor.whiteRGBA.ToXNA());
         }
 
         protected override void Dispose(bool disposing)

--- a/CutTheRope/GameMain/CandyBreak.cs
+++ b/CutTheRope/GameMain/CandyBreak.cs
@@ -69,15 +69,15 @@ namespace CutTheRope.GameMain
         public override void Draw()
         {
             PreDraw();
-            OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlBindTexture(drawer.image.texture.Name());
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlBindTexture(drawer.image.texture.Name());
             int quadCount = particleIdx;
             if (quadCount > 0)
             {
                 VertexPositionNormalTexture[] vertexBuffer = GetVertexBuffer(quadCount * 4);
-                OpenGL.FillTexturedVertices(drawer.vertices, drawer.texCoordinates, vertexBuffer, quadCount);
-                OpenGL.DrawTriangleList(vertexBuffer, drawer.indices, quadCount * 6);
+                OpenGLRenderer.FillTexturedVertices(drawer.vertices, drawer.texCoordinates, vertexBuffer, quadCount);
+                OpenGLRenderer.DrawTriangleList(vertexBuffer, drawer.indices, quadCount * 6);
             }
             PostDraw();
         }

--- a/CutTheRope/GameMain/GameScene.Draw.cs
+++ b/CutTheRope/GameMain/GameScene.Draw.cs
@@ -27,20 +27,20 @@ namespace CutTheRope.GameMain
 
         public override void Draw()
         {
-            OpenGL.GlClear(0);
+            OpenGLRenderer.GlClear(0);
             PreDraw();
             camera.ApplyCameraTransformation();
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlDisable(OpenGL.GL_BLEND);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_BLEND);
             Vector pos = VectDiv(camera.pos, 1.25f);
             back.UpdateWithCameraPos(pos);
             float num = Canvas.xOffsetScaled;
             float num2 = 0f;
-            OpenGL.GlPushMatrix();
-            OpenGL.GlTranslatef((double)num, (double)num2, 0.0);
-            OpenGL.GlScalef(back.scaleX, back.scaleY, 1.0);
-            OpenGL.GlTranslatef((double)(0f - num), (double)(0f - num2), 0.0);
-            OpenGL.GlTranslatef(Canvas.xOffsetScaled, 0.0, 0.0);
+            OpenGLRenderer.GlPushMatrix();
+            OpenGLRenderer.GlTranslatef((double)num, (double)num2, 0.0);
+            OpenGLRenderer.GlScalef(back.scaleX, back.scaleY, 1.0);
+            OpenGLRenderer.GlTranslatef((double)(0f - num), (double)(0f - num2), 0.0);
+            OpenGLRenderer.GlTranslatef(Canvas.xOffsetScaled, 0.0, 0.0);
             back.Draw();
             if (mapHeight > SCREEN_HEIGHT)
             {
@@ -58,16 +58,16 @@ namespace CutTheRope.GameMain
                             : new CTRRectangle(0, 0, p2Texture._realWidth, p2Texture._realHeight);
 
                         // Enable blending for p2 to avoid dark seams where alpha overlaps p1.
-                        OpenGL.GlEnable(OpenGL.GL_BLEND);
-                        OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+                        OpenGLRenderer.GlEnable(OpenGLRenderer.GL_BLEND);
+                        OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
                         // Draw p2 at configured Y position (p1 is handled by TileMap)
                         GLDrawer.DrawImagePart(p2Texture, p2Rect, 0.0, p2Y);
-                        OpenGL.GlDisable(OpenGL.GL_BLEND);
+                        OpenGLRenderer.GlDisable(OpenGLRenderer.GL_BLEND);
                     }
                 }
             }
-            OpenGL.GlEnable(OpenGL.GL_BLEND);
-            OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_BLEND);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
             if (earthAnims != null)
             {
                 foreach (object obj in earthAnims)
@@ -75,16 +75,16 @@ namespace CutTheRope.GameMain
                     ((Image)obj).Draw();
                 }
             }
-            OpenGL.GlTranslatef((double)-(double)Canvas.xOffsetScaled, 0.0, 0.0);
-            OpenGL.GlPopMatrix();
-            OpenGL.GlEnable(OpenGL.GL_BLEND);
-            OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlTranslatef((double)-(double)Canvas.xOffsetScaled, 0.0, 0.0);
+            OpenGLRenderer.GlPopMatrix();
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_BLEND);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
             pollenDrawer.Draw();
             gravityButton?.Draw();
             miceManager?.DrawHoles();
-            OpenGL.GlColor4f(Color.White);
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlColor4f(Color.White);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
             support.Draw();
             target.Draw();
             if (sleepAnimPrimary?.visible == true)
@@ -146,7 +146,7 @@ namespace CutTheRope.GameMain
                 lantern.Draw();
             }
 
-            OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
             if (ghosts != null)
             {
                 foreach (object objGhost in ghosts)
@@ -156,7 +156,7 @@ namespace CutTheRope.GameMain
                 }
             }
 
-            OpenGL.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
             foreach (object obj11 in bungees)
             {
                 ((Grab)obj11).DrawBack();
@@ -165,7 +165,7 @@ namespace CutTheRope.GameMain
             {
                 ((Grab)obj12).Draw();
             }
-            OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
             foreach (LightBulb bulb in lightBulbs)
             {
                 bulb?.DrawLight();
@@ -184,9 +184,9 @@ namespace CutTheRope.GameMain
                 candy.Draw();
                 if (candyBlink.GetCurrentTimeline() != null && !isCandyInLantern)
                 {
-                    OpenGL.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONE);
+                    OpenGLRenderer.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONE);
                     candyBlink.Draw();
-                    OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+                    OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
                 }
             }
             if (twoParts != 2)
@@ -221,12 +221,12 @@ namespace CutTheRope.GameMain
                 }
             }
             aniPool.Draw();
-            OpenGL.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
-            OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlColor4f(Color.White);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlColor4f(Color.White);
             DrawCuts();
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
             camera.CancelCameraTransformation();
             staticAniPool.Draw();
             PostDraw();
@@ -327,7 +327,7 @@ namespace CutTheRope.GameMain
                             array3[num4++] = vector6.Y;
                             num3 += num10;
                         }
-                        OpenGL.GlColor4f(Color.White);
+                        OpenGLRenderer.GlColor4f(Color.White);
                         int vertexCount = num4 / 2;
                         VertexPositionColor[] vertices = GetStripVertexCache(vertexCount);
                         int positionIndex = 0;
@@ -336,7 +336,7 @@ namespace CutTheRope.GameMain
                             Vector3 position = new(array3[positionIndex++], array3[positionIndex++], 0f);
                             vertices[vertex] = new VertexPositionColor(position, Color.White);
                         }
-                        OpenGL.DrawTriangleStrip(vertices, vertexCount);
+                        OpenGLRenderer.DrawTriangleStrip(vertices, vertexCount);
                     }
                 }
             }

--- a/CutTheRope/GameMain/GameView.cs
+++ b/CutTheRope/GameMain/GameView.cs
@@ -30,12 +30,12 @@ namespace CutTheRope.GameMain
                 {
                     if (i == 3)
                     {
-                        OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
-                        OpenGL.GlEnable(OpenGL.GL_BLEND);
-                        OpenGL.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
+                        OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
+                        OpenGLRenderer.GlEnable(OpenGLRenderer.GL_BLEND);
+                        OpenGLRenderer.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
                         GLDrawer.DrawSolidRectWOBorder(0f, 0f, SCREEN_WIDTH, SCREEN_HEIGHT, RGBAColor.MakeRGBA(0.1, 0.1, 0.1, 0.5));
-                        OpenGL.GlColor4f(Color.White);
-                        OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
+                        OpenGLRenderer.GlColor4f(Color.White);
+                        OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
                     }
                     child.Draw();
                 }
@@ -48,12 +48,12 @@ namespace CutTheRope.GameMain
                 {
                     num2 = 1f - num2;
                 }
-                OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
-                OpenGL.GlEnable(OpenGL.GL_BLEND);
-                OpenGL.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
+                OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
+                OpenGLRenderer.GlEnable(OpenGLRenderer.GL_BLEND);
+                OpenGLRenderer.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
                 GLDrawer.DrawSolidRectWOBorder(0f, 0f, SCREEN_WIDTH, SCREEN_HEIGHT, RGBAColor.MakeRGBA(1.0, 1.0, 1.0, (double)num2));
-                OpenGL.GlColor4f(Color.White);
-                OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
+                OpenGLRenderer.GlColor4f(Color.White);
+                OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
             }
         }
 

--- a/CutTheRope/GameMain/GhostGrab.cs
+++ b/CutTheRope/GameMain/GhostGrab.cs
@@ -90,10 +90,10 @@ namespace CutTheRope.GameMain
             }
             PreDraw();
             back.color = color;
-            OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
             back.Draw();
-            OpenGL.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
-            OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
             if (radius != -1f || hideRadius)
             {
                 CTRRootController rootController = (CTRRootController)Application.SharedRootController();
@@ -101,13 +101,13 @@ namespace CutTheRope.GameMain
                 RGBAColor grabColor = pack == 6 ? RGBAColor.MakeRGBA(0.4, 0.7, 1.0, radiusAlpha * color.AlphaChannel) : RGBAColor.MakeRGBA(0.2, 0.5, 0.9, radiusAlpha * color.AlphaChannel);
                 DrawGrabCircle(this, grabColor);
             }
-            OpenGL.GlColor4f(Color.White);
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
+            OpenGLRenderer.GlColor4f(Color.White);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
             rope?.Draw();
-            OpenGL.GlColor4f(Color.White);
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlColor4f(Color.White);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
             front.color = color;
             front.Draw();
             PostDraw();

--- a/CutTheRope/GameMain/Grab.cs
+++ b/CutTheRope/GameMain/Grab.cs
@@ -33,7 +33,7 @@ namespace CutTheRope.GameMain
             }
             if (writeIndex > 0)
             {
-                OpenGL.DrawTriangleStrip(vertices, writeIndex);
+                OpenGLRenderer.DrawTriangleStrip(vertices, writeIndex);
             }
         }
 
@@ -221,14 +221,14 @@ namespace CutTheRope.GameMain
             {
                 back.Draw();
             }
-            OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
             if (radius != -1f || hideRadius)
             {
                 RGBAColor rgbaColor = RGBAColor.MakeRGBA(0.2, 0.5, 0.9, radiusAlpha);
                 DrawGrabCircle(this, rgbaColor);
             }
-            OpenGL.GlColor4f(Color.White);
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
+            OpenGLRenderer.GlColor4f(Color.White);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
         }
 
         public void DrawBungee()
@@ -240,20 +240,20 @@ namespace CutTheRope.GameMain
         public override void Draw()
         {
             PreDraw();
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
             Bungee bungee = rope;
             if (wheel)
             {
                 wheelHighlight.visible = wheelOperating != -1;
                 wheelImage3.visible = wheelOperating == -1;
-                OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+                OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
                 wheelImage.Draw();
-                OpenGL.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
+                OpenGLRenderer.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
             }
-            OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
             bungee?.Draw();
-            OpenGL.GlColor4f(Color.White);
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
+            OpenGLRenderer.GlColor4f(Color.White);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
             if (moveLength <= 0.0)
             {
                 front.Draw();

--- a/CutTheRope/GameMain/LightBulb.cs
+++ b/CutTheRope/GameMain/LightBulb.cs
@@ -268,7 +268,7 @@ namespace CutTheRope.GameMain
             PreDraw(); // Apply transformations
             lightGlow.Draw();
             // Reset blend mode to premultiplied alpha after additive glow
-            OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
         }
 
         /// <summary>

--- a/CutTheRope/GameMain/LoadingView.cs
+++ b/CutTheRope/GameMain/LoadingView.cs
@@ -25,9 +25,9 @@ namespace CutTheRope.GameMain
         public override void Draw()
         {
             Global.MouseCursor.Enable(false);
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlEnable(OpenGL.GL_BLEND);
-            OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_BLEND);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
             PreDraw();
             CTRRootController cTRRootController = (CTRRootController)Application.SharedRootController();
             string boxCover = PackConfig.GetBoxCoverOrDefault(cTRRootController.GetPack());
@@ -59,31 +59,31 @@ namespace CutTheRope.GameMain
 
             float num2 = currentPercent;
             CTRTexture2D texture = Application.GetTexture(boxCover);
-            OpenGL.GlColor4f(s_Color1);
+            OpenGLRenderer.GlColor4f(s_Color1);
             Vector quadSize = Image.GetQuadSize(boxCover, 0);
             float num3 = (SCREEN_WIDTH / 2f) - quadSize.X;
             GLDrawer.DrawImageQuad(texture, 0, (double)num3, 0.0);
-            OpenGL.GlPushMatrix();
+            OpenGLRenderer.GlPushMatrix();
             float num4 = (SCREEN_WIDTH / 2f) + (quadSize.X / 2f);
-            OpenGL.GlTranslatef((double)num4, (double)(SCREEN_HEIGHT / 2f), 0.0);
-            OpenGL.GlRotatef(180.0, 0.0, 0.0, 1.0);
-            OpenGL.GlTranslatef((double)(0f - num4), (double)((0f - SCREEN_HEIGHT) / 2f), 0.0);
+            OpenGLRenderer.GlTranslatef((double)num4, (double)(SCREEN_HEIGHT / 2f), 0.0);
+            OpenGLRenderer.GlRotatef(180.0, 0.0, 0.0, 1.0);
+            OpenGLRenderer.GlTranslatef((double)(0f - num4), (double)((0f - SCREEN_HEIGHT) / 2f), 0.0);
             GLDrawer.DrawImageQuad(texture, 0, (double)(SCREEN_WIDTH / 2f), 0.5);
-            OpenGL.GlPopMatrix();
+            OpenGLRenderer.GlPopMatrix();
             CTRTexture2D texture2 = Application.GetTexture(Resources.Img.MenuLoading);
             if (!game)
             {
-                OpenGL.GlEnable(OpenGL.GL_SCISSOR_TEST);
-                OpenGL.SetScissorRectangle(0.0, 0.0, SCREEN_WIDTH, (double)(1200f * num2) / 100.0);
+                OpenGLRenderer.GlEnable(OpenGLRenderer.GL_SCISSOR_TEST);
+                OpenGLRenderer.SetScissorRectangle(0.0, 0.0, SCREEN_WIDTH, (double)(1200f * num2) / 100.0);
             }
-            OpenGL.GlColor4f(Color.White);
+            OpenGLRenderer.GlColor4f(Color.White);
             num3 = Image.GetQuadOffset(Resources.Img.MenuLoading, 0).X;
             GLDrawer.DrawImageQuad(texture2, 0, (double)num3, 80.0);
             num3 = Image.GetQuadOffset(Resources.Img.MenuLoading, 1).X;
             GLDrawer.DrawImageQuad(texture2, 1, (double)num3, 80.0);
             if (!game)
             {
-                OpenGL.GlDisable(OpenGL.GL_SCISSOR_TEST);
+                OpenGLRenderer.GlDisable(OpenGLRenderer.GL_SCISSOR_TEST);
             }
             if (game)
             {
@@ -97,9 +97,9 @@ namespace CutTheRope.GameMain
                 GLDrawer.DrawImageQuad(texture2, 2, 1084.0, (double)num6 - 100.0);
             }
             PostDraw();
-            OpenGL.GlColor4f(Color.White);
-            OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlDisable(OpenGL.GL_BLEND);
+            OpenGLRenderer.GlColor4f(Color.White);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_BLEND);
         }
 
         public bool game;

--- a/CutTheRope/GameMain/MenuController.cs
+++ b/CutTheRope/GameMain/MenuController.cs
@@ -2028,9 +2028,9 @@ namespace CutTheRope.GameMain
                 {
                     num -= preCutSize.X + -20f;
                     float num2 = num - ((s + e) / 2f);
-                    OpenGL.SetScissorRectangle(250.0 - (double)num2, 0.0, 200.0, SCREEN_HEIGHT);
+                    OpenGLRenderer.SetScissorRectangle(250.0 - (double)num2, 0.0, 200.0, SCREEN_HEIGHT);
                     PostDraw();
-                    OpenGL.SetScissorRectangle(c.drawX, c.drawY, c.width, c.height);
+                    OpenGLRenderer.SetScissorRectangle(c.drawX, c.drawY, c.width, c.height);
                 }
             }
 

--- a/CutTheRope/GameMain/MenuView.cs
+++ b/CutTheRope/GameMain/MenuView.cs
@@ -15,14 +15,14 @@ namespace CutTheRope.GameMain
 
         public override void Draw()
         {
-            OpenGL.GlColor4f(Color.White);
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlEnable(OpenGL.GL_BLEND);
-            OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlColor4f(Color.White);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_BLEND);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
             base.PreDraw();
             base.PostDraw();
-            OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlDisable(OpenGL.GL_BLEND);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_BLEND);
         }
     }
 }

--- a/CutTheRope/GameMain/PollenDrawer.cs
+++ b/CutTheRope/GameMain/PollenDrawer.cs
@@ -140,17 +140,17 @@ namespace CutTheRope.GameMain
             if (pollenCount >= 2)
             {
                 PreDraw();
-                OpenGL.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONE);
-                OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-                OpenGL.GlBindTexture(drawer.image.texture.Name());
+                OpenGLRenderer.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONE);
+                OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+                OpenGLRenderer.GlBindTexture(drawer.image.texture.Name());
                 int quadCount = pollenCount - 1;
                 if (quadCount > 0)
                 {
                     VertexPositionColorTexture[] vertexBuffer = GetVertexBuffer(quadCount * 4);
-                    OpenGL.FillTexturedColoredVertices(drawer.vertices, drawer.texCoordinates, colors, vertexBuffer, quadCount);
-                    OpenGL.DrawTriangleList(vertexBuffer, drawer.indices, quadCount * 6);
+                    OpenGLRenderer.FillTexturedColoredVertices(drawer.vertices, drawer.texCoordinates, colors, vertexBuffer, quadCount);
+                    OpenGLRenderer.DrawTriangleList(vertexBuffer, drawer.indices, quadCount * 6);
                 }
-                OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+                OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
                 PostDraw();
             }
         }

--- a/CutTheRope/GameMain/RotatedCircle.cs
+++ b/CutTheRope/GameMain/RotatedCircle.cs
@@ -121,16 +121,16 @@ namespace CutTheRope.GameMain
         {
             if (IsRightControllerActive() || IsLeftControllerActive())
             {
-                OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
-                OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+                OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
+                OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
                 RGBAColor whiteRGBA = RGBAColor.whiteRGBA;
                 if (color.AlphaChannel != 1.0)
                 {
                     whiteRGBA.AlphaChannel = color.AlphaChannel;
                 }
                 GLDrawer.DrawAntialiasedCurve2(x, y, sizeInPixels + (ACTIVE_CIRCLE_WIDTH * vinilControllerL.scaleX), 0f, 6.2831855f, 81, (ACTIVE_CIRCLE_WIDTH + (RTPD(1.0) * 3f)) * vinilControllerL.scaleX, 5f, whiteRGBA);
-                OpenGL.GlColor4f(Color.White);
-                OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
+                OpenGLRenderer.GlColor4f(Color.White);
+                OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
             }
             vinilHighlightL.color = color;
             vinilHighlightR.color = color;
@@ -138,8 +138,8 @@ namespace CutTheRope.GameMain
             vinilControllerR.color = color;
             vinil.color = color;
             vinil.Draw();
-            OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
             foreach (object obj in circlesArray)
             {
                 RotatedCircle item = (RotatedCircle)obj;
@@ -148,9 +148,9 @@ namespace CutTheRope.GameMain
                     GLDrawer.DrawCircleIntersection(x, y, sizeInPixels, item.x, item.y, item.sizeInPixels, 81, OUTER_CIRCLE_WIDTH * item.vinilHighlightL.scaleX * 0.5f, CONTOUR_COLOR);
                 }
             }
-            OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
-            OpenGL.GlColor4f(Color.White);
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlColor4f(Color.White);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
             vinilHighlightL.Draw();
             vinilHighlightR.Draw();
             base.Draw();

--- a/CutTheRope/GameMain/RotatedCircle2.cs
+++ b/CutTheRope/GameMain/RotatedCircle2.cs
@@ -155,19 +155,19 @@ namespace CutTheRope.GameMain
         {
             if (IsRightControllerActive() || IsLeftControllerActive())
             {
-                OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
-                OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+                OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
+                OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
                 GLDrawer.DrawAntialiasedCurve2(x, y, sizeInPixels + (3f * Math.Abs(vinilTR.scaleX)), 0f, 6.2831855f, 51, 2f, 1f * Math.Abs(vinilTR.scaleX), RGBAColor.whiteRGBA);
             }
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
             vinilTL.color = vinilTR.color = vinilBL.color = vinilBR.color = RGBAColor.solidOpaqueRGBA;
             vinilTL.Draw();
             vinilTR.Draw();
             vinilBL.Draw();
             vinilBR.Draw();
-            OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
             if (IsRightControllerActive() || IsLeftControllerActive() || color.AlphaChannel < 1.0)
             {
                 RGBAColor whiteRGBA = RGBAColor.whiteRGBA;
@@ -182,10 +182,10 @@ namespace CutTheRope.GameMain
                     GLDrawer.DrawCircleIntersection(x, y, sizeInPixels, rotatedCircle.x, rotatedCircle.y, rotatedCircle.sizeInPixels, 51, 7f * rotatedCircle.vinilHighlightL.scaleX * 0.5f, CONTOUR_COLOR);
                 }
             }
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
-            OpenGL.GlColor4f(Color.White);
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlColor4f(Color.White);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
             vinilHighlightL.color = color;
             vinilHighlightR.color = color;
             vinilHighlightL.Draw();
@@ -195,12 +195,12 @@ namespace CutTheRope.GameMain
             vinilStickerL.rotation = vinilStickerR.rotation = rotation;
             vinilStickerL.Draw();
             vinilStickerR.Draw();
-            OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
             GLDrawer.DrawAntialiasedCurve2(x, y, vinilStickerL.width * vinilStickerL.scaleX, 0f, 6.2831855f, 51, 1f, vinilStickerL.scaleX * 1.5f, INNER_CIRCLE_COLOR1);
             GLDrawer.DrawAntialiasedCurve2(x, y, (vinilStickerL.width - 2) * vinilStickerL.scaleX, 0f, 6.2831855f, 51, 0f, vinilStickerL.scaleX * 1f, INNER_CIRCLE_COLOR2);
-            OpenGL.GlColor4f(Color.White);
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
+            OpenGLRenderer.GlColor4f(Color.White);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
             vinilControllerL.color = color;
             vinilControllerR.color = color;
             base.Draw();

--- a/CutTheRope/GameMain/SnowfallOverlay.cs
+++ b/CutTheRope/GameMain/SnowfallOverlay.cs
@@ -175,9 +175,9 @@ namespace CutTheRope.GameMain
             PreDraw();
 
             // Enable blending with additive mode for soft glow effect
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlEnable(OpenGL.GL_BLEND);
-            OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_BLEND);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
 
             Vector[] offsets = texture.quadOffsets;
             CTRRectangle[] rects = texture.quadRects;
@@ -213,18 +213,18 @@ namespace CutTheRope.GameMain
                 RGBAColor final = new(1f, 1f, 1f, finalAlpha);
 
                 // Draw snowflake with transformation matrix
-                OpenGL.GlColor4f(final.ToXNA());
-                OpenGL.GlPushMatrix();
-                OpenGL.GlTranslatef(drawX, drawY, 0f);
-                OpenGL.GlScalef(flake.Scale, flake.Scale, 1f);
+                OpenGLRenderer.GlColor4f(final.ToXNA());
+                OpenGLRenderer.GlPushMatrix();
+                OpenGLRenderer.GlTranslatef(drawX, drawY, 0f);
+                OpenGLRenderer.GlScalef(flake.Scale, flake.Scale, 1f);
                 CTRTexture2D.DrawQuadAtPoint(texture, flake.FrameIndex, vectZero);
-                OpenGL.GlPopMatrix();
+                OpenGLRenderer.GlPopMatrix();
             }
 
             // Restore default GL state
-            OpenGL.GlColor4f(Color.White);
-            OpenGL.GlDisable(OpenGL.GL_BLEND);
-            OpenGL.GlDisable(OpenGL.GL_TEXTURE_2D);
+            OpenGLRenderer.GlColor4f(Color.White);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_BLEND);
+            OpenGLRenderer.GlDisable(OpenGLRenderer.GL_TEXTURE_2D);
 
             PostDraw();
         }

--- a/CutTheRope/GameMain/Star.cs
+++ b/CutTheRope/GameMain/Star.cs
@@ -93,7 +93,7 @@ namespace CutTheRope.GameMain
             PostDraw();
 
             // Reset blend state after drawing to prevent affecting subsequent elements (like candy)
-            OpenGL.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
         }
 
         public void CreateAnimations()

--- a/CutTheRope/GameMain/StarsBreak.cs
+++ b/CutTheRope/GameMain/StarsBreak.cs
@@ -58,15 +58,15 @@ namespace CutTheRope.GameMain
         public override void Draw()
         {
             PreDraw();
-            OpenGL.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONE);
-            OpenGL.GlEnable(OpenGL.GL_TEXTURE_2D);
-            OpenGL.GlBindTexture(drawer.image.texture.Name());
+            OpenGLRenderer.GlBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONE);
+            OpenGLRenderer.GlEnable(OpenGLRenderer.GL_TEXTURE_2D);
+            OpenGLRenderer.GlBindTexture(drawer.image.texture.Name());
             int quadCount = particleIdx;
             if (quadCount > 0)
             {
                 VertexPositionColorTexture[] vertexBuffer = GetVertexBuffer(quadCount * 4);
-                OpenGL.FillTexturedColoredVertices(drawer.vertices, drawer.texCoordinates, colors, vertexBuffer, quadCount);
-                OpenGL.DrawTriangleList(vertexBuffer, drawer.indices, quadCount * 6);
+                OpenGLRenderer.FillTexturedColoredVertices(drawer.vertices, drawer.texCoordinates, colors, vertexBuffer, quadCount);
+                OpenGLRenderer.DrawTriangleList(vertexBuffer, drawer.indices, quadCount * 6);
             }
             PostDraw();
         }


### PR DESCRIPTION
## Description

Renamed `OpenGL` to `OpenGLRenderer` to avoid potential name collision.

No changes to functionality.