### PR TITLE
enhancement: Reduce GC pressure in `SoundMgr.ClearStopped`

### DIFF
--- a/CutTheRopeDX/Framework/Media/SoundMgr.cs
+++ b/CutTheRopeDX/Framework/Media/SoundMgr.cs
@@ -100,16 +100,7 @@ namespace CutTheRopeDX.Framework.Media
         /// </summary>
         private void ClearStopped()
         {
-            List<SoundEffectInstance> list = [];
-            foreach (SoundEffectInstance activeSound in activeSounds)
-            {
-                if (activeSound != null && activeSound.State != SoundState.Stopped)
-                {
-                    list.Add(activeSound);
-                }
-            }
-            activeSounds.Clear();
-            activeSounds = list;
+            _ = activeSounds.RemoveAll(static sound => sound == null || sound.State == SoundState.Stopped);
         }
 
         /// <summary>
@@ -319,7 +310,7 @@ namespace CutTheRopeDX.Framework.Media
         /// <summary>
         /// Active one-shot sound instances that may still be playing.
         /// </summary>
-        private List<SoundEffectInstance> activeSounds;
+        private readonly List<SoundEffectInstance> activeSounds;
 
         /// <summary>
         /// Active looped sound instances managed by pause and stop operations.


### PR DESCRIPTION
## Description

- Replace per-call `List<SoundEffectInstance>` allocation in `ClearStopped()` with an in-place `RemoveAll` call, eliminating two allocations (list + backing array) on every `PlaySound`/`PlaySoundLooped` invocation.
- Use a `static` lambda so the predicate is cached as a singleton delegate rather than allocated per call.
- Mark `activeSounds` as `readonly` since the field is no longer reassigned after construction.