### PR TITLE
fix: Use true vertical centering for level select grid

### DIFF
--- a/CutTheRopeDX/GameMain/MenuController.cs
+++ b/CutTheRopeDX/GameMain/MenuController.cs
@@ -1411,9 +1411,7 @@ namespace CutTheRopeDX.GameMain
             else
             {
                 levelContainer = null;
-                float fillRatio = vBox.height / availableHeight;
-                float verticalOffset = (availableHeight - vBox.height) / 2f * MathF.Cbrt(1f - fillRatio);
-                vBox.y = levelsTopY + verticalOffset;
+                vBox.y = (SCREEN_HEIGHT - vBox.height) / 2f;
                 levelsElement = vBox;
             }
             Timeline timeline4 = new Timeline().InitWithMaxKeyFramesOnTrack(3);


### PR DESCRIPTION
## Description

Fix a regression introduced by #196 where 25-level layout is not in true center.