### PR TITLE
feat: Custom level gravity

### DIFF
--- a/CutTheRopeDX/Framework/Physics/ConstraintedPoint.cs
+++ b/CutTheRopeDX/Framework/Physics/ConstraintedPoint.cs
@@ -182,7 +182,7 @@ namespace CutTheRopeDX.Framework.Physics
         public override void Update(float delta)
         {
             totalForce = vectZero;
-            if (!disableGravity)
+            if (!disableGravity && !globalDisableGravity)
             {
                 totalForce = !VectEqual(globalGravity, vectZero) ? VectAdd(totalForce, VectMult(globalGravity, weight)) : VectAdd(totalForce, gravity);
             }
@@ -280,7 +280,7 @@ namespace CutTheRopeDX.Framework.Physics
         public static void Qcpupdate(ConstraintedPoint constrainedPoint, float delta, float coefficient)
         {
             constrainedPoint.totalForce = vectZero;
-            if (!constrainedPoint.disableGravity)
+            if (!constrainedPoint.disableGravity && !globalDisableGravity)
             {
                 constrainedPoint.totalForce = !VectEqual(globalGravity, vectZero)
                     ? VectAdd(constrainedPoint.totalForce, VectMult(globalGravity, constrainedPoint.weight))

--- a/CutTheRopeDX/Framework/Physics/MaterialPoint.cs
+++ b/CutTheRopeDX/Framework/Physics/MaterialPoint.cs
@@ -133,7 +133,7 @@ namespace CutTheRopeDX.Framework.Physics
         public virtual void Update(float delta)
         {
             totalForce = vectZero;
-            if (!disableGravity)
+            if (!disableGravity && !globalDisableGravity)
             {
                 totalForce = !VectEqual(globalGravity, vectZero) ? VectAdd(totalForce, VectMult(globalGravity, weight)) : VectAdd(totalForce, gravity);
             }
@@ -210,5 +210,10 @@ namespace CutTheRopeDX.Framework.Physics
         /// Whether gravity should be excluded from updates.
         /// </summary>
         public bool disableGravity;
+
+        /// <summary>
+        /// Optional override for whether gravity should be excluded from updates to all material points.
+        /// </summary>
+        public static bool globalDisableGravity;
     }
 }

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -542,15 +542,15 @@ namespace CutTheRopeDX.GameMain
         /// <param name="_">Game scene button identifier.</param>
         public void OnButtonPressed(GameSceneButtonId _)
         {
-            if (MaterialPoint.globalGravity.Y == ActivePhysicsConstants.GravityEarthY)
+            if (MaterialPoint.globalGravity.Y == globalGravityY)
             {
-                MaterialPoint.globalGravity.Y = -ActivePhysicsConstants.GravityEarthY;
+                MaterialPoint.globalGravity.Y = -globalGravityY;
                 gravityNormal = false;
                 CTRSoundMgr.PlaySound(Resources.Snd.GravityOn);
             }
             else
             {
-                MaterialPoint.globalGravity.Y = ActivePhysicsConstants.GravityEarthY;
+                MaterialPoint.globalGravity.Y = globalGravityY;
                 gravityNormal = true;
                 CTRSoundMgr.PlaySound(Resources.Snd.GravityOff);
             }

--- a/CutTheRopeDX/GameMain/GameScene.LoadMetadata.cs
+++ b/CutTheRopeDX/GameMain/GameScene.LoadMetadata.cs
@@ -99,6 +99,8 @@ namespace CutTheRopeDX.GameMain
                                 }
                             }
                             ropePhysicsSpeed *= ActivePhysicsConstants.RopePhysicsSpeedMultiplier;
+                            globalGravityX = (item2.Attribute("globalGravityX") != null) ? ParseFloatOrZero(item2.Attribute("globalGravityX")?.Value) : 0f;
+                            globalGravityY = (item2.Attribute("globalGravityY") != null) ? ParseFloatOrZero(item2.Attribute("globalGravityY")?.Value) : ActivePhysicsConstants.GravityEarthY;
                             break;
                         case "candyL":
                             starL.pos.X = (ParseIntOrZero(item2.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;

--- a/CutTheRopeDX/GameMain/GameScene.LoadObjects.cs
+++ b/CutTheRopeDX/GameMain/GameScene.LoadObjects.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Xml.Linq;
+
 using CutTheRopeDX.Framework.Physics;
 
 namespace CutTheRopeDX.GameMain

--- a/CutTheRopeDX/GameMain/GameScene.LoadObjects.cs
+++ b/CutTheRopeDX/GameMain/GameScene.LoadObjects.cs
@@ -1,8 +1,6 @@
 using System.Collections.Generic;
 using System.Xml.Linq;
 
-using CutTheRopeDX.Framework.Physics;
-
 namespace CutTheRopeDX.GameMain
 {
     internal sealed partial class GameScene
@@ -43,10 +41,7 @@ namespace CutTheRopeDX.GameMain
                     switch (item3.Name.LocalName)
                     {
                         case "gravitySwitch":
-                            if (!MaterialPoint.globalDisableGravity)
-                            {
-                                LoadGravityButton(item3, scale, offsetX + mapOffsetX, offsetY + mapOffsetY, 0, 0);
-                            }
+                            LoadGravityButton(item3, scale, offsetX + mapOffsetX, offsetY + mapOffsetY, 0, 0);
                             break;
                         case "star":
                             LoadStar(item3, scale, offsetX + mapOffsetX, offsetY + mapOffsetY, 0, 0);

--- a/CutTheRopeDX/GameMain/GameScene.LoadObjects.cs
+++ b/CutTheRopeDX/GameMain/GameScene.LoadObjects.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Xml.Linq;
+using CutTheRopeDX.Framework.Physics;
 
 namespace CutTheRopeDX.GameMain
 {
@@ -41,7 +42,10 @@ namespace CutTheRopeDX.GameMain
                     switch (item3.Name.LocalName)
                     {
                         case "gravitySwitch":
-                            LoadGravityButton(item3, scale, offsetX + mapOffsetX, offsetY + mapOffsetY, 0, 0);
+                            if (!MaterialPoint.globalDisableGravity)
+                            {
+                                LoadGravityButton(item3, scale, offsetX + mapOffsetX, offsetY + mapOffsetY, 0, 0);
+                            }
                             break;
                         case "star":
                             LoadStar(item3, scale, offsetX + mapOffsetX, offsetY + mapOffsetY, 0, 0);

--- a/CutTheRopeDX/GameMain/GameScene.Show.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Show.cs
@@ -71,7 +71,8 @@ namespace CutTheRopeDX.GameMain
             time = 0f;
             score = 0;
             gravityNormal = true;
-            MaterialPoint.globalGravity = Vect(0f, ActivePhysicsConstants.GravityEarthY);
+            MaterialPoint.globalGravity = Vect(globalGravityX, globalGravityY);
+            MaterialPoint.globalDisableGravity = VectEqual(MaterialPoint.globalGravity, vectZero);
             dimTime = 0f;
             ropesCutAtOnce = 0;
             ropeAtOnceTimer = 0f;

--- a/CutTheRopeDX/GameMain/GameScene.Show.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Show.cs
@@ -31,6 +31,10 @@ namespace CutTheRopeDX.GameMain
             mapOriginX = mapOffsetX + mapGridOffsetX;
             mapOriginY = mapOffsetY + mapGridOffsetY;
 
+            gravityNormal = true;
+            MaterialPoint.globalGravity = Vect(globalGravityX, globalGravityY);
+            MaterialPoint.globalDisableGravity = VectEqual(MaterialPoint.globalGravity, vectZero);
+
             // Load all game objects from XML
             LoadObjectsFromMap(map, mapScale, mapOffsetX, mapOffsetY, mapGridOffsetX, mapGridOffsetY);
 
@@ -70,9 +74,6 @@ namespace CutTheRopeDX.GameMain
             // spiderTookCandy = false;
             time = 0f;
             score = 0;
-            gravityNormal = true;
-            MaterialPoint.globalGravity = Vect(globalGravityX, globalGravityY);
-            MaterialPoint.globalDisableGravity = VectEqual(MaterialPoint.globalGravity, vectZero);
             dimTime = 0f;
             ropesCutAtOnce = 0;
             ropeAtOnceTimer = 0f;

--- a/CutTheRopeDX/GameMain/GameScene.Show.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Show.cs
@@ -31,10 +31,6 @@ namespace CutTheRopeDX.GameMain
             mapOriginX = mapOffsetX + mapGridOffsetX;
             mapOriginY = mapOffsetY + mapGridOffsetY;
 
-            gravityNormal = true;
-            MaterialPoint.globalGravity = Vect(globalGravityX, globalGravityY);
-            MaterialPoint.globalDisableGravity = VectEqual(MaterialPoint.globalGravity, vectZero);
-
             // Load all game objects from XML
             LoadObjectsFromMap(map, mapScale, mapOffsetX, mapOffsetY, mapGridOffsetX, mapGridOffsetY);
 
@@ -74,6 +70,9 @@ namespace CutTheRopeDX.GameMain
             // spiderTookCandy = false;
             time = 0f;
             score = 0;
+            gravityNormal = true;
+            MaterialPoint.globalGravity = Vect(globalGravityX, globalGravityY);
+            MaterialPoint.globalDisableGravity = VectEqual(MaterialPoint.globalGravity, vectZero);
             dimTime = 0f;
             ropesCutAtOnce = 0;
             ropeAtOnceTimer = 0f;

--- a/CutTheRopeDX/GameMain/GameScene.cs
+++ b/CutTheRopeDX/GameMain/GameScene.cs
@@ -1167,6 +1167,16 @@ namespace CutTheRopeDX.GameMain
         public float partsDist;
 
         /// <summary>
+        /// The X value for the global gravity.
+        /// </summary>
+        public float globalGravityX;
+
+        /// <summary>
+        /// The Y value for the global gravity.
+        /// </summary>
+        public float globalGravityY;
+
+        /// <summary>
         /// Earth animation images used by gravity-switch levels.
         /// </summary>
         public List<Image> earthAnims;

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadGravityButton.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadGravityButton.cs
@@ -18,13 +18,16 @@ namespace CutTheRopeDX.GameMain
         /// <param name="mapOffsetY">The additional map Y offset applied during loading.</param>
         private void LoadGravityButton(XElement xmlNode, float scale, float offsetX, float offsetY, int mapOffsetX, int mapOffsetY)
         {
-            gravityButton = CreateGravityButtonWithDelegate(this);
-            gravityButton.visible = false;
-            gravityButton.touchable = false;
-            _ = AddChild(gravityButton);
-            gravityButton.x = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-            gravityButton.y = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
-            gravityButton.anchor = 18;
+            if (globalGravityY != 0f)
+            {
+                gravityButton = CreateGravityButtonWithDelegate(this);
+                gravityButton.visible = false;
+                gravityButton.touchable = false;
+                _ = AddChild(gravityButton);
+                gravityButton.x = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+                gravityButton.y = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+                gravityButton.anchor = 18;
+            }
         }
     }
 }

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadGravityButton.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadGravityButton.cs
@@ -18,16 +18,17 @@ namespace CutTheRopeDX.GameMain
         /// <param name="mapOffsetY">The additional map Y offset applied during loading.</param>
         private void LoadGravityButton(XElement xmlNode, float scale, float offsetX, float offsetY, int mapOffsetX, int mapOffsetY)
         {
-            if (globalGravityY != 0f)
+            if (globalGravityY == 0f)
             {
-                gravityButton = CreateGravityButtonWithDelegate(this);
-                gravityButton.visible = false;
-                gravityButton.touchable = false;
-                _ = AddChild(gravityButton);
-                gravityButton.x = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-                gravityButton.y = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
-                gravityButton.anchor = 18;
+                return;
             }
+            gravityButton = CreateGravityButtonWithDelegate(this);
+            gravityButton.visible = false;
+            gravityButton.touchable = false;
+            _ = AddChild(gravityButton);
+            gravityButton.x = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+            gravityButton.y = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+            gravityButton.anchor = 18;
         }
     }
 }


### PR DESCRIPTION
This PR adds two new parameters that can be used in levels. gameDesign: globalGravityX (float, default 0f), globalGravityY (float, default ActivePhysicsConstants.GravityEarthY)

If both globalGravityX and globalGravityY are set to 0, the level will enter a zero gravity mode. Since globalGravityX is 0 by default, setting globalGravityY to 0 in a level is enough to get into zero gravity mode.