### PR TITLE
fix: drop decimal values for x, y, mapOffsetX and mapOffsetY

### DIFF
--- a/CutTheRopeDX.Tests/ParsingHelpersTests.cs
+++ b/CutTheRopeDX.Tests/ParsingHelpersTests.cs
@@ -1,0 +1,28 @@
+using CutTheRopeDX.Helpers;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class ParsingHelpersTests
+    {
+        [Theory]
+        [InlineData("12.9", 12)]
+        [InlineData("-12.9", -12)]
+        [InlineData("42", 42)]
+        [InlineData("invalid", 0)]
+        [InlineData(null, 0)]
+        public void ParseCoordinateIntOrZeroTruncatesDecimalValues(string value, int expected)
+        {
+            Assert.Equal(expected, ParsingHelpers.ParseCoordinateIntOrZero(value));
+        }
+
+        [Theory]
+        [InlineData("2147483648")]
+        [InlineData("1e100")]
+        public void ParseCoordinateIntOrZeroReturnsZeroWhenValueIsOutsideIntRange(string value)
+        {
+            Assert.Equal(0, ParsingHelpers.ParseCoordinateIntOrZero(value));
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/GameScene.LoadMetadata.cs
+++ b/CutTheRopeDX/GameMain/GameScene.LoadMetadata.cs
@@ -60,8 +60,8 @@ namespace CutTheRopeDX.GameMain
                             }
                             break;
                         case "gameDesign":
-                            mapOffsetX = ParseIntOrZero(item2.Attribute("mapOffsetX")?.Value);
-                            mapOffsetY = ParseIntOrZero(item2.Attribute("mapOffsetY")?.Value);
+                            mapOffsetX = ParseCoordinateIntOrZero(item2.Attribute("mapOffsetX")?.Value);
+                            mapOffsetY = ParseCoordinateIntOrZero(item2.Attribute("mapOffsetY")?.Value);
                             special = ParseIntOrZero(item2.Attribute("special")?.Value);
                             ropePhysicsSpeed = ParseFloatOrZero(item2.Attribute("ropePhysicsSpeed")?.Value);
                             _ = bool.TryParse(item2.Attribute("useMobilePhysics")?.Value, out bool useMobilePhysics);
@@ -106,8 +106,8 @@ namespace CutTheRopeDX.GameMain
                             candiesConnectedLength = ParseFloatOrZero(item2.Attribute("candiesConnectedLength")?.Value) * scale;
                             break;
                         case "candyL":
-                            starL.pos.X = (ParseIntOrZero(item2.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-                            starL.pos.Y = (ParseIntOrZero(item2.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+                            starL.pos.X = (ParseCoordinateIntOrZero(item2.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+                            starL.pos.Y = (ParseCoordinateIntOrZero(item2.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
                             {
                                 int selectedCandySkin = Preferences.GetIntForKey("PREFS_SELECTED_CANDY");
                                 string candyResource = CandySkinHelper.GetCandyResource(selectedCandySkin);
@@ -122,8 +122,8 @@ namespace CutTheRopeDX.GameMain
                             candyL.bb = GetSplitCandyBoundingBox();
                             break;
                         case "candyR":
-                            starR.pos.X = (ParseIntOrZero(item2.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-                            starR.pos.Y = (ParseIntOrZero(item2.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+                            starR.pos.X = (ParseCoordinateIntOrZero(item2.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+                            starR.pos.Y = (ParseCoordinateIntOrZero(item2.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
                             {
                                 int selectedCandySkin = Preferences.GetIntForKey("PREFS_SELECTED_CANDY");
                                 string candyResource = CandySkinHelper.GetCandyResource(selectedCandySkin);
@@ -139,8 +139,8 @@ namespace CutTheRopeDX.GameMain
                             break;
                         case "candy":
                             {
-                                float cx = (ParseIntOrZero(item2.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-                                float cy = (ParseIntOrZero(item2.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+                                float cx = (ParseCoordinateIntOrZero(item2.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+                                float cy = (ParseCoordinateIntOrZero(item2.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
                                 // Key comes straight from XML; null for legacy single-candy packs (never matched).
                                 string number = item2.Attribute("candyNumber")?.Value;
 

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadAnts.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadAnts.cs
@@ -22,8 +22,8 @@ namespace CutTheRopeDX.GameMain
         {
             float moveSpeed = ParseFloatOrZero(xmlNode.Attribute("moveSpeed")?.Value);
             string path = xmlNode.Attribute("path")?.Value ?? string.Empty;
-            float x = ParseFloatOrZero(xmlNode.Attribute("x")?.Value);
-            float y = ParseFloatOrZero(xmlNode.Attribute("y")?.Value);
+            float x = ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value);
+            float y = ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value);
 
             float scaledSpeed = moveSpeed * scale;
             Vector position = new(x, y);

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadBambooTubes.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadBambooTubes.cs
@@ -17,8 +17,8 @@ namespace CutTheRopeDX.GameMain
         /// <param name="mapOffsetY">The additional map Y offset applied during loading.</param>
         private void LoadBambooTube(XElement xmlNode, float scale, float offsetX, float offsetY, int mapOffsetX, int mapOffsetY)
         {
-            float x = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-            float y = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+            float x = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+            float y = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
             float angle = ParseFloatOrZero(xmlNode.Attribute("angle")?.Value);
             BambooTube bambooTube = new BambooTube().InitWithPositionAngle(Vect(x, y), angle, scale);
             bambooTubes.Add(bambooTube);

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadBouncers.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadBouncers.cs
@@ -17,8 +17,8 @@ namespace CutTheRopeDX.GameMain
         /// <param name="mapOffsetY">The additional map Y offset applied during loading.</param>
         private void LoadBouncer(XElement xmlNode, float scale, float offsetX, float offsetY, int mapOffsetX, int mapOffsetY)
         {
-            float px2 = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-            float py2 = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+            float px2 = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+            float py2 = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
             int w2 = ParseIntOrZero(xmlNode.Attribute("size")?.Value);
             float an2 = ParseIntOrZero(xmlNode.Attribute("angle")?.Value);
             Bouncer bouncer = new Bouncer().InitWithPosXYWidthAndAngle(px2, py2, w2, an2);

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadBubbles.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadBubbles.cs
@@ -23,8 +23,8 @@ namespace CutTheRopeDX.GameMain
             Bubble bubble = Bubble.Bubble_createWithResIDQuad(Resources.Img.ObjBubble, q2);
             bubble.DoRestoreCutTransparency();
             bubble.bb = GetBubbleBoundingBox();
-            bubble.initial_x = bubble.x = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-            bubble.initial_y = bubble.y = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+            bubble.initial_x = bubble.x = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+            bubble.initial_y = bubble.y = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
             bubble.initial_rotation = 0f;
             bubble.initial_rotatedCircle = null;
             bubble.anchor = 18;

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadConveyorBelts.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadConveyorBelts.cs
@@ -17,8 +17,8 @@ namespace CutTheRopeDX.GameMain
         /// <param name="mapOffsetY">The additional map Y offset applied during loading.</param>
         private void LoadConveyorBelt(XElement xmlNode, float scale, float offsetX, float offsetY, int mapOffsetX, int mapOffsetY)
         {
-            float x = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-            float y = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+            float x = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+            float y = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
             float length = ParseFloatOrZero(xmlNode.Attribute("length")?.Value) * scale;
             float height = ParseFloatOrZero(xmlNode.Attribute("width")?.Value) * scale;
             float rotation = ParseFloatOrZero(xmlNode.Attribute("angle")?.Value);

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadGhosts.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadGhosts.cs
@@ -17,8 +17,8 @@ namespace CutTheRopeDX.GameMain
         /// <param name="mapOffsetY">The additional map Y offset applied during loading.</param>
         private void LoadGhost(XElement xmlNode, float scale, float offsetX, float offsetY, int mapOffsetX, int mapOffsetY)
         {
-            float px = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-            float py = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+            float px = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+            float py = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
             float grabRadius = ParseFloatOrZero(xmlNode.Attribute("radius")?.Value);
             if (grabRadius != -1f)
             {

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadGrabs.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadGrabs.cs
@@ -21,8 +21,8 @@ namespace CutTheRopeDX.GameMain
         /// <param name="mapOffsetY">The additional map Y offset applied during loading.</param>
         private void LoadGrab(XElement xmlNode, float scale, float offsetX, float offsetY, int mapOffsetX, int mapOffsetY)
         {
-            float hx = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-            float hy = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+            float hx = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+            float hy = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
             float len = ParseIntOrZero(xmlNode.Attribute("length")?.Value) * scale;
             float grabRadius = ParseFloatOrZero(xmlNode.Attribute("radius")?.Value);
             _ = bool.TryParse(xmlNode.Attribute("wheel")?.Value, out bool wheel);

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadGravityButton.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadGravityButton.cs
@@ -26,8 +26,8 @@ namespace CutTheRopeDX.GameMain
             gravityButton.visible = false;
             gravityButton.touchable = false;
             _ = AddChild(gravityButton);
-            gravityButton.x = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-            gravityButton.y = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+            gravityButton.x = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+            gravityButton.y = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
             gravityButton.anchor = 18;
         }
     }

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadHands.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadHands.cs
@@ -21,8 +21,8 @@ namespace CutTheRopeDX.GameMain
 
             MechanicalHand hand = new()
             {
-                x = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX,
-                y = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY
+                x = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX,
+                y = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY
             };
 
             CalculateTopLeft(hand);

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadLanterns.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadLanterns.cs
@@ -19,8 +19,8 @@ namespace CutTheRopeDX.GameMain
         /// <param name="mapOffsetY">The additional map Y offset applied during loading.</param>
         private void LoadLantern(XElement xmlNode, float scale, float offsetX, float offsetY, int mapOffsetX, int mapOffsetY)
         {
-            float x = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-            float y = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+            float x = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+            float y = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
             _ = bool.TryParse(xmlNode.Attribute("candyCaptured")?.Value, out bool isCandyCaptured);
 
             Lantern lantern = new Lantern().InitWithPosition(Vect(x, y));

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadLightBulb.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadLightBulb.cs
@@ -19,8 +19,8 @@ namespace CutTheRopeDX.GameMain
         /// <param name="mapOffsetY">The additional map Y offset applied during loading.</param>
         private void LoadLightBulb(XElement xmlNode, float scale, float offsetX, float offsetY, int mapOffsetX, int mapOffsetY)
         {
-            float x = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-            float y = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+            float x = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+            float y = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
             float litRadius = ParseFloatOrZero(xmlNode.Attribute("litRadius")?.Value) * scale;
             string bulbNumber = xmlNode.Attribute("bulbNumber")?.Value ?? string.Empty;
 

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadMice.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadMice.cs
@@ -17,8 +17,8 @@ namespace CutTheRopeDX.GameMain
         /// <param name="mapOffsetY">The additional map Y offset applied during loading.</param>
         private void LoadMouse(XElement xmlNode, float scale, float offsetX, float offsetY, int mapOffsetX, int mapOffsetY)
         {
-            float px = (ParseFloatOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-            float py = (ParseFloatOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+            float px = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+            float py = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
             float angle = ParseFloatOrZero(xmlNode.Attribute("angle")?.Value);
             float radius = ParseFloatOrZero(xmlNode.Attribute("radius")?.Value);
             radius = radius != 0f ? radius * scale : 80f * scale;

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadPumps.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadPumps.cs
@@ -23,8 +23,8 @@ namespace CutTheRopeDX.GameMain
             pump.DoRestoreCutTransparency();
             _ = pump.AddAnimationWithDelayLoopedCountSequence(0.05f, Timeline.LoopType.TIMELINE_NO_LOOP, 4, 1, [2, 3, 0]);
             pump.bb = GetPumpBoundingBox();
-            pump.initial_x = pump.x = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-            pump.initial_y = pump.y = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+            pump.initial_x = pump.x = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+            pump.initial_y = pump.y = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
             pump.initial_rotation = 0f;
             pump.initial_rotatedCircle = null;
             pump.rotation = ParseFloatOrZero(xmlNode.Attribute("angle")?.Value) + DEG_90;

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadRockets.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadRockets.cs
@@ -31,8 +31,8 @@ namespace CutTheRopeDX.GameMain
             quadSize.Y *= 0.05f;
             rocket.bb = MakeRectangle(quadCenter.X - (quadSize.X / 2f), quadCenter.Y - (quadSize.Y / 2f), quadSize.X, quadSize.Y);
 
-            rocket.x = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-            rocket.y = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+            rocket.x = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+            rocket.y = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
             rocket.rotation = ParseFloatOrZero(xmlNode.Attribute("angle")?.Value) - DEG_180;
             rocket.impulse = ParseFloatOrZero(xmlNode.Attribute("impulse")?.Value);
             rocket.impulseFactor = ParseFloatOrZero(xmlNode.Attribute("impulseFactor")?.Value);

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadRotatedCircles.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadRotatedCircles.cs
@@ -17,8 +17,8 @@ namespace CutTheRopeDX.GameMain
         /// <param name="mapOffsetY">The additional map Y offset applied during loading.</param>
         private void LoadRotatedCircle(XElement xmlNode, float scale, float offsetX, float offsetY, int mapOffsetX, int mapOffsetY)
         {
-            float centerX = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-            float centerY = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+            float centerX = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+            float centerY = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
             float circleSize = ParseIntOrZero(xmlNode.Attribute("size")?.Value);
             float d = ParseIntOrZero(xmlNode.Attribute("handleAngle")?.Value);
             _ = bool.TryParse(xmlNode.Attribute("oneHandle")?.Value, out bool hasOneHandle);

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadSnails.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadSnails.cs
@@ -17,8 +17,8 @@ namespace CutTheRopeDX.GameMain
         /// <param name="mapOffsetY">The additional map Y offset applied during loading.</param>
         private void LoadSnail(XElement xmlNode, float scale, float offsetX, float offsetY, int mapOffsetX, int mapOffsetY)
         {
-            float x = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-            float y = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+            float x = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+            float y = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
 
             Snail snail = Snail.Snail_createWithResIDQuad(Resources.Img.ObjSnail, 8);
             snail.anchor = 18;

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadSocks.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadSocks.cs
@@ -30,8 +30,8 @@ namespace CutTheRopeDX.GameMain
             sock.CreateAnimations();
             sock.scaleX = sock.scaleY = 0.7f;
             sock.DoRestoreCutTransparency();
-            sock.x = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-            sock.y = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+            sock.x = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+            sock.y = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
             sock.group = ParseIntOrZero(xmlNode.Attribute("group")?.Value);
             sock.anchor = 10;
             sock.rotationCenterY -= (sock.height / 2f) - 85f;

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadSpikes.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadSpikes.cs
@@ -18,8 +18,8 @@ namespace CutTheRopeDX.GameMain
         /// <param name="mapOffsetY">The additional map Y offset applied during loading.</param>
         private void LoadSpike(XElement xmlNode, float scale, float offsetX, float offsetY, int mapOffsetX, int mapOffsetY)
         {
-            float px = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-            float py = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+            float px = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+            float py = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
             int w = ParseIntOrZero(xmlNode.Attribute("size")?.Value);
             float an = ParseIntOrZero(xmlNode.Attribute("angle")?.Value);
             string toggledAttribute = xmlNode.Attribute("toggled")?.Value ?? string.Empty;

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadStars.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadStars.cs
@@ -22,8 +22,8 @@ namespace CutTheRopeDX.GameMain
             {
                 star.EnableNightMode();
             }
-            star.x = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-            star.y = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+            star.x = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+            star.y = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
             star.timeout = ParseFloatOrZero(xmlNode.Attribute("timeout")?.Value);
             star.CreateAnimations();
             star.bb = GetStarBoundingBox();

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadSteamTubes.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadSteamTubes.cs
@@ -17,8 +17,8 @@ namespace CutTheRopeDX.GameMain
         /// <param name="mapOffsetY">The additional map Y offset applied during loading.</param>
         private void LoadSteamTube(XElement xmlNode, float scale, float offsetX, float offsetY, int mapOffsetX, int mapOffsetY)
         {
-            float x = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-            float y = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+            float x = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+            float y = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
             float angle = ParseFloatOrZero(xmlNode.Attribute("angle")?.Value);
             SteamTube steamTube = new SteamTube().InitWithPositionAngle(Vect(x, y), angle, scale);
             tubes.Add(steamTube);

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadTarget.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadTarget.cs
@@ -44,12 +44,12 @@ namespace CutTheRopeDX.GameMain
             targetObj.scaleY = targetBaseScaleY;
 
             string xAttribute = xmlNode.Attribute("x")?.Value ?? string.Empty;
-            int sourceX = ParseIntOrZero(xAttribute);
+            int sourceX = ParseCoordinateIntOrZero(xAttribute);
             float transformedX = (sourceX * scale) + offsetX + mapOffsetX;
             targetObj.x = support.x = transformedX;
 
             string yAttribute = xmlNode.Attribute("y")?.Value ?? string.Empty;
-            int sourceY = ParseIntOrZero(yAttribute);
+            int sourceY = ParseCoordinateIntOrZero(yAttribute);
             float transformedY = (sourceY * scale) + offsetY + mapOffsetY;
             targetObj.y = support.y = transformedY;
 

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadTutorials.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadTutorials.cs
@@ -27,8 +27,8 @@ namespace CutTheRopeDX.GameMain
                 CTRRootController cTRRootController = (CTRRootController)Application.SharedRootController();
                 TutorialText tutorialText = (TutorialText)new TutorialText().InitWithFont(Application.GetFont(Resources.Fnt.SmallFont));
                 tutorialText.color = RGBAColor.MakeRGBA(1, 1, 1, 0.9f);
-                tutorialText.x = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-                tutorialText.y = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+                tutorialText.x = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+                tutorialText.y = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
                 tutorialText.special = ParseIntOrZero(xmlNode.Attribute("special")?.Value);
                 tutorialText.SetAlignment(2);
                 string textKey = xmlNode.Attribute("text")?.Value ?? string.Empty;
@@ -75,8 +75,8 @@ namespace CutTheRopeDX.GameMain
                 int q = ParseIntOrZero(new string(xmlNode.Name.LocalName.AsSpan()[8..])) - 1;
                 GameObjectSpecial gameObjectSpecial = GameObjectSpecial.GameObjectSpecial_createWithResIDQuad(Resources.Img.TutorialSigns, q);
                 gameObjectSpecial.color = RGBAColor.transparentRGBA;
-                gameObjectSpecial.x = (ParseIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
-                gameObjectSpecial.y = (ParseIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
+                gameObjectSpecial.x = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
+                gameObjectSpecial.y = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;
                 gameObjectSpecial.rotation = ParseIntOrZero(xmlNode.Attribute("angle")?.Value);
                 gameObjectSpecial.special = ParseIntOrZero(xmlNode.Attribute("special")?.Value);
                 gameObjectSpecial.ParseMover(xmlNode);

--- a/CutTheRopeDX/Helpers/ParsingHelpers.cs
+++ b/CutTheRopeDX/Helpers/ParsingHelpers.cs
@@ -18,6 +18,21 @@ namespace CutTheRopeDX.Helpers
         }
 
         /// <summary>
+        /// Parses a map coordinate using invariant culture and truncates its fractional part toward zero.
+        /// Returns 0 when the value is missing, invalid, or outside the range of an integer.
+        /// </summary>
+        /// <param name="value">The coordinate string to parse.</param>
+        /// <returns>The truncated integer coordinate, or 0 if parsing fails.</returns>
+        public static int ParseCoordinateIntOrZero(string value)
+        {
+            return !decimal.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out decimal parsed)
+                || parsed < int.MinValue
+                || parsed > int.MaxValue
+                ? 0
+                : decimal.ToInt32(decimal.Truncate(parsed));
+        }
+
+        /// <summary>
         /// Parses a floating-point number from a string using invariant culture, returning 0 if the value
         /// is <see langword="null"/>, empty, or not a valid number.
         /// </summary>


### PR DESCRIPTION
## Description

X/Y coordinates and mapOffsetX/mapOffsetY only support integer values. Previously, decimal values failed integer parsing and defaulted to 0, causing incorrect object positioning.

This PR truncates decimal coordinates toward zero before positioning objects. For example, 12.9 becomes 12 and -12.9 becomes -12.