### PR TITLE
fix: update rocket state and stop animation when it enters water

### DIFF
--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1551,7 +1551,8 @@ namespace CutTheRopeDX.GameMain
                         if (ctx.activeRocket.state == Rocket.STATE_ROCKET_FLY)
                         {
                             CTRSoundMgr.PlaySound(Resources.Snd.ExpRocketInWater);
-                            ExhaustRocketForCandy(ctx);
+                            ctx.activeRocket.state = Rocket.STATE_ROCKET_EXAUST;
+                            ctx.activeRocket.StopAnimation();
                         }
                     }
                     ctx.point.ApplyImpulseDelta(Vect(-ctx.point.v.X / damping, (-ctx.point.v.Y / damping) + verticalWaterImpulse), delta);


### PR DESCRIPTION
## Description

Fix a regression where candy binds to rocket while submerged in water, it will fly up instead of just floats in water.