### PR TITLE
fix: Make stretched rope's red color for custom rope skins more prominent

### DIFF
--- a/CutTheRopeDX/GameMain/Bungee.cs
+++ b/CutTheRopeDX/GameMain/Bungee.cs
@@ -199,73 +199,31 @@ namespace CutTheRopeDX.GameMain
         private static void DrawBungee(Bungee b, Vector[] pts, int count, int points)
         {
             float alphaMultiplier = b.cut == -1 || b.forceWhite ? 1f : b.cutTime / 1.95f;
+            float stretchRedThreshold = ActivePhysicsConstants.BungeeStretchRedThreshold;
+            float segmentLength = VectDistance(Vect(pts[0].X, pts[0].Y), Vect(pts[1].X, pts[1].Y));
 
             // Get selected rope colors from preferences
             int selectedRopeIndex = Preferences.GetIntForKey("PREFS_SELECTED_ROPE");
-            RopeColorHelper.RopeColors ropeColors = RopeColorHelper.GetRopeColors(selectedRopeIndex);
+            RopeColorHelper.RopeDrawColors drawColors = RopeColorHelper.GetDrawColors(
+                selectedRopeIndex,
+                alphaMultiplier,
+                b.highlighted,
+                segmentLength,
+                BUNGEE_REST_LEN,
+                stretchRedThreshold);
+            RGBAColor rgbaColor = drawColors.BaseColor1;
+            RGBAColor rgbaColor2 = drawColors.BaseColor2;
+            RGBAColor rgbaColor3 = drawColors.ShadeColor1;
+            RGBAColor rgbaColor4 = drawColors.ShadeColor2;
 
-            // Apply alpha multiplier to base colors
-            RGBAColor rgbaColor = RGBAColor.MakeRGBA(
-                ropeColors.Color1.RedColor * alphaMultiplier,
-                ropeColors.Color1.GreenColor * alphaMultiplier,
-                ropeColors.Color1.BlueColor * alphaMultiplier,
-                alphaMultiplier
-            );
-            RGBAColor rgbaColor2 = RGBAColor.MakeRGBA(
-                ropeColors.Color2.RedColor * alphaMultiplier,
-                ropeColors.Color2.GreenColor * alphaMultiplier,
-                ropeColors.Color2.BlueColor * alphaMultiplier,
-                alphaMultiplier
-            );
-
-            // Create darker variants for shading
-            // Only the default skin (0) uses dark shading; other skins use full brightness
-            float darkFactor1 = selectedRopeIndex == 0 ? 0.4f : 1f;
-            float darkFactor2 = selectedRopeIndex == 0 ? 0.45f : 1f;
-            RGBAColor rgbaColor3 = RGBAColor.MakeRGBA(
-                ropeColors.Color1.RedColor * darkFactor1 * alphaMultiplier,
-                ropeColors.Color1.GreenColor * darkFactor1 * alphaMultiplier,
-                ropeColors.Color1.BlueColor * darkFactor1 * alphaMultiplier,
-                alphaMultiplier
-            );
-            RGBAColor rgbaColor4 = RGBAColor.MakeRGBA(
-                ropeColors.Color2.RedColor * darkFactor2 * alphaMultiplier,
-                ropeColors.Color2.GreenColor * darkFactor2 * alphaMultiplier,
-                ropeColors.Color2.BlueColor * darkFactor2 * alphaMultiplier,
-                alphaMultiplier
-            );
-            if (b.highlighted)
-            {
-                float highlightMultiplier = 3f;
-                rgbaColor.RedColor *= highlightMultiplier;
-                rgbaColor.GreenColor *= highlightMultiplier;
-                rgbaColor.BlueColor *= highlightMultiplier;
-                rgbaColor2.RedColor *= highlightMultiplier;
-                rgbaColor2.GreenColor *= highlightMultiplier;
-                rgbaColor2.BlueColor *= highlightMultiplier;
-                rgbaColor3.RedColor *= highlightMultiplier;
-                rgbaColor3.GreenColor *= highlightMultiplier;
-                rgbaColor3.BlueColor *= highlightMultiplier;
-                rgbaColor4.RedColor *= highlightMultiplier;
-                rgbaColor4.GreenColor *= highlightMultiplier;
-                rgbaColor4.BlueColor *= highlightMultiplier;
-            }
             float relaxThresholdSoft = ActivePhysicsConstants.BungeeRelaxThresholdSoft;
             float relaxThresholdMedium = ActivePhysicsConstants.BungeeRelaxThresholdMedium;
             float relaxThresholdHard = ActivePhysicsConstants.BungeeRelaxThresholdHard;
-            float stretchRedThreshold = ActivePhysicsConstants.BungeeStretchRedThreshold;
-            float segmentLength = VectDistance(Vect(pts[0].X, pts[0].Y), Vect(pts[1].X, pts[1].Y));
             b.relaxed = segmentLength <= BUNGEE_REST_LEN + relaxThresholdSoft
                 ? 0
                 : segmentLength <= BUNGEE_REST_LEN + relaxThresholdMedium
                     ? 1
                     : segmentLength <= BUNGEE_REST_LEN + relaxThresholdHard ? 2 : 3;
-            if (segmentLength > BUNGEE_REST_LEN + stretchRedThreshold)
-            {
-                float stretchRedScale = segmentLength / BUNGEE_REST_LEN * 2f;
-                rgbaColor3.RedColor *= stretchRedScale;
-                rgbaColor4.RedColor *= stretchRedScale;
-            }
             bool flag = false;
             int sampleCount = (count - 1) * points;
             float[] array = new float[sampleCount * 2];

--- a/CutTheRopeDX/GameMain/RopeColorHelper.cs
+++ b/CutTheRopeDX/GameMain/RopeColorHelper.cs
@@ -18,6 +18,20 @@ namespace CutTheRopeDX.GameMain
         );
 
         /// <summary>
+        /// Represents the fully prepared rope colors used by the bungee renderer.
+        /// </summary>
+        /// <param name="BaseColor1">The primary rope color at full brightness.</param>
+        /// <param name="BaseColor2">The secondary rope color at full brightness.</param>
+        /// <param name="ShadeColor1">The primary rope color used for the darker stripe/stretched ramp.</param>
+        /// <param name="ShadeColor2">The secondary rope color used for the darker stripe/stretched ramp.</param>
+        public readonly record struct RopeDrawColors(
+            RGBAColor BaseColor1,
+            RGBAColor BaseColor2,
+            RGBAColor ShadeColor1,
+            RGBAColor ShadeColor2
+        );
+
+        /// <summary>
         /// Gets the rope color scheme for a given rope index (0-8).
         /// </summary>
         /// <param name="ropeIndex">The rope skin index. Values outside 0–8 return the default scheme.</param>
@@ -67,6 +81,92 @@ namespace CutTheRopeDX.GameMain
                     RGBAColor.MakeRGBA(0.6755555555555556f, 0.44f, 0.27555555555555555f, 1)
                 )
             };
+        }
+
+        /// <summary>
+        /// Creates the rope colors used for bungee rendering after alpha, highlighting, and stretch color are applied.
+        /// </summary>
+        /// <param name="ropeIndex">The selected rope skin index.</param>
+        /// <param name="alphaMultiplier">Alpha applied to all rope colors.</param>
+        /// <param name="highlighted">Whether the rope is in the highlighted state.</param>
+        /// <param name="segmentLength">Current length of the first rope segment.</param>
+        /// <param name="restLength">Rest length used for stretch color calculations.</param>
+        /// <param name="stretchRedThreshold">Stretch threshold that enables the red color state.</param>
+        /// <returns>The prepared bungee draw colors.</returns>
+        public static RopeDrawColors GetDrawColors(
+            int ropeIndex,
+            float alphaMultiplier,
+            bool highlighted,
+            float segmentLength,
+            float restLength,
+            float stretchRedThreshold)
+        {
+            RopeColors ropeColors = GetRopeColors(ropeIndex);
+            bool isStretchColorActive = segmentLength > restLength + stretchRedThreshold;
+
+            // Base colors are the bright end of the gradient.
+            // When the stretch color fires on a custom skin, the iOS code draws toward
+            // the default rope palette (brown) so that green/blue channels drop naturally.
+            // The shade (dark) end keeps the custom skin's own colors.
+            RopeColors baseSource = isStretchColorActive && ropeIndex != 0
+                ? GetRopeColors(0)
+                : ropeColors;
+            RGBAColor baseColor1 = RGBAColor.MakeRGBA(
+                baseSource.Color1.RedColor * alphaMultiplier,
+                baseSource.Color1.GreenColor * alphaMultiplier,
+                baseSource.Color1.BlueColor * alphaMultiplier,
+                alphaMultiplier
+            );
+            RGBAColor baseColor2 = RGBAColor.MakeRGBA(
+                baseSource.Color2.RedColor * alphaMultiplier,
+                baseSource.Color2.GreenColor * alphaMultiplier,
+                baseSource.Color2.BlueColor * alphaMultiplier,
+                alphaMultiplier
+            );
+
+            // The default skin always uses dark shading. Custom skins use full brightness
+            // normally, but when stretched the dark factor is restored so the red channel
+            // boost can dominate over the suppressed green/blue channels.
+            float darkFactor1 = ropeIndex == 0 || isStretchColorActive ? 0.4f : 1f;
+            float darkFactor2 = ropeIndex == 0 || isStretchColorActive ? 0.45f : 1f;
+            RGBAColor shadeColor1 = RGBAColor.MakeRGBA(
+                ropeColors.Color1.RedColor * darkFactor1 * alphaMultiplier,
+                ropeColors.Color1.GreenColor * darkFactor1 * alphaMultiplier,
+                ropeColors.Color1.BlueColor * darkFactor1 * alphaMultiplier,
+                alphaMultiplier
+            );
+            RGBAColor shadeColor2 = RGBAColor.MakeRGBA(
+                ropeColors.Color2.RedColor * darkFactor2 * alphaMultiplier,
+                ropeColors.Color2.GreenColor * darkFactor2 * alphaMultiplier,
+                ropeColors.Color2.BlueColor * darkFactor2 * alphaMultiplier,
+                alphaMultiplier
+            );
+
+            if (highlighted)
+            {
+                float highlightMultiplier = 3f;
+                baseColor1.RedColor *= highlightMultiplier;
+                baseColor1.GreenColor *= highlightMultiplier;
+                baseColor1.BlueColor *= highlightMultiplier;
+                baseColor2.RedColor *= highlightMultiplier;
+                baseColor2.GreenColor *= highlightMultiplier;
+                baseColor2.BlueColor *= highlightMultiplier;
+                shadeColor1.RedColor *= highlightMultiplier;
+                shadeColor1.GreenColor *= highlightMultiplier;
+                shadeColor1.BlueColor *= highlightMultiplier;
+                shadeColor2.RedColor *= highlightMultiplier;
+                shadeColor2.GreenColor *= highlightMultiplier;
+                shadeColor2.BlueColor *= highlightMultiplier;
+            }
+
+            if (isStretchColorActive && !highlighted)
+            {
+                float stretchRedScale = segmentLength / restLength * 2f;
+                shadeColor1.RedColor *= stretchRedScale;
+                shadeColor2.RedColor *= stretchRedScale;
+            }
+
+            return new RopeDrawColors(baseColor1, baseColor2, shadeColor1, shadeColor2);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

- Extract rope color calculation from `DrawBungee` into `RopeColorHelper.GetDrawColors`
- When a custom rope skin is stretched past the red threshold, darken the shade colors so the red channel boost visually dominates over green/blue
- Gradient the base (bright end) toward the default brown palette, matching the iOS decompiled behavior where the bright target uses hardcoded default values
- Skip stretch red when the rope is highlighted, matching the iOS `!highlighted` guard
