### PR TITLE
feat: Custom level names

### DIFF
--- a/CutTheRope/GameMain/GameController.cs
+++ b/CutTheRope/GameMain/GameController.cs
@@ -335,7 +335,7 @@ namespace CutTheRope.GameMain
 
             // Update RPC to show win state with stars and score
             CTRRootController ctrRoot = (CTRRootController)Application.SharedRootController();
-            Game1.RPC.SetLevelPresence(ctrRoot.GetPack(), ctrRoot.GetLevel(), gameScene.starsCollected, true, gameScene.score, (int)gameScene.time);
+            Game1.RPC.SetLevelPresence(ctrRoot.GetPack(), ctrRoot.GetLevel(), gameScene.starsCollected, true, gameScene.levelName, gameScene.score, (int)gameScene.time);
 
             UnlockNextLevel();
         }

--- a/CutTheRope/GameMain/GameScene.Initialize.cs
+++ b/CutTheRope/GameMain/GameScene.Initialize.cs
@@ -101,6 +101,8 @@ namespace CutTheRope.GameMain
             sleepSoundTimer = 0f;
             nightSleepOverlayVisible = false;
             gameLostTriggered = false;
+
+            levelName = null;
         }
 
         /// <summary>

--- a/CutTheRope/GameMain/GameScene.LoadMetadata.cs
+++ b/CutTheRope/GameMain/GameScene.LoadMetadata.cs
@@ -43,6 +43,7 @@ namespace CutTheRope.GameMain
                             offsetX = (2560f - (mapWidth * scale)) / 2f;
                             mapWidth *= scale;
                             mapHeight *= scale;
+                            levelName = item2.Attribute("levelName")?.Value ?? null;
 
                             if (PackConfig.GetEarthBg(rc.GetPack()))
                             {
@@ -99,9 +100,6 @@ namespace CutTheRope.GameMain
                                 }
                             }
                             ropePhysicsSpeed *= ActivePhysicsConstants.RopePhysicsSpeedMultiplier;
-                            break;
-                        case "extra":
-                            levelName = item2.Attribute("levelName")?.Value ?? string.Empty;
                             break;
                         case "candyL":
                             starL.pos.X = (ParseIntOrZero(item2.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;

--- a/CutTheRope/GameMain/GameScene.LoadMetadata.cs
+++ b/CutTheRope/GameMain/GameScene.LoadMetadata.cs
@@ -101,6 +101,9 @@ namespace CutTheRope.GameMain
                             }
                             ropePhysicsSpeed *= ActivePhysicsConstants.RopePhysicsSpeedMultiplier;
                             break;
+                        case "extra":
+                            levelName = item2.Attribute("levelName")?.Value ?? string.Empty;
+                            break;
                         case "candyL":
                             starL.pos.X = (ParseIntOrZero(item2.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
                             starL.pos.Y = (ParseIntOrZero(item2.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;

--- a/CutTheRope/GameMain/GameScene.LoadMetadata.cs
+++ b/CutTheRope/GameMain/GameScene.LoadMetadata.cs
@@ -100,6 +100,9 @@ namespace CutTheRope.GameMain
                             }
                             ropePhysicsSpeed *= ActivePhysicsConstants.RopePhysicsSpeedMultiplier;
                             break;
+                        case "extra":
+                            levelName = item2.Attribute("levelName")?.Value ?? string.Empty;
+                            break;
                         case "candyL":
                             starL.pos.X = (ParseIntOrZero(item2.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
                             starL.pos.Y = (ParseIntOrZero(item2.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;

--- a/CutTheRope/GameMain/GameScene.Show.cs
+++ b/CutTheRope/GameMain/GameScene.Show.cs
@@ -58,7 +58,7 @@ namespace CutTheRope.GameMain
             tummyTeasers = 0;
             starsCollected = 0;
             // Update RPC with current level info (on start/restart)
-            Game1.RPC?.SetLevelPresence(cTRRootController.GetPack(), cTRRootController.GetLevel(), starsCollected, false);
+            Game1.RPC?.SetLevelPresence(cTRRootController.GetPack(), cTRRootController.GetLevel(), starsCollected, false, levelName);
             candyBubble = null;
             candyBubbleL = null;
             candyBubbleR = null;
@@ -76,9 +76,10 @@ namespace CutTheRope.GameMain
             ropesCutAtOnce = 0;
             ropeAtOnceTimer = 0f;
             dd.CallObjectSelectorParamafterDelay(new DelayedDispatcher.DispatchFunc(Selector_doCandyBlink), null, 1);
-            Text text = Text.CreateWithFontandString(Resources.Fnt.BigFont, (cTRRootController.GetPack() + 1).ToString(CultureInfo.InvariantCulture) + " - " + (cTRRootController.GetLevel() + 1).ToString(CultureInfo.InvariantCulture));
+            string packAndLevelNumbers = (cTRRootController.GetPack() + 1).ToString(CultureInfo.InvariantCulture) + " - " + (cTRRootController.GetLevel() + 1).ToString(CultureInfo.InvariantCulture);
+            Text text = Text.CreateWithFontandString(Resources.Fnt.BigFont, levelName == null ? packAndLevelNumbers : Application.GetString(levelName));
+            Text text2 = Text.CreateWithFontandString(Resources.Fnt.BigFont, levelName == null ? Application.GetString("LEVEL") : Application.GetString("LEVEL") + " " + packAndLevelNumbers);
             text.anchor = 33;
-            Text text2 = Text.CreateWithFontandString(Resources.Fnt.BigFont, Application.GetString("LEVEL"));
             text2.anchor = 33;
             text2.parentAnchor = 9;
             text.SetName("levelLabel");

--- a/CutTheRope/GameMain/GameScene.Show.cs
+++ b/CutTheRope/GameMain/GameScene.Show.cs
@@ -77,8 +77,9 @@ namespace CutTheRope.GameMain
             ropeAtOnceTimer = 0f;
             dd.CallObjectSelectorParamafterDelay(new DelayedDispatcher.DispatchFunc(Selector_doCandyBlink), null, 1);
             string packAndLevelNumbers = (cTRRootController.GetPack() + 1).ToString(CultureInfo.InvariantCulture) + " - " + (cTRRootController.GetLevel() + 1).ToString(CultureInfo.InvariantCulture);
-            Text text = Text.CreateWithFontandString(Resources.Fnt.BigFont, levelName == null ? packAndLevelNumbers : Application.GetString(levelName));
-            Text text2 = Text.CreateWithFontandString(Resources.Fnt.BigFont, levelName == null ? Application.GetString("LEVEL") : Application.GetString("LEVEL") + " " + packAndLevelNumbers);
+            bool useCustomLevelName = levelName != null && Application.GetString(levelName) != string.Empty;
+            Text text = Text.CreateWithFontandString(Resources.Fnt.BigFont, useCustomLevelName ? Application.GetString(levelName) : packAndLevelNumbers);
+            Text text2 = Text.CreateWithFontandString(Resources.Fnt.BigFont, useCustomLevelName ? Application.GetString("LEVEL") + " " + packAndLevelNumbers : Application.GetString("LEVEL"));
             text.anchor = 33;
             text2.anchor = 33;
             text2.parentAnchor = 9;

--- a/CutTheRope/GameMain/GameScene.Update.cs
+++ b/CutTheRope/GameMain/GameScene.Update.cs
@@ -631,7 +631,7 @@ namespace CutTheRope.GameMain
                         candyBlink.PlayTimeline(1);
                         starsCollected++;
                         // Update RPC with new star count
-                        Game1.RPC?.SetLevelPresence(cTRRootController.GetPack(), cTRRootController.GetLevel(), starsCollected, false);
+                        Game1.RPC?.SetLevelPresence(cTRRootController.GetPack(), cTRRootController.GetLevel(), starsCollected, false, levelName);
                         if (starsCollected <= hudStar.Length)
                         {
                             hudStar[starsCollected - 1].PlayTimeline(0);

--- a/CutTheRope/GameMain/GameScene.cs
+++ b/CutTheRope/GameMain/GameScene.cs
@@ -1166,6 +1166,8 @@ namespace CutTheRope.GameMain
         /// </summary>
         public float partsDist;
 
+        public string levelName;
+
         /// <summary>
         /// Earth animation images used by gravity-switch levels.
         /// </summary>

--- a/CutTheRope/GameMain/GameScene.cs
+++ b/CutTheRope/GameMain/GameScene.cs
@@ -1166,6 +1166,9 @@ namespace CutTheRope.GameMain
         /// </summary>
         public float partsDist;
 
+        /// <summary>
+        /// Optional custom localization key for the current level title.
+        /// </summary>
         public string levelName;
 
         /// <summary>

--- a/CutTheRope/Helpers/RPCHelpers.cs
+++ b/CutTheRope/Helpers/RPCHelpers.cs
@@ -129,7 +129,7 @@ namespace CutTheRope.Helpers
         /// <param name="isWon">Whether the level has been completed.</param>
         /// <param name="score">Final score if the level was won.</param>
         /// <param name="time">Elapsed time in seconds if the level was won.</param>
-        public void SetLevelPresence(int pack, int level, int stars, bool isWon = false, int? score = null, int? time = null)
+        public void SetLevelPresence(int pack, int level, int stars, bool isWon = false, string levelName = null, int? score = null, int? time = null)
         {
             DiscordIpcClient client = Volatile.Read(ref _client);
             if (client == null || !IsRpcEnabled || !client.IsConnected || Application.GetString($"BOX{pack + 1}_LABEL", forceEnglish: true) == null)
@@ -161,7 +161,7 @@ namespace CutTheRope.Helpers
             }
 
             client.SetActivity(
-                details: $"{Application.GetString($"BOX{pack + 1}_LABEL", forceEnglish: true)}: {Application.GetString($"LEVEL", forceEnglish: true)} {pack + 1}-{level + 1}",
+                details: levelName == null ? $"{Application.GetString($"BOX{pack + 1}_LABEL", forceEnglish: true)}: {Application.GetString($"LEVEL", forceEnglish: true)} {pack + 1}-{level + 1}" : $"{Application.GetString($"BOX{pack + 1}_LABEL", forceEnglish: true)}: {Application.GetString(levelName, forceEnglish: true)}",
                 state: state,
                 startTimestamp: GetOrCreateEpochSeconds(),
                 smallImageKey: $"pack_{pack + 1}",

--- a/CutTheRope/Helpers/RPCHelpers.cs
+++ b/CutTheRope/Helpers/RPCHelpers.cs
@@ -160,8 +160,10 @@ namespace CutTheRope.Helpers
                 }
             }
 
+            bool useCustomLevelName = levelName != null && Application.GetString(levelName) != string.Empty;
+
             client.SetActivity(
-                details: levelName == null ? $"{Application.GetString($"BOX{pack + 1}_LABEL", forceEnglish: true)}: {Application.GetString($"LEVEL", forceEnglish: true)} {pack + 1}-{level + 1}" : $"{Application.GetString($"BOX{pack + 1}_LABEL", forceEnglish: true)}: {Application.GetString(levelName, forceEnglish: true)}",
+                details: useCustomLevelName ? $"{Application.GetString($"BOX{pack + 1}_LABEL", forceEnglish: true)}: {Application.GetString(levelName, forceEnglish: true)}" : $"{Application.GetString($"BOX{pack + 1}_LABEL", forceEnglish: true)}: {Application.GetString($"LEVEL", forceEnglish: true)} {pack + 1}-{level + 1}",
                 state: state,
                 startTimestamp: GetOrCreateEpochSeconds(),
                 smallImageKey: $"pack_{pack + 1}",


### PR DESCRIPTION
This introduces the `extra` settings for levels and the new parameter `levelName`.

To-do:
Check and fix the Y values for Chinese text.
Figure out what to do if the string set does not exist in the locales.