### PR TITLE
feat: Custom level names and better Chinese level name text heights

### DIFF
--- a/CutTheRopeDX/GameMain/GameController.cs
+++ b/CutTheRopeDX/GameMain/GameController.cs
@@ -335,7 +335,7 @@ namespace CutTheRopeDX.GameMain
 
             // Update RPC to show win state with stars and score
             CTRRootController ctrRoot = (CTRRootController)Application.SharedRootController();
-            Game1.RPC.SetLevelPresence(ctrRoot.GetPack(), ctrRoot.GetLevel(), gameScene.starsCollected, true, gameScene.score, (int)gameScene.time);
+            Game1.RPC.SetLevelPresence(ctrRoot.GetPack(), ctrRoot.GetLevel(), gameScene.starsCollected, true, gameScene.levelName, gameScene.score, (int)gameScene.time);
 
             UnlockNextLevel();
         }

--- a/CutTheRopeDX/GameMain/GameScene.Initialize.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Initialize.cs
@@ -86,6 +86,7 @@ namespace CutTheRopeDX.GameMain
             gameLostTriggered = false;
             gameWonTriggered = false;
             outcomeTransitionActive = false;
+            levelName = null;
         }
 
         /// <summary>

--- a/CutTheRopeDX/GameMain/GameScene.LoadMetadata.cs
+++ b/CutTheRopeDX/GameMain/GameScene.LoadMetadata.cs
@@ -44,6 +44,7 @@ namespace CutTheRopeDX.GameMain
                             offsetX = (2560f - (mapWidth * scale)) / 2f;
                             mapWidth *= scale;
                             mapHeight *= scale;
+                            levelName = item2.Attribute("levelName")?.Value ?? null;
 
                             if (PackConfig.GetEarthBg(rc.GetPack()))
                             {

--- a/CutTheRopeDX/GameMain/GameScene.Show.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Show.cs
@@ -58,7 +58,7 @@ namespace CutTheRopeDX.GameMain
             tummyTeasers = 0;
             starsCollected = 0;
             // Update RPC with current level info (on start/restart)
-            Game1.RPC?.SetLevelPresence(cTRRootController.GetPack(), cTRRootController.GetLevel(), starsCollected, false);
+            Game1.RPC?.SetLevelPresence(cTRRootController.GetPack(), cTRRootController.GetLevel(), starsCollected, false, levelName);
             candyBubble = null;
             candyBubbleL = null;
             candyBubbleR = null;
@@ -79,9 +79,11 @@ namespace CutTheRopeDX.GameMain
             ropesCutAtOnce = 0;
             ropeAtOnceTimer = 0f;
             dd.CallObjectSelectorParamafterDelay(new DelayedDispatcher.DispatchFunc(Selector_doCandyBlink), null, 1);
-            Text text = Text.CreateWithFontandString(Resources.Fnt.BigFont, (cTRRootController.GetPack() + 1).ToString(CultureInfo.InvariantCulture) + " - " + (cTRRootController.GetLevel() + 1).ToString(CultureInfo.InvariantCulture));
+            string packAndLevelNumbers = (cTRRootController.GetPack() + 1).ToString(CultureInfo.InvariantCulture) + " - " + (cTRRootController.GetLevel() + 1).ToString(CultureInfo.InvariantCulture);
+            bool useCustomLevelName = levelName != null && Application.GetString(levelName) != string.Empty;
+            Text text = Text.CreateWithFontandString(Resources.Fnt.BigFont, useCustomLevelName ? Application.GetString(levelName) : packAndLevelNumbers);
+            Text text2 = Text.CreateWithFontandString(Resources.Fnt.BigFont, useCustomLevelName ? Application.GetString("LEVEL") + " " + packAndLevelNumbers : Application.GetString("LEVEL"));
             text.anchor = 33;
-            Text text2 = Text.CreateWithFontandString(Resources.Fnt.BigFont, Application.GetString("LEVEL"));
             text2.anchor = 33;
             text2.parentAnchor = 9;
             text.SetName("levelLabel");

--- a/CutTheRopeDX/GameMain/GameScene.Show.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Show.cs
@@ -88,9 +88,9 @@ namespace CutTheRopeDX.GameMain
             text2.parentAnchor = 9;
             text.SetName("levelLabel");
             text.x = 15f + Canvas.xOffsetScaled;
-            text.y = SCREEN_HEIGHT + 15f;
             bool isChinese = LanguageHelper.IsCurrentAny(Language.LANGZH, Language.LANGZHTW);
-            text2.y = isChinese ? 20f : 30f; // the "Level" label in game
+            text.y = isChinese ? SCREEN_HEIGHT : SCREEN_HEIGHT + 15f; // the box and level number or level name in game
+            text2.y = isChinese ? 3f : 30f; // the "Level" label in game
             text2.rotationCenterX -= text2.width / 2f;
             text2.scaleX = text2.scaleY = 0.7f;
             _ = text.AddChild(text2);

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -723,7 +723,7 @@ namespace CutTheRopeDX.GameMain
                         collectingCandy?.candyBlink?.PlayTimeline(1);
                         starsCollected++;
                         // Update RPC with new star count
-                        Game1.RPC?.SetLevelPresence(cTRRootController.GetPack(), cTRRootController.GetLevel(), starsCollected, false);
+                        Game1.RPC?.SetLevelPresence(cTRRootController.GetPack(), cTRRootController.GetLevel(), starsCollected, false, levelName);
                         if (starsCollected <= hudStar.Length)
                         {
                             hudStar[starsCollected - 1].PlayTimeline(0);

--- a/CutTheRopeDX/GameMain/GameScene.cs
+++ b/CutTheRopeDX/GameMain/GameScene.cs
@@ -1232,6 +1232,11 @@ namespace CutTheRopeDX.GameMain
         public List<Image> earthAnims;
 
         /// <summary>
+        /// Optional string to load as a name for the level.
+        /// </summary>
+        public string levelName;
+
+        /// <summary>
         /// Count of tummy teaser interactions completed in the scene.
         /// </summary>
         public int tummyTeasers;

--- a/CutTheRopeDX/Helpers/RPCHelpers.cs
+++ b/CutTheRopeDX/Helpers/RPCHelpers.cs
@@ -127,6 +127,7 @@ namespace CutTheRopeDX.Helpers
         /// <param name="level">Zero-based level index within the pack.</param>
         /// <param name="stars">Number of stars collected (0-3).</param>
         /// <param name="isWon">Whether the level has been completed.</param>
+        /// <param name="levelName">The optional name of the level.</param>
         /// <param name="score">Final score if the level was won.</param>
         /// <param name="time">Elapsed time in seconds if the level was won.</param>
         public void SetLevelPresence(int pack, int level, int stars, bool isWon = false, string levelName = null, int? score = null, int? time = null)

--- a/CutTheRopeDX/Helpers/RPCHelpers.cs
+++ b/CutTheRopeDX/Helpers/RPCHelpers.cs
@@ -129,7 +129,7 @@ namespace CutTheRopeDX.Helpers
         /// <param name="isWon">Whether the level has been completed.</param>
         /// <param name="score">Final score if the level was won.</param>
         /// <param name="time">Elapsed time in seconds if the level was won.</param>
-        public void SetLevelPresence(int pack, int level, int stars, bool isWon = false, int? score = null, int? time = null)
+        public void SetLevelPresence(int pack, int level, int stars, bool isWon = false, string levelName = null, int? score = null, int? time = null)
         {
             DiscordIpcClient client = Volatile.Read(ref _client);
             if (client == null || !IsRpcEnabled || !client.IsConnected || Application.GetString($"BOX{pack + 1}_LABEL", forceEnglish: true) == null)
@@ -160,8 +160,10 @@ namespace CutTheRopeDX.Helpers
                 }
             }
 
+            bool useCustomLevelName = levelName != null && Application.GetString(levelName) != string.Empty;
+
             client.SetActivity(
-                details: $"{Application.GetString($"BOX{pack + 1}_LABEL", forceEnglish: true)}: {Application.GetString($"LEVEL", forceEnglish: true)} {pack + 1}-{level + 1}",
+                details: useCustomLevelName ? $"{Application.GetString($"BOX{pack + 1}_LABEL", forceEnglish: true)}: {Application.GetString(levelName, forceEnglish: true)}" : $"{Application.GetString($"BOX{pack + 1}_LABEL", forceEnglish: true)}: {Application.GetString($"LEVEL", forceEnglish: true)} {pack + 1}-{level + 1}",
                 state: state,
                 startTimestamp: GetOrCreateEpochSeconds(),
                 smallImageKey: $"pack_{pack + 1}",


### PR DESCRIPTION
What a mouthful that title is!
This PR adds a new attribute to the `map` element of the `settings` layer, `levelName`. It only accepts valid string names from the locales.
It also uses much better heights for the Chinese level names, matching closer to the other full-width language fonts.