### PR TITLE
refactor: Remove `PREFS_` string constants in favor of inline string literals

### DIFF
--- a/CutTheRope/GameMain/Bungee.cs
+++ b/CutTheRope/GameMain/Bungee.cs
@@ -152,7 +152,7 @@ namespace CutTheRope.GameMain
             float alphaMultiplier = b.cut == -1 || b.forceWhite ? 1f : b.cutTime / 1.95f;
 
             // Get selected rope colors from preferences
-            int selectedRopeIndex = Preferences.GetIntForKey(CTRPreferences.PREFS_SELECTED_ROPE);
+            int selectedRopeIndex = Preferences.GetIntForKey("PREFS_SELECTED_ROPE");
             RopeColorHelper.RopeColors ropeColors = RopeColorHelper.GetRopeColors(selectedRopeIndex);
 
             // Apply alpha multiplier to base colors

--- a/CutTheRope/GameMain/CTRPreferences.cs
+++ b/CutTheRope/GameMain/CTRPreferences.cs
@@ -34,7 +34,7 @@ namespace CutTheRope.GameMain
                         int levelsInPackCount = GetLevelsInPackCount(i);
                         while (j < levelsInPackCount)
                         {
-                            int intForKey2 = GetBoxIntForKey(GetBoxForPack(i), GetPackLevelKey(PREFS_SCORE_, i, j));
+                            int intForKey2 = GetBoxIntForKey(GetBoxForPack(i), GetPackLevelKey("SCORE_", i, j));
                             if (intForKey2 > 5999)
                             {
                                 packScoreTotal = 150000;
@@ -71,24 +71,24 @@ namespace CutTheRope.GameMain
         // temporary hack, remove after setting UI is implemented
         private static void SetRpcPreferenceInJson()
         {
-            if (!ContainsKey(PREFS_RPC_ENABLED))
+            if (!ContainsKey("PREFS_RPC_ENABLED"))
             {
-                SetBooleanForKey(true, PREFS_RPC_ENABLED, true);
+                SetBooleanForKey(true, "PREFS_RPC_ENABLED", true);
             }
         }
 
         // temporary hack, remove after setting UI is implemented
         private static void SetUpdateCheckPreferenceInJson()
         {
-            if (!ContainsKey(PREFS_UPDATE_CHECK))
+            if (!ContainsKey("PREFS_UPDATE_CHECK"))
             {
-                SetBooleanForKey(true, PREFS_UPDATE_CHECK, true);
+                SetBooleanForKey(true, "PREFS_UPDATE_CHECK", true);
             }
         }
 
         public static bool IsUpdateCheckEnabled()
         {
-            return GetBooleanForKey(PREFS_UPDATE_CHECK);
+            return GetBooleanForKey("PREFS_UPDATE_CHECK");
         }
 
         private static bool IsShareware()
@@ -114,7 +114,7 @@ namespace CutTheRope.GameMain
 
         public static int GetStarsForPackLevel(int box, int p, int l)
         {
-            return GetBoxIntForKey(box, GetPackLevelKey(PREFS_STARS_, p, l));
+            return GetBoxIntForKey(box, GetPackLevelKey("STARS_", p, l));
         }
 
         public static int GetStarsForPackLevel(int p, int l)
@@ -124,7 +124,7 @@ namespace CutTheRope.GameMain
 
         public static UNLOCKEDSTATE GetUnlockedForPackLevel(int box, int p, int l)
         {
-            string unlockedKey = GetPackLevelKey(PREFS_UNLOCKED_, p, l);
+            string unlockedKey = GetPackLevelKey("UNLOCKED_", p, l);
             bool isUnlocked = GetBoxBoolForKey(box, unlockedKey);
 
             if (!isUnlocked)
@@ -132,7 +132,7 @@ namespace CutTheRope.GameMain
                 return UNLOCKEDSTATE.LOCKED;
             }
 
-            string stateKey = GetPackLevelKey(PREFS_UNLOCKED_STATE_, p, l);
+            string stateKey = GetPackLevelKey("UNLOCKED_STATE_", p, l);
             string stateValue = GetBoxStringForKey(box, stateKey);
             return Enum.TryParse(stateValue, ignoreCase: false, out UNLOCKEDSTATE parsedState) &&
                 parsedState != UNLOCKEDSTATE.LOCKED &&
@@ -216,8 +216,8 @@ namespace CutTheRope.GameMain
 
         public static void SetUnlockedForPackLevel(int box, UNLOCKEDSTATE s, int p, int l)
         {
-            string unlockedKey = GetPackLevelKey(PREFS_UNLOCKED_, p, l);
-            string stateKey = GetPackLevelKey(PREFS_UNLOCKED_STATE_, p, l);
+            string unlockedKey = GetPackLevelKey("UNLOCKED_", p, l);
+            string stateKey = GetPackLevelKey("UNLOCKED_STATE_", p, l);
 
             if (s == UNLOCKEDSTATE.LOCKED)
             {
@@ -303,7 +303,7 @@ namespace CutTheRope.GameMain
 
         public static int GetScoreForPackLevel(int box, int p, int l)
         {
-            return GetBoxIntForKey(box, GetPackLevelKey(PREFS_SCORE_, p, l));
+            return GetBoxIntForKey(box, GetPackLevelKey("SCORE_", p, l));
         }
 
         public static int GetScoreForPackLevel(int p, int l)
@@ -313,7 +313,7 @@ namespace CutTheRope.GameMain
 
         public static void SetScoreForPackLevel(int box, int s, int p, int l)
         {
-            SetBoxIntForKey(box, s, GetPackLevelKey(PREFS_SCORE_, p, l), true);
+            SetBoxIntForKey(box, s, GetPackLevelKey("SCORE_", p, l), true);
         }
 
         public static void SetScoreForPackLevel(int s, int p, int l)
@@ -323,7 +323,7 @@ namespace CutTheRope.GameMain
 
         public static void SetStarsForPackLevel(int box, int s, int p, int l)
         {
-            SetBoxIntForKey(box, s, GetPackLevelKey(PREFS_STARS_, p, l), true);
+            SetBoxIntForKey(box, s, GetPackLevelKey("STARS_", p, l), true);
         }
 
         public static void SetStarsForPackLevel(int s, int p, int l)
@@ -389,8 +389,8 @@ namespace CutTheRope.GameMain
                     continue;
                 }
 
-                SetBoxBoolForKey(box, true, GetPackLevelKey(PREFS_UNLOCKED_, pack, 0), false);
-                RemoveBoxKey(box, GetPackLevelKey(PREFS_UNLOCKED_STATE_, pack, 0));
+                SetBoxBoolForKey(box, true, GetPackLevelKey("UNLOCKED_", pack, 0), false);
+                RemoveBoxKey(box, GetPackLevelKey("UNLOCKED_STATE_", pack, 0));
                 changed = true;
             }
 
@@ -412,7 +412,7 @@ namespace CutTheRope.GameMain
                 }
 
                 int box = GetBoxForPack(i);
-                SetBoxBoolForKey(box, true, GetPackLevelKey(PREFS_UNLOCKED_, i, 0), false);
+                SetBoxBoolForKey(box, true, GetPackLevelKey("UNLOCKED_", i, 0), false);
             }
 
             SetIntForKey(0, "PREFS_ROPES_CUT", true);
@@ -432,8 +432,8 @@ namespace CutTheRope.GameMain
             SetIntForKey(0, "PREFS_LAST_BOX", true);
             SetIntForKey(0, "PREFS_LAST_GAMEPACK", true);
             SetBooleanForKey(true, "PREFS_WINDOW_FULLSCREEN", true);
-            SetBooleanForKey(true, PREFS_RPC_ENABLED, true);
-            SetBooleanForKey(true, PREFS_UPDATE_CHECK, true);
+            SetBooleanForKey(true, "PREFS_RPC_ENABLED", true);
+            SetBooleanForKey(true, "PREFS_UPDATE_CHECK", true);
             CheckForUnlockIAP();
             RequestSave();
             SetScoreHash();
@@ -465,7 +465,7 @@ namespace CutTheRope.GameMain
             {
                 for (int j = 0; j < GetLevelsInPackCount(i); j++)
                 {
-                    totalScore += GetBoxIntForKey(GetBoxForPack(i), GetPackLevelKey(PREFS_SCORE_, i, j));
+                    totalScore += GetBoxIntForKey(GetBoxForPack(i), GetPackLevelKey("SCORE_", i, j));
                 }
             }
             return totalScore;
@@ -493,9 +493,9 @@ namespace CutTheRope.GameMain
                 while (j < levelsInPackCount)
                 {
                     int box = GetBoxForPack(i);
-                    SetBoxBoolForKey(box, true, GetPackLevelKey(PREFS_UNLOCKED_, i, j), false);
-                    RemoveBoxKey(box, GetPackLevelKey(PREFS_UNLOCKED_STATE_, i, j));
-                    SetBoxIntForKey(box, stars, GetPackLevelKey(PREFS_STARS_, i, j), false);
+                    SetBoxBoolForKey(box, true, GetPackLevelKey("UNLOCKED_", i, j), false);
+                    RemoveBoxKey(box, GetPackLevelKey("UNLOCKED_STATE_", i, j));
+                    SetBoxIntForKey(box, stars, GetPackLevelKey("STARS_", i, j), false);
                     j++;
                 }
                 i++;
@@ -508,187 +508,11 @@ namespace CutTheRope.GameMain
             return true;
         }
 
-        public const int VERSION_NUMBER_AT_WHICH_SCORE_HASH_INTRODUCED = 1;
-
-        public const int VERSION_NUMBER = 2;
-
-        public const int MAX_LEVEL_SCORE = 5999;
-
-        public const int MAX_PACK_SCORE = 149999;
-
-        public const int CANDIES_COUNT = 3;
-
         public const string TWITTER_LINK = "https://mobile.twitter.com/zeptolab";
 
         public const string FACEBOOK_LINK = "http://www.facebook.com/cuttherope";
 
         public const string EXPERIMENTS_LINK = "http://www.amazon.com/gp/mas/dl/android?p=com.zeptolab.ctrexperiments.hd.amazon.paid";
-
-        public const int BOXES_CUT_OUT = 0;
-
-        public const int MAX_PACKS = 12;
-
-        public const int MAX_LEVELS_IN_A_PACK = 25;
-
-        public const string PREFS_WINDOW_WIDTH = "PREFS_WINDOW_WIDTH";
-
-        public const string PREFS_WINDOW_HEIGHT = "PREFS_WINDOW_HEIGHT";
-
-        public const string PREFS_WINDOW_FULLSCREEN = "PREFS_WINDOW_FULLSCREEN";
-
-        public const string PREFS_LOCALE = "PREFS_LOCALE";
-
-        public const string PREFS_PREFER_OLD_FONT_SYSTEM = "PREFS_PREFER_OLD_FONT_SYSTEM";
-
-        public const string PREFS_IS_EXIST = "PREFS_EXIST";
-
-        public const string PREFS_RPC_ENABLED = "PREFS_RPC_ENABLED";
-
-        public const string PREFS_UPDATE_CHECK = "PREFS_UPDATE_CHECK";
-
-        public const string PREFS_SOUND_ON = "SOUND_ON";
-
-        public const string PREFS_MUSIC_ON = "MUSIC_ON";
-
-        public const string PREFS_SCORE_ = "SCORE_";
-
-        public const string PREFS_STARS_ = "STARS_";
-
-        public const string PREFS_UNLOCKED_ = "UNLOCKED_";
-
-        public const string PREFS_UNLOCKED_STATE_ = "UNLOCKED_STATE_";
-
-        public const string PREFS_DRAWINGS_ = "DRAWINGS_";
-
-        public const string PREFS_NEW_DRAWINGS_COUNTER = "PREFS_NEW_DRAWINGS_COUNTER";
-
-        public const string PREFS_ROPES_CUT = "PREFS_ROPES_CUT";
-
-        public const string PREFS_ROPES_SHOOT = "PREFS_ROPES_SHOOT";
-
-        public const string PREFS_BUBBLES_POPPED = "PREFS_BUBBLES_POPPED";
-
-        public const string PREFS_SPIDERS_BUSTED = "PREFS_SPIDERS_BUSTED";
-
-        public const string PREFS_CANDIES_LOST = "PREFS_CANDIES_LOST";
-
-        public const string PREFS_CANDIES_UNITED = "PREFS_CANDIES_UNITED";
-
-        public const string PREFS_SOCKS_USED = "PREFS_SOCKS_USED";
-
-        public const string PREFS_LAST_BOX = "PREFS_LAST_BOX";
-
-        public const string PREFS_LAST_GAMEPACK = "PREFS_LAST_GAMEPACK";
-
-        public const string PREFS_CLICK_TO_CUT = "PREFS_CLICK_TO_CUT";
-
-        public const string PREFS_CANDY_WAS_CHANGED = "PREFS_CANDY_WAS_CHANGED";
-
-        public const string PREFS_SELECTED_CANDY = "PREFS_SELECTED_CANDY";
-
-        public const string PREFS_SELECTED_ROPE = "PREFS_SELECTED_ROPE";
-
-        public const string PREFS_SELECTED_OMNOM = "PREFS_SELECTED_OMNOM";
-
-        public const string PREFS_SELECTED_TRACE = "PREFS_SELECTED_TRACE";
-
-        public const string PREFS_GAME_CENTER_ENABLED = "PREFS_GAME_CENTER_ENABLED";
-
-        public const string PREFS_SCORE_HASH = "PREFS_SCORE_HASH";
-
-        public const string PREFS_VERSION = "PREFS_VERSION";
-
-        public const string PREFS_GAME_STARTS = "PREFS_GAME_STARTS";
-
-        public const string PREFS_LEVELS_WON = "PREFS_LEVELS_WON";
-
-        public const string PREFS_IAP_UNLOCK = "IAP_UNLOCK";
-
-        public const string PREFS_IAP_BANNERS = "IAP_BANNERS";
-
-        public const string PREFS_IAP_SHAREWARE = "IAP_SHAREWARE";
-
-        public const string acBronzeScissors = "677900534";
-
-        public const string acSilverScissors = "681508185";
-
-        public const string acGoldenScissors = "681473653";
-
-        public const string acRopeCutter = "681461850";
-
-        public const string acRopeCutterManiac = "681457931";
-
-        public const string acUltimateRopeCutter = "1058248892";
-
-        public const string acQuickFinger = "681464917";
-
-        public const string acMasterFinger = "681508316";
-
-        public const string acBubblePopper = "681513183";
-
-        public const string acBubbleMaster = "1058345234";
-
-        public const string acSpiderBuster = "681486608";
-
-        public const string acSpiderTamer = "1058341284";
-
-        public const string acWeightLoser = "681497443";
-
-        public const string acCalorieMinimizer = "1058341297";
-
-        public const string acTummyTeaser = "1058281905";
-
-        public const string acRomanticSoul = "1432722351";
-
-        public const string acMagician = "1515796440";
-
-        public const string acCardboardBox = "681486798";
-
-        public const string acCardboardPerfect = "1058364368";
-
-        public const string acFabricBox = "681462993";
-
-        public const string acFabricPerfect = "1058328727";
-
-        public const string acFoilBox = "681520253";
-
-        public const string acFoilPerfect = "1058324751";
-
-        public const string acGiftBox = "681512374";
-
-        public const string acGiftPerfect = "1058327768";
-
-        public const string acCosmicBox = "1058310903";
-
-        public const string acCosmicPerfect = "1058407145";
-
-        public const string acValentineBox = "1432721430";
-
-        public const string acValentinePerfect = "1432760157";
-
-        public const string acMagicBox = "1515813296";
-
-        public const string acMagicPerfect = "1515793567";
-
-        public const string acToyBox = "1991474812";
-
-        public const string acToyPerfect = "1991641832";
-
-        public const string acToolBox = "1321820679";
-
-        public const string acToolPerfect = "1335599628";
-
-        public const string acBuzzBox = "23523272771";
-
-        public const string acBuzzPerfect = "99928734496";
-
-        public const string acDJBox = "com.zeptolab.ctr.djboxcompleted";
-
-        public const string acDJPerfect = "com.zeptolab.ctr.djboxperfect";
-
-        public const string acSpookyBox = "com.zeptolab.ctr.spookyboxcompleted";
-
-        public const string acSpookyPerfect = "com.zeptolab.ctr.spookyboxperfect";
 
         public RemoteDataManager remoteDataManager = new();
 

--- a/CutTheRope/GameMain/CTRRootController.cs
+++ b/CutTheRope/GameMain/CTRRootController.cs
@@ -647,7 +647,7 @@ namespace CutTheRope.GameMain
         private static readonly string[] PackGame = [
             Resources.Img.MenuButtons,
             Resources.Img.HudUi,
-            CandySkinHelper.GetCandyResource(Preferences.GetIntForKey(CTRPreferences.PREFS_SELECTED_CANDY)),
+            CandySkinHelper.GetCandyResource(Preferences.GetIntForKey("PREFS_SELECTED_CANDY")),
             Resources.Img.ObjCandyFx,
             Resources.Img.ObjSpider,
             Resources.Img.ConfettiParticles,

--- a/CutTheRope/GameMain/CandySelectionView.cs
+++ b/CutTheRope/GameMain/CandySelectionView.cs
@@ -329,7 +329,7 @@ namespace CutTheRope.GameMain
             {
                 case CandySelectionMode.Rope:
                     totalItems = RopeColorHelper.TotalRopeColors;
-                    selectedIndex = Preferences.GetIntForKey(CTRPreferences.PREFS_SELECTED_ROPE);
+                    selectedIndex = Preferences.GetIntForKey("PREFS_SELECTED_ROPE");
                     baseQuadIndex = 60; // rope01-rope09 are quads 60-68
                     getButtonId = MenuButtonId.ForRopeSlot;
                     break;
@@ -337,7 +337,7 @@ namespace CutTheRope.GameMain
                     throw new InvalidOperationException("Om Nom grids are built through the warmup pipeline.");
                 case CandySelectionMode.Trace:
                     totalItems = FingerTraceFactory.TotalTraceSkins;
-                    selectedIndex = Preferences.GetIntForKey(CTRPreferences.PREFS_SELECTED_TRACE);
+                    selectedIndex = Preferences.GetIntForKey("PREFS_SELECTED_TRACE");
                     baseQuadIndex = 0;
                     itemResourceName = Resources.Img.FingerTraceSkinOptions;
                     itemYOffset = -20f;
@@ -348,7 +348,7 @@ namespace CutTheRope.GameMain
                 default: // Candy
                     const int TOTAL_CANDIES = 52;
                     totalItems = TOTAL_CANDIES;
-                    selectedIndex = Preferences.GetIntForKey(CTRPreferences.PREFS_SELECTED_CANDY);
+                    selectedIndex = Preferences.GetIntForKey("PREFS_SELECTED_CANDY");
                     baseQuadIndex = 6; // candy01-candy52 are quads 6-57
                     getButtonId = MenuButtonId.ForCandySlot;
                     break;
@@ -449,7 +449,7 @@ namespace CutTheRope.GameMain
             return new OmNomWarmupState
             {
                 Grid = new VBox().InitWithOffsetAlignWidth(layout.RowSpacing, 2, layout.ContainerWidth),
-                SelectedIndex = Preferences.GetIntForKey(CTRPreferences.PREFS_SELECTED_OMNOM),
+                SelectedIndex = Preferences.GetIntForKey("PREFS_SELECTED_OMNOM"),
                 SlotScale = layout.SlotScale,
                 ColumnSpacing = layout.ColumnSpacing,
                 RowHeight = layout.RowHeight,

--- a/CutTheRope/GameMain/GameScene.Init.cs
+++ b/CutTheRope/GameMain/GameScene.Init.cs
@@ -80,7 +80,7 @@ namespace CutTheRope.GameMain
             for (int j = 0; j < 5; j++)
             {
                 fingerCuts[j] = [];
-                int selectedTraceIndex = Preferences.GetIntForKey(CTRPreferences.PREFS_SELECTED_TRACE);
+                int selectedTraceIndex = Preferences.GetIntForKey("PREFS_SELECTED_TRACE");
                 fingerTraces[j] = FingerTraceFactory.CreateForSlot(selectedTraceIndex, j + 1);
             }
             clickToCut = Preferences.GetBooleanForKey("PREFS_CLICK_TO_CUT");

--- a/CutTheRope/GameMain/GameScene.Initialize.cs
+++ b/CutTheRope/GameMain/GameScene.Initialize.cs
@@ -122,7 +122,7 @@ namespace CutTheRope.GameMain
             starR.SetWeight(1f);
 
             // Get selected candy skin from preferences (0-50 for candy_01 to candy_51)
-            int selectedCandySkin = Framework.Core.Preferences.GetIntForKey(CTRPreferences.PREFS_SELECTED_CANDY);
+            int selectedCandySkin = Framework.Core.Preferences.GetIntForKey("PREFS_SELECTED_CANDY");
             string candyResource = CandySkinHelper.GetCandyResource(selectedCandySkin);
 
             // Initialize main candy

--- a/CutTheRope/GameMain/GameScene.LoadMetadata.cs
+++ b/CutTheRope/GameMain/GameScene.LoadMetadata.cs
@@ -102,7 +102,7 @@ namespace CutTheRope.GameMain
                             starL.pos.X = (ParseIntOrZero(item2.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
                             starL.pos.Y = (ParseIntOrZero(item2.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
                             {
-                                int selectedCandySkin = Preferences.GetIntForKey(CTRPreferences.PREFS_SELECTED_CANDY);
+                                int selectedCandySkin = Preferences.GetIntForKey("PREFS_SELECTED_CANDY");
                                 string candyResource = CandySkinHelper.GetCandyResource(selectedCandySkin);
                                 candyL = GameObject.GameObject_createWithResIDQuad(candyResource, 8);
                             }
@@ -118,7 +118,7 @@ namespace CutTheRope.GameMain
                             starR.pos.X = (ParseIntOrZero(item2.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
                             starR.pos.Y = (ParseIntOrZero(item2.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
                             {
-                                int selectedCandySkin = Preferences.GetIntForKey(CTRPreferences.PREFS_SELECTED_CANDY);
+                                int selectedCandySkin = Preferences.GetIntForKey("PREFS_SELECTED_CANDY");
                                 string candyResource = CandySkinHelper.GetCandyResource(selectedCandySkin);
                                 candyR = GameObject.GameObject_createWithResIDQuad(candyResource, 9);
                             }

--- a/CutTheRope/GameMain/GameScene.Update.cs
+++ b/CutTheRope/GameMain/GameScene.Update.cs
@@ -1345,7 +1345,7 @@ namespace CutTheRope.GameMain
                             PopCandyBubble(false);
                         }
 
-                        int selectedCandySkin = Preferences.GetIntForKey(CTRPreferences.PREFS_SELECTED_CANDY);
+                        int selectedCandySkin = Preferences.GetIntForKey("PREFS_SELECTED_CANDY");
                         string candyResource = CandySkinHelper.GetCandyResource(selectedCandySkin);
                         Image image2 = Image.Image_createWithResID(candyResource);
                         image2.DoRestoreCutTransparency();

--- a/CutTheRope/GameMain/GameScene.cs
+++ b/CutTheRope/GameMain/GameScene.cs
@@ -69,7 +69,7 @@ namespace CutTheRope.GameMain
         {
             targetAnimationController?.PlayGreeting();
             CTRSoundMgr.PlayOmNomSound(Resources.Snd.MonsterGreeting);
-            if (SpecialEvents.IsXmas && Preferences.GetIntForKey(CTRPreferences.PREFS_SELECTED_OMNOM) == 0)
+            if (SpecialEvents.IsXmas && Preferences.GetIntForKey("PREFS_SELECTED_OMNOM") == 0)
             {
                 CTRSoundMgr.PlaySound(Resources.Snd.XmasBell);
             }

--- a/CutTheRope/GameMain/Lantern.cs
+++ b/CutTheRope/GameMain/Lantern.cs
@@ -72,7 +72,7 @@ namespace CutTheRope.GameMain
             timeline.AddKeyFrame(KeyFrame.MakeColor(RGBAColor.transparentRGBA, KeyFrame.TransitionType.FRAME_TRANSITION_LINEAR, 0.3f));
             activeForm.AddTimelinewithID(timeline, (int)LanternActivation.Deactivation);
 
-            int candyVariant = Preferences.GetIntForKey(CTRPreferences.PREFS_SELECTED_CANDY);
+            int candyVariant = Preferences.GetIntForKey("PREFS_SELECTED_CANDY");
 
             // First 3 candy variants are in obj_lantern texture (quads 3, 4, 5)
             // Variants 3+ use the _lantern quad (quad 10) from their respective candy textures

--- a/CutTheRope/GameMain/MenuController.cs
+++ b/CutTheRope/GameMain/MenuController.cs
@@ -221,7 +221,7 @@ namespace CutTheRope.GameMain
 
                 // Candy on rope (positioned under the logo)
                 // Get selected candy skin from preferences (0-50 for candy_01 to candy_51)
-                int selectedCandySkin = Preferences.GetIntForKey(CTRPreferences.PREFS_SELECTED_CANDY);
+                int selectedCandySkin = Preferences.GetIntForKey("PREFS_SELECTED_CANDY");
                 Image candyUp = Image.Image_createWithResIDQuad(Resources.Img.MenuLogoNew, selectedCandySkin);
                 Image candyDown = Image.Image_createWithResIDQuad(Resources.Img.MenuLogoNew, selectedCandySkin);
                 candyDown.scaleX = candyDown.scaleY = 0.95f;  // Slight press feedback
@@ -1709,7 +1709,7 @@ namespace CutTheRope.GameMain
                         }
                         else if (skinAction.Mode == SkinSelectionMode.Candy)
                         {
-                            Preferences.SetBooleanForKey(true, CTRPreferences.PREFS_CANDY_WAS_CHANGED, true);
+                            Preferences.SetBooleanForKey(true, "PREFS_CANDY_WAS_CHANGED", true);
                             ShowView(VIEW_CANDY_SELECT);
                         }
 

--- a/CutTheRope/GameMain/MenuSkinSelectionActionResolver.cs
+++ b/CutTheRope/GameMain/MenuSkinSelectionActionResolver.cs
@@ -34,25 +34,25 @@ namespace CutTheRope.GameMain
                 var _ when buttonId.IsCandySlotButton() => new(
                     MenuSkinSelectionActionKind.SelectSlot,
                     SkinSelectionMode.Candy,
-                    CTRPreferences.PREFS_SELECTED_CANDY,
+                    "PREFS_SELECTED_CANDY",
                     buttonId.GetCandyIndex()
                 ),
                 var _ when buttonId.IsRopeSlotButton() => new(
                     MenuSkinSelectionActionKind.SelectSlot,
                     SkinSelectionMode.Rope,
-                    CTRPreferences.PREFS_SELECTED_ROPE,
+                    "PREFS_SELECTED_ROPE",
                     buttonId.GetRopeIndex()
                 ),
                 var _ when buttonId.IsOmNomSlotButton() => new(
                     MenuSkinSelectionActionKind.SelectSlot,
                     SkinSelectionMode.OmNom,
-                    CTRPreferences.PREFS_SELECTED_OMNOM,
+                    "PREFS_SELECTED_OMNOM",
                     buttonId.GetOmNomIndex()
                 ),
                 var _ when buttonId.IsTraceSlotButton() => new(
                     MenuSkinSelectionActionKind.SelectSlot,
                     SkinSelectionMode.Trace,
-                    CTRPreferences.PREFS_SELECTED_TRACE,
+                    "PREFS_SELECTED_TRACE",
                     buttonId.GetTraceIndex()
                 ),
                 _ => new(MenuSkinSelectionActionKind.None, SkinSelectionMode.Candy, null, null),

--- a/CutTheRope/GameMain/OmNomSkinRegistry.cs
+++ b/CutTheRope/GameMain/OmNomSkinRegistry.cs
@@ -36,7 +36,7 @@ namespace CutTheRope.GameMain
         /// <summary>Gets the currently selected skin index from preferences.</summary>
         public static int GetSelectedSkinIndex()
         {
-            int index = Preferences.GetIntForKey(CTRPreferences.PREFS_SELECTED_OMNOM);
+            int index = Preferences.GetIntForKey("PREFS_SELECTED_OMNOM");
             return index >= 0 && index < TotalSkinCount ? index : 0;
         }
 

--- a/CutTheRope/Helpers/RPCHelpers.cs
+++ b/CutTheRope/Helpers/RPCHelpers.cs
@@ -19,7 +19,7 @@ namespace CutTheRope.Helpers
         // By default, RPC is enabled
         // Exposing in a save file is to make way for later setting UI integration
         private static bool IsRpcEnabled =>
-            Preferences.GetBooleanForKey(CTRPreferences.PREFS_RPC_ENABLED);
+            Preferences.GetBooleanForKey("PREFS_RPC_ENABLED");
 
         // Replace with your own Discord Application ID if needed
         private readonly string DISCORD_APP_ID = "1457063659724603457";


### PR DESCRIPTION
## Description

- Remove `public const string PREFS_*` fields from `CTRPreferences`.
  - Also remove achievement constant string fields.
- Replace all usages across files with their inline string values.

No changes to functionality.