### PR TITLE
fix: Various bug fixes with lanterns and rope/gun

### DIFF
--- a/CutTheRopeDX.Tests/GunAvailabilityTests.cs
+++ b/CutTheRopeDX.Tests/GunAvailabilityTests.cs
@@ -1,0 +1,25 @@
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public class GunAvailabilityTests
+    {
+        [Fact]
+        public void GunIsDisabledAndCannotFireWhileCandyIsInLantern()
+        {
+            Assert.True(GunAvailability.IsDisabled(candyInLantern: true));
+            Assert.False(GunAvailability.CanFire(
+                candyPresent: true, candyInLantern: true, gunFired: false, ropeAbsent: true));
+        }
+
+        [Fact]
+        public void GunBecomesEnabledAndCanFireAfterCandyIsFreed()
+        {
+            Assert.False(GunAvailability.IsDisabled(candyInLantern: false));
+            Assert.True(GunAvailability.CanFire(
+                candyPresent: true, candyInLantern: false, gunFired: false, ropeAbsent: true));
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/NormalRopeLoadTests.cs
+++ b/CutTheRopeDX.Tests/NormalRopeLoadTests.cs
@@ -1,0 +1,33 @@
+using System.Xml.Linq;
+
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public class NormalRopeLoadTests
+    {
+        [Fact]
+        public void ShouldCreate_FalseWhenTargetCandyIsInLantern()
+        {
+            Assert.False(NormalRopeLoad.ShouldCreate(targetCandyInLantern: true));
+            Assert.True(NormalRopeLoad.ShouldCreate(targetCandyInLantern: false));
+        }
+
+        [Fact]
+        public void CandyStartsInLantern_TrueRegardlessOfObjectOrder()
+        {
+            XElement map = XElement.Parse("""
+                <level>
+                  <objects>
+                    <grab radius="-1" />
+                    <lantern candyCaptured="true" />
+                  </objects>
+                </level>
+                """);
+
+            Assert.True(NormalRopeLoad.CandyStartsInLantern(map));
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/GameScene.Draw.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Draw.cs
@@ -195,6 +195,10 @@ namespace CutTheRopeDX.GameMain
                 Grab grab = (Grab)bungeeObj;
                 // Reset blend mode per grab to avoid state leakage from child draws.
                 Renderer.SetBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
+                if (grab.gun)
+                {
+                    grab.SetGunDisabled(GunAvailability.IsDisabled(candies[0].inLantern));
+                }
                 grab.DrawBack();
                 grab.Draw();
             }

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -225,6 +225,11 @@ namespace CutTheRopeDX.GameMain
                     {
                         SpiderBusted(grab);
                     }
+                    if (grab.gun && grab.gunCup != null
+                        && RGBAColor.RGBAEqual(RGBAColor.solidOpaqueRGBA, grab.gunCup.color))
+                    {
+                        grab.gunCup.PlayTimeline(Grab.GUN_CUP_DROP_AND_HIDE);
+                    }
                 }
             }
             // candiesConnected elastic: not in `bungees`. When one of its candy endpoints is

--- a/CutTheRopeDX/GameMain/GameScene.Input.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Input.cs
@@ -194,7 +194,11 @@ namespace CutTheRopeDX.GameMain
                 foreach (object obj in bungees)
                 {
                     Grab grab = (Grab)obj;
-                    if (grab.gun && !grab.gunFired && grab.rope == null)
+                    if (grab.gun && GunAvailability.CanFire(
+                        candyPresent: !noCandy,
+                        candyInLantern: candies[0].inLantern,
+                        gunFired: grab.gunFired,
+                        ropeAbsent: grab.rope == null))
                     {
                         float mapLeftX = waterLayer?.x ?? 0f;
                         float mapRightX = waterLayer != null ? waterLayer.x + waterLayer.width : mapWidth;

--- a/CutTheRopeDX/GameMain/GameScene.LoadObjects.cs
+++ b/CutTheRopeDX/GameMain/GameScene.LoadObjects.cs
@@ -18,6 +18,10 @@ namespace CutTheRopeDX.GameMain
         private void LoadObjectsFromMap(XElement map, float scale, float offsetX, float offsetY, int mapOffsetX, int mapOffsetY)
         {
             List<XElement> list = [.. map.Elements()];
+            // Establish captured state before grabs are loaded so XML object order cannot attach a
+            // fixed rope to candy that starts inside a lantern.
+            candies[0].inLantern = NormalRopeLoad.CandyStartsInLantern(map);
+
             // Preload light bulbs so bindBulb grabs can resolve regardless of XML order.
             foreach (XElement xmlnode2 in list)
             {

--- a/CutTheRopeDX/GameMain/Grab.cs
+++ b/CutTheRopeDX/GameMain/Grab.cs
@@ -388,6 +388,15 @@ namespace CutTheRopeDX.GameMain
             gunCup?.Draw();
         }
 
+        /// <summary>Updates the gun body to show whether the gun can currently fire.</summary>
+        /// <param name="disabled">
+        /// <see langword="true"/> to show the fired body; otherwise, <see langword="false"/>.
+        /// </param>
+        public void SetGunDisabled(bool disabled)
+        {
+            gunFront?.SetDrawQuad(gunFired || disabled ? GunDisabledFrontQuad : GunFrontQuad);
+        }
+
         /// <summary>
         /// Attaches a rope to this grab and activates spider startup when needed.
         /// </summary>
@@ -1027,6 +1036,9 @@ namespace CutTheRopeDX.GameMain
 
         /// <summary>Gun hook front quad.</summary>
         private const int GunFrontQuad = 2;
+
+        /// <summary>Gun hook front quad used after firing and while disabled.</summary>
+        private const int GunDisabledFrontQuad = 3;
 
         /// <summary>
         /// Selects one of the fixed hook back quad variants.

--- a/CutTheRopeDX/GameMain/GunAvailability.cs
+++ b/CutTheRopeDX/GameMain/GunAvailability.cs
@@ -1,0 +1,36 @@
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>Determines whether a gun grab is enabled and can fire at the candy.</summary>
+    internal static class GunAvailability
+    {
+        /// <summary>Determines whether the gun should use its disabled appearance.</summary>
+        /// <param name="candyInLantern">
+        /// <see langword="true"/> when the target candy is captured in a lantern.
+        /// </param>
+        /// <returns><see langword="true"/> when the gun should appear disabled.</returns>
+        public static bool IsDisabled(bool candyInLantern)
+        {
+            return candyInLantern;
+        }
+
+        /// <summary>Determines whether an unfired gun can create a rope to the candy.</summary>
+        /// <param name="candyPresent"><see langword="true"/> when the candy is still available.</param>
+        /// <param name="candyInLantern">
+        /// <see langword="true"/> when the target candy is captured in a lantern.
+        /// </param>
+        /// <param name="gunFired"><see langword="true"/> when the gun has already fired.</param>
+        /// <param name="ropeAbsent"><see langword="true"/> when the gun has no attached rope.</param>
+        /// <returns><see langword="true"/> when the gun can fire.</returns>
+        public static bool CanFire(
+            bool candyPresent,
+            bool candyInLantern,
+            bool gunFired,
+            bool ropeAbsent)
+        {
+            return candyPresent
+                && !candyInLantern
+                && !gunFired
+                && ropeAbsent;
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadGrabs.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadGrabs.cs
@@ -107,13 +107,17 @@ namespace CutTheRopeDX.GameMain
                     }
                 }
 
-                Bungee bungee = new Bungee().InitWithHeadAtXYTailAtTXTYandLength(null, hx, hy, constraintedPoint, constraintedPoint.pos.X, constraintedPoint.pos.Y, len);
-                bungee.bungeeAnchor.pin = bungee.bungeeAnchor.pos;
-                grab.SetRope(bungee);
-                if (grab.kicked)
+                CandyContext ropeTarget = CandyForPoint(constraintedPoint);
+                if (NormalRopeLoad.ShouldCreate(ropeTarget.inLantern))
                 {
-                    bungee.bungeeAnchor.pin = Vect(-1f, -1f);
-                    bungee.bungeeAnchor.SetWeight(0.1f);
+                    Bungee bungee = new Bungee().InitWithHeadAtXYTailAtTXTYandLength(null, hx, hy, constraintedPoint, constraintedPoint.pos.X, constraintedPoint.pos.Y, len);
+                    bungee.bungeeAnchor.pin = bungee.bungeeAnchor.pos;
+                    grab.SetRope(bungee);
+                    if (grab.kicked)
+                    {
+                        bungee.bungeeAnchor.pin = Vect(-1f, -1f);
+                        bungee.bungeeAnchor.SetWeight(0.1f);
+                    }
                 }
             }
             grab.SetRadius(grabRadius);

--- a/CutTheRopeDX/GameMain/NormalRopeLoad.cs
+++ b/CutTheRopeDX/GameMain/NormalRopeLoad.cs
@@ -1,0 +1,46 @@
+using System.Xml.Linq;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>Policies used while loading fixed ropes and their initial candy state.</summary>
+    internal static class NormalRopeLoad
+    {
+        /// <summary>
+        /// Determines whether a fixed rope should be created for its target candy.
+        /// </summary>
+        /// <param name="targetCandyInLantern">
+        /// <see langword="true"/> when the target candy starts captured in a lantern.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> when the target candy is available for a fixed rope; otherwise,
+        /// <see langword="false"/>.
+        /// </returns>
+        public static bool ShouldCreate(bool targetCandyInLantern)
+        {
+            return !targetCandyInLantern;
+        }
+
+        /// <summary>
+        /// Determines whether the level contains a lantern whose candy is captured at startup.
+        /// </summary>
+        /// <param name="map">The level XML element whose descendants contain the game objects.</param>
+        /// <returns>
+        /// <see langword="true"/> when any lantern has <c>candyCaptured="true"</c>; otherwise,
+        /// <see langword="false"/>.
+        /// </returns>
+        public static bool CandyStartsInLantern(XElement map)
+        {
+            foreach (XElement element in map.Descendants())
+            {
+                if (element.Name.LocalName == "lantern"
+                    && bool.TryParse(element.Attribute("candyCaptured")?.Value, out bool captured)
+                    && captured)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Disconnect rope when there are lanterns with `candyCaptured="true"`.
- Disable gun firing when candy is already inside lantern.