### PR TITLE
fix: change `PREFS_WINDOW_FULLSCREEN` to `false` at boot in save file

### DIFF
--- a/CutTheRopeDX/GameMain/CTRPreferences.cs
+++ b/CutTheRopeDX/GameMain/CTRPreferences.cs
@@ -655,7 +655,7 @@ namespace CutTheRopeDX.GameMain
             SetIntForKey(0, "PREFS_NEW_DRAWINGS_COUNTER", true);
             SetIntForKey(0, "PREFS_LAST_BOX", true);
             SetIntForKey(0, "PREFS_LAST_GAMEPACK", true);
-            SetBooleanForKey(true, "PREFS_WINDOW_FULLSCREEN", true);
+            SetBooleanForKey(false, "PREFS_WINDOW_FULLSCREEN", true);
             SetBooleanForKey(true, "PREFS_RPC_ENABLED", true);
             SetBooleanForKey(true, "PREFS_UPDATE_CHECK", true);
             CheckForUnlockIAP();


### PR DESCRIPTION
## Description

Prevents the game from booting as fullscreen on second launch on a fresh save file, which might cause some problems for some operating systems like macOS.