### PR TITLE
fix: update menu RPC when resetting save

### DIFF
--- a/CutTheRopeDX/GameMain/CTRPreferences.cs
+++ b/CutTheRopeDX/GameMain/CTRPreferences.cs
@@ -661,6 +661,8 @@ namespace CutTheRopeDX.GameMain
             CheckForUnlockIAP();
             RequestSave();
             SetScoreHash();
+            // Show menu presence to use the correct total
+            Game1.RPC?.MenuPresence();
         }
 
         /// <summary>


### PR DESCRIPTION
I noticed it stayed on what it was before resetting the save, so I made this quick little fix for that.