### PR TITLE
enhancement: Improve mobile physics mode, plus atlas-independent collision constants

### DIFF
--- a/CutTheRopeDX.Tests/AssemblyInfo.cs
+++ b/CutTheRopeDX.Tests/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using Xunit;
+
+// Several test classes toggle the process-wide ActivePhysicsConstants.UseMobilePhysicsModel
+// flag (save/set/restore), and others assert against mode-dependent constants assuming the
+// desktop default. Parallel test classes race on that global, so run the suite serially.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/CutTheRopeDX.Tests/TextureCollisionWidthTests.cs
+++ b/CutTheRopeDX.Tests/TextureCollisionWidthTests.cs
@@ -4,9 +4,10 @@ using Xunit;
 
 namespace CutTheRopeDX.Tests
 {
-    // Mobile physics must use the WP7 base-asset quad widths (x3) for collision geometry that
-    // the engine derives from texture sizes, because the desktop art is trimmed differently
-    // (e.g. obj_spikes_02 is 335 px wide on desktop but 106x3=318 in WP7 units).
+    // Spike/bouncer collision widths are table-driven from the original XML quad data rather than
+    // read from the live texture atlas: the JSON atlas trim differs from both originals (every
+    // frame is +2 px vs the pre-json atlas; the WP7 base assets differ more), so deriving physics
+    // from the atlas silently changes collision whenever art is re-packed.
     public class TextureCollisionWidthTests
     {
         private static T WithMobilePhysics<T>(bool mobile, System.Func<T> body)
@@ -31,7 +32,7 @@ namespace CutTheRopeDX.Tests
         public void SpikesLineWidth_MobileUsesWp7StaticQuadWidths(int widthIndex, float expected)
         {
             float result = WithMobilePhysics(true, () =>
-                ActivePhysicsConstants.SpikesCollisionLineWidth(rotatable: false, widthIndex, textureQuadWidth: 999f));
+                ActivePhysicsConstants.SpikesCollisionLineWidth(rotatable: false, widthIndex));
             Assert.Equal(expected, result, precision: 3);
         }
 
@@ -43,38 +44,44 @@ namespace CutTheRopeDX.Tests
         public void SpikesLineWidth_MobileUsesWp7RotatableQuadWidths(int widthIndex, float expected)
         {
             float result = WithMobilePhysics(true, () =>
-                ActivePhysicsConstants.SpikesCollisionLineWidth(rotatable: true, widthIndex, textureQuadWidth: 999f));
+                ActivePhysicsConstants.SpikesCollisionLineWidth(rotatable: true, widthIndex));
             Assert.Equal(expected, result, precision: 3);
         }
 
-        [Fact]
-        public void SpikesLineWidth_DesktopPassesTextureQuadWidthThrough()
+        [Theory]
+        [InlineData(false, 1, 212f)]
+        [InlineData(false, 2, 333f)]
+        [InlineData(false, 3, 453f)]
+        [InlineData(false, 4, 566f)]
+        [InlineData(true, 1, 202f)]
+        [InlineData(true, 2, 319f)]
+        [InlineData(true, 3, 444f)]
+        [InlineData(true, 4, 559f)]
+        public void SpikesLineWidth_DesktopUsesXmlQuadWidths(bool rotatable, int widthIndex, float expected)
         {
             float result = WithMobilePhysics(false, () =>
-                ActivePhysicsConstants.SpikesCollisionLineWidth(rotatable: false, widthIndex: 2, textureQuadWidth: 335f));
-            Assert.Equal(335f, result, precision: 3);
+                ActivePhysicsConstants.SpikesCollisionLineWidth(rotatable, widthIndex));
+            Assert.Equal(expected, result, precision: 3);
         }
 
-        // WP7 electro zap length = preCut width 267 - 130 = 137 -> x3 = 411. The dx electrodes
-        // sheet is 833 wide (not 267x3=801), so the object width must be overridden on mobile.
+        // WP7 electro zap length = preCut width 267 - 130 = 137 -> x3 = 411.
+        // XML quad preCut width = 833, zap = 833 - 400 = 433.
         [Fact]
         public void ElectroSpikesObjectWidth_MobileUsesWp7PreCutWidth()
         {
-            float objectWidth = WithMobilePhysics(true, () =>
-                ActivePhysicsConstants.ElectroSpikesCollisionObjectWidth(833f));
+            float objectWidth = WithMobilePhysics(true, ActivePhysicsConstants.ElectroSpikesCollisionObjectWidth);
             Assert.Equal(801f, objectWidth, precision: 3);
         }
 
         [Fact]
-        public void ElectroSpikesObjectWidth_DesktopPassesObjectWidthThrough()
+        public void ElectroSpikesObjectWidth_DesktopUsesXmlPreCutWidth()
         {
-            float objectWidth = WithMobilePhysics(false, () =>
-                ActivePhysicsConstants.ElectroSpikesCollisionObjectWidth(833f));
+            float objectWidth = WithMobilePhysics(false, ActivePhysicsConstants.ElectroSpikesCollisionObjectWidth);
             Assert.Equal(833f, objectWidth, precision: 3);
         }
 
-        // WP7 bouncer collision width follows the current animation quad, so the mobile
-        // override is frame-indexed to keep the per-frame wobble 1:1.
+        // Both originals let the bouncer's collision width follow the current animation quad,
+        // so the tables are frame-indexed to keep the per-frame wobble faithful.
         [Theory]
         [InlineData(false, 0, 198f)] // 66 * 3
         [InlineData(false, 2, 210f)] // 70 * 3
@@ -84,25 +91,68 @@ namespace CutTheRopeDX.Tests
         public void BouncerWidth_MobileUsesWp7QuadWidthsPerFrame(bool large, int frameIndex, float expected)
         {
             float result = WithMobilePhysics(true, () =>
-                ActivePhysicsConstants.BouncerCollisionWidth(large, frameIndex, objectWidth: 999f));
+                ActivePhysicsConstants.BouncerCollisionWidth(large, frameIndex));
             Assert.Equal(expected, result, precision: 3);
         }
 
-        [Fact]
-        public void BouncerWidth_DesktopPassesObjectWidthThrough()
+        [Theory]
+        [InlineData(false, 0, 194f)]
+        [InlineData(false, 2, 204f)]
+        [InlineData(false, 4, 194f)]
+        [InlineData(true, 0, 302f)]
+        [InlineData(true, 2, 322f)]
+        [InlineData(true, 4, 302f)]
+        public void BouncerWidth_DesktopUsesXmlQuadWidthsPerFrame(bool large, int frameIndex, float expected)
         {
             float result = WithMobilePhysics(false, () =>
-                ActivePhysicsConstants.BouncerCollisionWidth(large: true, frameIndex: 0, objectWidth: 304f));
-            Assert.Equal(304f, result, precision: 3);
+                ActivePhysicsConstants.BouncerCollisionWidth(large, frameIndex));
+            Assert.Equal(expected, result, precision: 3);
+        }
+
+        // Rocket catch-slat bb (0.6 x quad width, 0.05 x quad height of the rocket body quad),
+        // pinned from XML quads and expressed center-relative to the rocket object.
+        // Mobile: Experiments base quad 10 = 116x58 centered at (91,67) on the 199x134 sheet, x3.
+        [Fact]
+        public void RocketCatchBox_MobileUsesExperimentsBaseQuad()
+        {
+            (float w, float h, float ox, float oy) = WithMobilePhysics(true, () => (
+                ActivePhysicsConstants.RocketCatchBoxWidth,
+                ActivePhysicsConstants.RocketCatchBoxHeight,
+                ActivePhysicsConstants.RocketCatchBoxCenterOffsetX,
+                ActivePhysicsConstants.RocketCatchBoxCenterOffsetY));
+            Assert.Equal(208.8f, w, precision: 3);  // 116 * 0.6 * 3
+            Assert.Equal(8.7f, h, precision: 3);    // 58 * 0.05 * 3
+            Assert.Equal(-25.5f, ox, precision: 3); // (91 - 99.5) * 3
+            Assert.Equal(0f, oy, precision: 3);     // (67 - 67) * 3
+        }
+
+        // Desktop: dx atlas quad 10 = 358x179 centered at (288, 208.5) on the 619x418 sheet,
+        // frozen as constants so atlas repacks cannot move the hitbox.
+        [Fact]
+        public void RocketCatchBox_DesktopUsesFrozenDxAtlasQuad()
+        {
+            (float w, float h, float ox, float oy) = WithMobilePhysics(false, () => (
+                ActivePhysicsConstants.RocketCatchBoxWidth,
+                ActivePhysicsConstants.RocketCatchBoxHeight,
+                ActivePhysicsConstants.RocketCatchBoxCenterOffsetX,
+                ActivePhysicsConstants.RocketCatchBoxCenterOffsetY));
+            Assert.Equal(214.8f, w, precision: 3);  // 358 * 0.6
+            Assert.Equal(8.95f, h, precision: 3);   // 179 * 0.05
+            Assert.Equal(-21.5f, ox, precision: 3); // 288 - 309.5
+            Assert.Equal(-0.5f, oy, precision: 3);  // 208.5 - 209
         }
 
         // Defensive: an out-of-range animation frame must clamp into the table, not throw.
         [Fact]
-        public void BouncerWidth_MobileClampsFrameIndexIntoTable()
+        public void BouncerWidth_ClampsFrameIndexIntoTable()
         {
-            float result = WithMobilePhysics(true, () =>
-                ActivePhysicsConstants.BouncerCollisionWidth(large: false, frameIndex: 9, objectWidth: 999f));
-            Assert.Equal(198f, result, precision: 3); // clamped to last small frame (66 * 3)
+            float mobile = WithMobilePhysics(true, () =>
+                ActivePhysicsConstants.BouncerCollisionWidth(large: false, frameIndex: 9));
+            Assert.Equal(198f, mobile, precision: 3); // clamped to last small frame (66 * 3)
+
+            float desktop = WithMobilePhysics(false, () =>
+                ActivePhysicsConstants.BouncerCollisionWidth(large: true, frameIndex: -1));
+            Assert.Equal(302f, desktop, precision: 3); // clamped to first large frame
         }
     }
 }

--- a/CutTheRopeDX.Tests/TextureCollisionWidthTests.cs
+++ b/CutTheRopeDX.Tests/TextureCollisionWidthTests.cs
@@ -80,32 +80,25 @@ namespace CutTheRopeDX.Tests
             Assert.Equal(833f, objectWidth, precision: 3);
         }
 
-        // Both originals let the bouncer's collision width follow the current animation quad,
-        // so the tables are frame-indexed to keep the per-frame wobble faithful.
+        // Both originals set the bouncer's collision width from the initial sprite (quad 0) and
+        // never advance it with the bounce animation, so only the first quad width is used.
         [Theory]
-        [InlineData(false, 0, 198f)] // 66 * 3
-        [InlineData(false, 2, 210f)] // 70 * 3
-        [InlineData(true, 0, 333f)]  // 111 * 3
-        [InlineData(true, 2, 354f)]  // 118 * 3
-        [InlineData(true, 4, 318f)]  // 106 * 3
-        public void BouncerWidth_MobileUsesWp7QuadWidthsPerFrame(bool large, int frameIndex, float expected)
+        [InlineData(false, 198f)] // small quad 0: 66 * 3
+        [InlineData(true, 333f)]  // large quad 0: 111 * 3
+        public void BouncerWidth_MobileUsesWp7FirstQuadWidth(bool large, float expected)
         {
             float result = WithMobilePhysics(true, () =>
-                ActivePhysicsConstants.BouncerCollisionWidth(large, frameIndex));
+                ActivePhysicsConstants.BouncerCollisionWidth(large));
             Assert.Equal(expected, result, precision: 3);
         }
 
         [Theory]
-        [InlineData(false, 0, 194f)]
-        [InlineData(false, 2, 204f)]
-        [InlineData(false, 4, 194f)]
-        [InlineData(true, 0, 302f)]
-        [InlineData(true, 2, 322f)]
-        [InlineData(true, 4, 302f)]
-        public void BouncerWidth_DesktopUsesXmlQuadWidthsPerFrame(bool large, int frameIndex, float expected)
+        [InlineData(false, 194f)] // small quad 0
+        [InlineData(true, 302f)]  // large quad 0
+        public void BouncerWidth_DesktopUsesXmlFirstQuadWidth(bool large, float expected)
         {
             float result = WithMobilePhysics(false, () =>
-                ActivePhysicsConstants.BouncerCollisionWidth(large, frameIndex));
+                ActivePhysicsConstants.BouncerCollisionWidth(large));
             Assert.Equal(expected, result, precision: 3);
         }
 
@@ -140,19 +133,6 @@ namespace CutTheRopeDX.Tests
             Assert.Equal(8.95f, h, precision: 3);   // 179 * 0.05
             Assert.Equal(-21.5f, ox, precision: 3); // 288 - 309.5
             Assert.Equal(-0.5f, oy, precision: 3);  // 208.5 - 209
-        }
-
-        // Defensive: an out-of-range animation frame must clamp into the table, not throw.
-        [Fact]
-        public void BouncerWidth_ClampsFrameIndexIntoTable()
-        {
-            float mobile = WithMobilePhysics(true, () =>
-                ActivePhysicsConstants.BouncerCollisionWidth(large: false, frameIndex: 9));
-            Assert.Equal(198f, mobile, precision: 3); // clamped to last small frame (66 * 3)
-
-            float desktop = WithMobilePhysics(false, () =>
-                ActivePhysicsConstants.BouncerCollisionWidth(large: true, frameIndex: -1));
-            Assert.Equal(302f, desktop, precision: 3); // clamped to first large frame
         }
     }
 }

--- a/CutTheRopeDX.Tests/TextureCollisionWidthTests.cs
+++ b/CutTheRopeDX.Tests/TextureCollisionWidthTests.cs
@@ -82,9 +82,10 @@ namespace CutTheRopeDX.Tests
 
         // Both originals set the bouncer's collision width from the initial sprite (quad 0) and
         // never advance it with the bounce animation, so only the first quad width is used.
+        // Mobile applies the Experiments-style end-cap of 20 (1x) to the quad-0 width.
         [Theory]
-        [InlineData(false, 198f)] // small quad 0: 66 * 3
-        [InlineData(true, 333f)]  // large quad 0: 111 * 3
+        [InlineData(false, 138f)] // small quad 0: (66 - 20) * 3
+        [InlineData(true, 273f)]  // large quad 0: (111 - 20) * 3
         public void BouncerWidth_MobileUsesWp7FirstQuadWidth(bool large, float expected)
         {
             float result = WithMobilePhysics(true, () =>

--- a/CutTheRopeDX.Tests/TextureCollisionWidthTests.cs
+++ b/CutTheRopeDX.Tests/TextureCollisionWidthTests.cs
@@ -1,0 +1,108 @@
+using CutTheRopeDX.Framework;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    // Mobile physics must use the WP7 base-asset quad widths (x3) for collision geometry that
+    // the engine derives from texture sizes, because the desktop art is trimmed differently
+    // (e.g. obj_spikes_02 is 335 px wide on desktop but 106x3=318 in WP7 units).
+    public class TextureCollisionWidthTests
+    {
+        private static T WithMobilePhysics<T>(bool mobile, System.Func<T> body)
+        {
+            bool previous = ActivePhysicsConstants.UseMobilePhysicsModel;
+            try
+            {
+                ActivePhysicsConstants.UseMobilePhysicsModel = mobile;
+                return body();
+            }
+            finally
+            {
+                ActivePhysicsConstants.UseMobilePhysicsModel = previous;
+            }
+        }
+
+        [Theory]
+        [InlineData(1, 204f)] // 68 * 3
+        [InlineData(2, 318f)] // 106 * 3
+        [InlineData(3, 438f)] // 146 * 3
+        [InlineData(4, 543f)] // 181 * 3
+        public void SpikesLineWidth_MobileUsesWp7StaticQuadWidths(int widthIndex, float expected)
+        {
+            float result = WithMobilePhysics(true, () =>
+                ActivePhysicsConstants.SpikesCollisionLineWidth(rotatable: false, widthIndex, textureQuadWidth: 999f));
+            Assert.Equal(expected, result, precision: 3);
+        }
+
+        [Theory]
+        [InlineData(1, 204f)] // 68 * 3
+        [InlineData(2, 354f)] // 118 * 3
+        [InlineData(3, 426f)] // 142 * 3
+        [InlineData(4, 534f)] // 178 * 3
+        public void SpikesLineWidth_MobileUsesWp7RotatableQuadWidths(int widthIndex, float expected)
+        {
+            float result = WithMobilePhysics(true, () =>
+                ActivePhysicsConstants.SpikesCollisionLineWidth(rotatable: true, widthIndex, textureQuadWidth: 999f));
+            Assert.Equal(expected, result, precision: 3);
+        }
+
+        [Fact]
+        public void SpikesLineWidth_DesktopPassesTextureQuadWidthThrough()
+        {
+            float result = WithMobilePhysics(false, () =>
+                ActivePhysicsConstants.SpikesCollisionLineWidth(rotatable: false, widthIndex: 2, textureQuadWidth: 335f));
+            Assert.Equal(335f, result, precision: 3);
+        }
+
+        // WP7 electro zap length = preCut width 267 - 130 = 137 -> x3 = 411. The dx electrodes
+        // sheet is 833 wide (not 267x3=801), so the object width must be overridden on mobile.
+        [Fact]
+        public void ElectroSpikesObjectWidth_MobileUsesWp7PreCutWidth()
+        {
+            float objectWidth = WithMobilePhysics(true, () =>
+                ActivePhysicsConstants.ElectroSpikesCollisionObjectWidth(833f));
+            Assert.Equal(801f, objectWidth, precision: 3);
+        }
+
+        [Fact]
+        public void ElectroSpikesObjectWidth_DesktopPassesObjectWidthThrough()
+        {
+            float objectWidth = WithMobilePhysics(false, () =>
+                ActivePhysicsConstants.ElectroSpikesCollisionObjectWidth(833f));
+            Assert.Equal(833f, objectWidth, precision: 3);
+        }
+
+        // WP7 bouncer collision width follows the current animation quad, so the mobile
+        // override is frame-indexed to keep the per-frame wobble 1:1.
+        [Theory]
+        [InlineData(false, 0, 198f)] // 66 * 3
+        [InlineData(false, 2, 210f)] // 70 * 3
+        [InlineData(true, 0, 333f)]  // 111 * 3
+        [InlineData(true, 2, 354f)]  // 118 * 3
+        [InlineData(true, 4, 318f)]  // 106 * 3
+        public void BouncerWidth_MobileUsesWp7QuadWidthsPerFrame(bool large, int frameIndex, float expected)
+        {
+            float result = WithMobilePhysics(true, () =>
+                ActivePhysicsConstants.BouncerCollisionWidth(large, frameIndex, objectWidth: 999f));
+            Assert.Equal(expected, result, precision: 3);
+        }
+
+        [Fact]
+        public void BouncerWidth_DesktopPassesObjectWidthThrough()
+        {
+            float result = WithMobilePhysics(false, () =>
+                ActivePhysicsConstants.BouncerCollisionWidth(large: true, frameIndex: 0, objectWidth: 304f));
+            Assert.Equal(304f, result, precision: 3);
+        }
+
+        // Defensive: an out-of-range animation frame must clamp into the table, not throw.
+        [Fact]
+        public void BouncerWidth_MobileClampsFrameIndexIntoTable()
+        {
+            float result = WithMobilePhysics(true, () =>
+                ActivePhysicsConstants.BouncerCollisionWidth(large: false, frameIndex: 9, objectWidth: 999f));
+            Assert.Equal(198f, result, precision: 3); // clamped to last small frame (66 * 3)
+        }
+    }
+}

--- a/CutTheRopeDX/Framework/ActivePhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/ActivePhysicsConstants.cs
@@ -305,6 +305,16 @@ namespace CutTheRopeDX.Framework
         public static float SpiderTraversalSpeed => SelectRaw(PhysicsConstants.SpiderTraversalSpeed, MobilePhysicsConstants.SpiderTraversalSpeed);
 
         /// <summary>
+        /// Half-height of the spikes collision band around the spike line.
+        /// </summary>
+        public static float SpikesCollisionBandHalfHeight => SelectScaled(PhysicsConstants.SpikesCollisionBandHalfHeight, MobilePhysicsConstants.SpikesCollisionBandHalfHeight);
+
+        /// <summary>
+        /// Amount subtracted from an electro spike's width to get the active zap segment length.
+        /// </summary>
+        public static float ElectroSpikesWidthReduction => SelectScaled(PhysicsConstants.ElectroSpikesWidthReduction, MobilePhysicsConstants.ElectroSpikesWidthReduction);
+
+        /// <summary>
         /// Number of sample points drawn for each bungee segment.
         /// </summary>
         public static int BungeeDrawSamplePoints => SelectRaw(PhysicsConstants.BungeeDrawSamplePoints, MobilePhysicsConstants.BungeeDrawSamplePoints);

--- a/CutTheRopeDX/Framework/ActivePhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/ActivePhysicsConstants.cs
@@ -150,6 +150,16 @@ namespace CutTheRopeDX.Framework
         public static float SockSpeedKoeff => SelectRaw(PhysicsConstants.SockSpeedKoeff, MobilePhysicsConstants.SockSpeedKoeff);
 
         /// <summary>
+        /// Half-size of the candy collision box used when a sock catches the candy.
+        /// </summary>
+        public static float SockCatchHalfSize => SelectScaled(PhysicsConstants.SockCatchHalfSize, MobilePhysicsConstants.SockCatchHalfSize);
+
+        /// <summary>
+        /// Vertical offset applied to the candy when it exits a sock.
+        /// </summary>
+        public static float SockExitOffsetY => SelectScaled(PhysicsConstants.SockExitOffsetY, MobilePhysicsConstants.SockExitOffsetY);
+
+        /// <summary>
         /// Maximum rope roll length used by grab mechanics.
         /// </summary>
         public static float GrabRopeRollMaxLength => SelectScaled(PhysicsConstants.GrabRopeRollMaxLength, MobilePhysicsConstants.GrabRopeRollMaxLength);

--- a/CutTheRopeDX/Framework/ActivePhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/ActivePhysicsConstants.cs
@@ -155,9 +155,24 @@ namespace CutTheRopeDX.Framework
         public static float GrabRopeRollMaxLength => SelectScaled(PhysicsConstants.GrabRopeRollMaxLength, MobilePhysicsConstants.GrabRopeRollMaxLength);
 
         /// <summary>
-        /// Maximum wheel rotation delta used by grab mechanics.
+        /// Maximum rope length rolled per wheel rotate event.
         /// </summary>
-        public static float GrabWheelRotateDeltaMax => SelectRaw(PhysicsConstants.GrabWheelRotateDeltaMax, MobilePhysicsConstants.GrabWheelRotateDeltaMax);
+        public static float GrabWheelRotateDeltaMax => SelectScaled(PhysicsConstants.GrabWheelRotateDeltaMax, MobilePhysicsConstants.GrabWheelRotateDeltaMax);
+
+        /// <summary>
+        /// Minimum rope length rolled per wheel rotate event.
+        /// </summary>
+        public static float GrabWheelRotateDeltaMin => SelectScaled(PhysicsConstants.GrabWheelRotateDeltaMin, MobilePhysicsConstants.GrabWheelRotateDeltaMin);
+
+        /// <summary>
+        /// Speed at which a rocket reels the candy in before flying.
+        /// </summary>
+        public static float RocketReelSpeed => SelectScaled(PhysicsConstants.RocketReelSpeed, MobilePhysicsConstants.RocketReelSpeed);
+
+        /// <summary>
+        /// Speed at which two candy halves converge while merging.
+        /// </summary>
+        public static float CandyPartsMergeSpeed => SelectScaled(PhysicsConstants.CandyPartsMergeSpeed, MobilePhysicsConstants.CandyPartsMergeSpeed);
 
         /// <summary>
         /// Height band used for detecting the water surface.

--- a/CutTheRopeDX/Framework/ActivePhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/ActivePhysicsConstants.cs
@@ -376,20 +376,15 @@ namespace CutTheRopeDX.Framework
         }
 
         /// <summary>
-        /// Full collision width of a bouncer for the current animation frame, table-driven from
-        /// the original XML quad (see <see cref="SpikesCollisionLineWidth"/>). Both originals let
-        /// the width follow the current draw quad, so the tables are frame-indexed to keep the
-        /// per-frame wobble faithful.
+        /// Full collision width of a bouncer, pinned from the original XML first quad (see
+        /// <see cref="SpikesCollisionLineWidth"/>).
         /// </summary>
         /// <param name="large">Whether this is the large (type 2) bouncer.</param>
-        /// <param name="frameIndex">Current animation frame relative to the bouncer's first quad.</param>
-        public static float BouncerCollisionWidth(bool large, int frameIndex)
+        public static float BouncerCollisionWidth(bool large)
         {
-            float[] table = UseMobilePhysicsModel
-                ? large ? MobilePhysicsConstants.BouncerLargeQuadWidths : MobilePhysicsConstants.BouncerSmallQuadWidths
-                : large ? PhysicsConstants.BouncerLargeQuadWidths : PhysicsConstants.BouncerSmallQuadWidths;
-            int index = System.Math.Clamp(frameIndex, 0, table.Length - 1);
-            return UseMobilePhysicsModel ? ToWorld(table[index]) : table[index];
+            return large
+                ? SelectScaled(PhysicsConstants.BouncerLargeCollisionWidth, MobilePhysicsConstants.BouncerLargeCollisionWidth)
+                : SelectScaled(PhysicsConstants.BouncerSmallCollisionWidth, MobilePhysicsConstants.BouncerSmallCollisionWidth);
         }
 
         /// <summary>

--- a/CutTheRopeDX/Framework/ActivePhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/ActivePhysicsConstants.cs
@@ -393,6 +393,27 @@ namespace CutTheRopeDX.Framework
         }
 
         /// <summary>
+        /// Width of the rocket's catch-slat bounding box (0.6 x the rocket body quad width),
+        /// pinned from the original XML quads rather than the live atlas.
+        /// </summary>
+        public static float RocketCatchBoxWidth => SelectScaled(PhysicsConstants.RocketCatchBoxWidth, MobilePhysicsConstants.RocketCatchBoxWidth);
+
+        /// <summary>
+        /// Height of the rocket's catch-slat bounding box (0.05 x the rocket body quad height).
+        /// </summary>
+        public static float RocketCatchBoxHeight => SelectScaled(PhysicsConstants.RocketCatchBoxHeight, MobilePhysicsConstants.RocketCatchBoxHeight);
+
+        /// <summary>
+        /// X offset of the catch-slat box center from the rocket object's center.
+        /// </summary>
+        public static float RocketCatchBoxCenterOffsetX => SelectScaled(PhysicsConstants.RocketCatchBoxCenterOffsetX, MobilePhysicsConstants.RocketCatchBoxCenterOffsetX);
+
+        /// <summary>
+        /// Y offset of the catch-slat box center from the rocket object's center.
+        /// </summary>
+        public static float RocketCatchBoxCenterOffsetY => SelectScaled(PhysicsConstants.RocketCatchBoxCenterOffsetY, MobilePhysicsConstants.RocketCatchBoxCenterOffsetY);
+
+        /// <summary>
         /// Number of sample points drawn for each bungee segment.
         /// </summary>
         public static int BungeeDrawSamplePoints => SelectRaw(PhysicsConstants.BungeeDrawSamplePoints, MobilePhysicsConstants.BungeeDrawSamplePoints);

--- a/CutTheRopeDX/Framework/ActivePhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/ActivePhysicsConstants.cs
@@ -350,6 +350,54 @@ namespace CutTheRopeDX.Framework
         public static float ElectroSpikesWidthReduction => SelectScaled(PhysicsConstants.ElectroSpikesWidthReduction, MobilePhysicsConstants.ElectroSpikesWidthReduction);
 
         /// <summary>
+        /// Full collision line width for a non-electro spike. Desktop reads the live texture
+        /// quad; mobile substitutes the WP7 base-asset quad width because the desktop art is
+        /// trimmed differently.
+        /// </summary>
+        /// <param name="rotatable">Whether the spike belongs to a rotate-toggle group.</param>
+        /// <param name="widthIndex">Spike width/type index (1-4).</param>
+        /// <param name="textureQuadWidth">Live texture quad width (desktop value).</param>
+        public static float SpikesCollisionLineWidth(bool rotatable, int widthIndex, float textureQuadWidth)
+        {
+            if (!UseMobilePhysicsModel)
+            {
+                return textureQuadWidth;
+            }
+            float[] table = rotatable ? MobilePhysicsConstants.RotatableSpikesQuadWidths : MobilePhysicsConstants.SpikesQuadWidths;
+            int index = System.Math.Clamp(widthIndex - 1, 0, table.Length - 1);
+            return ToWorld(table[index]);
+        }
+
+        /// <summary>
+        /// Effective electro spike object width the zap length is derived from
+        /// (zap = this minus <see cref="ElectroSpikesWidthReduction"/>).
+        /// </summary>
+        /// <param name="objectWidth">Live object width (desktop value; the electrodes pre-cut sheet width).</param>
+        public static float ElectroSpikesCollisionObjectWidth(float objectWidth)
+        {
+            return UseMobilePhysicsModel ? ToWorld(MobilePhysicsConstants.ElectroSpikesObjectWidth) : objectWidth;
+        }
+
+        /// <summary>
+        /// Full collision width of a bouncer for the current animation frame. Desktop reads the
+        /// live object width (which follows the draw quad); mobile substitutes the WP7 quad
+        /// width of the same frame so the per-frame wobble stays 1:1.
+        /// </summary>
+        /// <param name="large">Whether this is the large (type 2) bouncer.</param>
+        /// <param name="frameIndex">Current animation frame relative to the bouncer's first quad.</param>
+        /// <param name="objectWidth">Live object width (desktop value).</param>
+        public static float BouncerCollisionWidth(bool large, int frameIndex, float objectWidth)
+        {
+            if (!UseMobilePhysicsModel)
+            {
+                return objectWidth;
+            }
+            float[] table = large ? MobilePhysicsConstants.BouncerLargeQuadWidths : MobilePhysicsConstants.BouncerSmallQuadWidths;
+            int index = System.Math.Clamp(frameIndex, 0, table.Length - 1);
+            return ToWorld(table[index]);
+        }
+
+        /// <summary>
         /// Number of sample points drawn for each bungee segment.
         /// </summary>
         public static int BungeeDrawSamplePoints => SelectRaw(PhysicsConstants.BungeeDrawSamplePoints, MobilePhysicsConstants.BungeeDrawSamplePoints);

--- a/CutTheRopeDX/Framework/ActivePhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/ActivePhysicsConstants.cs
@@ -310,6 +310,26 @@ namespace CutTheRopeDX.Framework
         public static float SteamTubeOppositeGravityDivisor => SelectRaw(PhysicsConstants.SteamTubeOppositeGravityDivisor, MobilePhysicsConstants.SteamTubeOppositeGravityDivisor);
 
         /// <summary>
+        /// Exponent (per world unit) of the steam force falloff beyond the column top.
+        /// </summary>
+        public static float SteamTubeFalloffExponent => SelectRaw(PhysicsConstants.SteamTubeFalloffExponent, MobilePhysicsConstants.SteamTubeFalloffExponent);
+
+        /// <summary>
+        /// Horizontal velocity below which the steam column cancels velocity outright.
+        /// </summary>
+        public static float SteamTubeVelocityDeadzone => SelectScaled(PhysicsConstants.SteamTubeVelocityDeadzone, MobilePhysicsConstants.SteamTubeVelocityDeadzone);
+
+        /// <summary>
+        /// Distance from a lantern at which it captures the candy.
+        /// </summary>
+        public static float LanternCaptureRadius => SelectScaled(PhysicsConstants.LanternCaptureRadius, MobilePhysicsConstants.LanternCaptureRadius);
+
+        /// <summary>
+        /// Length of the pump's air flow column.
+        /// </summary>
+        public static float PumpFlowLength => SelectScaled(PhysicsConstants.PumpFlowLength, MobilePhysicsConstants.PumpFlowLength);
+
+        /// <summary>
         /// Spider's traversal speed.
         /// </summary>
         public static float SpiderTraversalSpeed => SelectRaw(PhysicsConstants.SpiderTraversalSpeed, MobilePhysicsConstants.SpiderTraversalSpeed);

--- a/CutTheRopeDX/Framework/ActivePhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/ActivePhysicsConstants.cs
@@ -305,6 +305,11 @@ namespace CutTheRopeDX.Framework
         public static float SpiderTraversalSpeed => SelectRaw(PhysicsConstants.SpiderTraversalSpeed, MobilePhysicsConstants.SpiderTraversalSpeed);
 
         /// <summary>
+        /// Distance from Om Nom at which the candy makes him open his mouth.
+        /// </summary>
+        public static float MouthOpenDistance => SelectScaled(PhysicsConstants.MouthOpenDistance, MobilePhysicsConstants.MouthOpenDistance);
+
+        /// <summary>
         /// Half-height of the spikes collision band around the spike line.
         /// </summary>
         public static float SpikesCollisionBandHalfHeight => SelectScaled(PhysicsConstants.SpikesCollisionBandHalfHeight, MobilePhysicsConstants.SpikesCollisionBandHalfHeight);

--- a/CutTheRopeDX/Framework/ActivePhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/ActivePhysicsConstants.cs
@@ -350,51 +350,46 @@ namespace CutTheRopeDX.Framework
         public static float ElectroSpikesWidthReduction => SelectScaled(PhysicsConstants.ElectroSpikesWidthReduction, MobilePhysicsConstants.ElectroSpikesWidthReduction);
 
         /// <summary>
-        /// Full collision line width for a non-electro spike. Desktop reads the live texture
-        /// quad; mobile substitutes the WP7 base-asset quad width because the desktop art is
-        /// trimmed differently.
+        /// Full collision line width for a non-electro spike, table-driven from the original
+        /// XML quad. Never read from
+        /// the live texture: the JSON atlas trim differs from both originals, so atlas-derived
+        /// widths silently change collision whenever art is re-packed.
         /// </summary>
         /// <param name="rotatable">Whether the spike belongs to a rotate-toggle group.</param>
         /// <param name="widthIndex">Spike width/type index (1-4).</param>
-        /// <param name="textureQuadWidth">Live texture quad width (desktop value).</param>
-        public static float SpikesCollisionLineWidth(bool rotatable, int widthIndex, float textureQuadWidth)
+        public static float SpikesCollisionLineWidth(bool rotatable, int widthIndex)
         {
-            if (!UseMobilePhysicsModel)
-            {
-                return textureQuadWidth;
-            }
-            float[] table = rotatable ? MobilePhysicsConstants.RotatableSpikesQuadWidths : MobilePhysicsConstants.SpikesQuadWidths;
+            float[] table = UseMobilePhysicsModel
+                ? rotatable ? MobilePhysicsConstants.RotatableSpikesQuadWidths : MobilePhysicsConstants.SpikesQuadWidths
+                : rotatable ? PhysicsConstants.RotatableSpikesQuadWidths : PhysicsConstants.SpikesQuadWidths;
             int index = System.Math.Clamp(widthIndex - 1, 0, table.Length - 1);
-            return ToWorld(table[index]);
+            return UseMobilePhysicsModel ? ToWorld(table[index]) : table[index];
         }
 
         /// <summary>
         /// Effective electro spike object width the zap length is derived from
         /// (zap = this minus <see cref="ElectroSpikesWidthReduction"/>).
         /// </summary>
-        /// <param name="objectWidth">Live object width (desktop value; the electrodes pre-cut sheet width).</param>
-        public static float ElectroSpikesCollisionObjectWidth(float objectWidth)
+        public static float ElectroSpikesCollisionObjectWidth()
         {
-            return UseMobilePhysicsModel ? ToWorld(MobilePhysicsConstants.ElectroSpikesObjectWidth) : objectWidth;
+            return SelectScaled(PhysicsConstants.ElectroSpikesObjectWidth, MobilePhysicsConstants.ElectroSpikesObjectWidth);
         }
 
         /// <summary>
-        /// Full collision width of a bouncer for the current animation frame. Desktop reads the
-        /// live object width (which follows the draw quad); mobile substitutes the WP7 quad
-        /// width of the same frame so the per-frame wobble stays 1:1.
+        /// Full collision width of a bouncer for the current animation frame, table-driven from
+        /// the original XML quad (see <see cref="SpikesCollisionLineWidth"/>). Both originals let
+        /// the width follow the current draw quad, so the tables are frame-indexed to keep the
+        /// per-frame wobble faithful.
         /// </summary>
         /// <param name="large">Whether this is the large (type 2) bouncer.</param>
         /// <param name="frameIndex">Current animation frame relative to the bouncer's first quad.</param>
-        /// <param name="objectWidth">Live object width (desktop value).</param>
-        public static float BouncerCollisionWidth(bool large, int frameIndex, float objectWidth)
+        public static float BouncerCollisionWidth(bool large, int frameIndex)
         {
-            if (!UseMobilePhysicsModel)
-            {
-                return objectWidth;
-            }
-            float[] table = large ? MobilePhysicsConstants.BouncerLargeQuadWidths : MobilePhysicsConstants.BouncerSmallQuadWidths;
+            float[] table = UseMobilePhysicsModel
+                ? large ? MobilePhysicsConstants.BouncerLargeQuadWidths : MobilePhysicsConstants.BouncerSmallQuadWidths
+                : large ? PhysicsConstants.BouncerLargeQuadWidths : PhysicsConstants.BouncerSmallQuadWidths;
             int index = System.Math.Clamp(frameIndex, 0, table.Length - 1);
-            return ToWorld(table[index]);
+            return UseMobilePhysicsModel ? ToWorld(table[index]) : table[index];
         }
 
         /// <summary>

--- a/CutTheRopeDX/Framework/MobilePhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/MobilePhysicsConstants.cs
@@ -181,7 +181,7 @@ namespace CutTheRopeDX.Framework
 
         /// <summary>
         /// WP7 pre-cut width of obj_electrodes; the electro zap length is this minus
-        /// <see cref="ElectroSpikesWidthReduction"/>. The dx electrodes sheet is 833 wide, not 267x3.
+        /// <see cref="ElectroSpikesWidthReduction"/>. The JSON electrodes sheet is 833 wide, not 267x3.
         /// </summary>
         public const float ElectroSpikesObjectWidth = 267f;
 
@@ -193,6 +193,22 @@ namespace CutTheRopeDX.Framework
 
         /// <inheritdoc cref="ActivePhysicsConstants.BouncerCollisionWidth" />
         public static readonly float[] BouncerLargeQuadWidths = [111f, 116f, 118f, 108f, 106f];
+
+        /// <summary>
+        /// Rocket catch-slat box from the Experiments base assets: quad 10 is 116x58 centered
+        /// at (91,67) on the 199x134 obj_rocket sheet; the engine takes 0.6 x width and
+        /// 0.05 x height of that quad.
+        /// </summary>
+        public const float RocketCatchBoxWidth = 69.6f; // 116 * 0.6
+
+        /// <inheritdoc cref="ActivePhysicsConstants.RocketCatchBoxHeight" />
+        public const float RocketCatchBoxHeight = 2.9f; // 58 * 0.05
+
+        /// <inheritdoc cref="ActivePhysicsConstants.RocketCatchBoxCenterOffsetX" />
+        public const float RocketCatchBoxCenterOffsetX = -8.5f; // 91 - 199/2
+
+        /// <inheritdoc cref="ActivePhysicsConstants.RocketCatchBoxCenterOffsetY" />
+        public const float RocketCatchBoxCenterOffsetY = 0f; // 67 - 134/2
 
         /// <summary>
         /// Maximum rope length used by the mobile bungee renderer.

--- a/CutTheRopeDX/Framework/MobilePhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/MobilePhysicsConstants.cs
@@ -59,6 +59,12 @@ namespace CutTheRopeDX.Framework
         /// <inheritdoc cref="ActivePhysicsConstants.SockSpeedKoeff" />
         public const float SockSpeedKoeff = 0.9f;
 
+        /// <inheritdoc cref="ActivePhysicsConstants.SockCatchHalfSize" />
+        public const float SockCatchHalfSize = 10f;
+
+        /// <inheritdoc cref="ActivePhysicsConstants.SockExitOffsetY" />
+        public const float SockExitOffsetY = -8f;
+
         /// <inheritdoc cref="ActivePhysicsConstants.GrabRopeRollMaxLength" />
         public const float GrabRopeRollMaxLength = 500f;
 

--- a/CutTheRopeDX/Framework/MobilePhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/MobilePhysicsConstants.cs
@@ -65,6 +65,15 @@ namespace CutTheRopeDX.Framework
         /// <inheritdoc cref="ActivePhysicsConstants.GrabWheelRotateDeltaMax" />
         public const float GrabWheelRotateDeltaMax = 2f;
 
+        /// <inheritdoc cref="ActivePhysicsConstants.GrabWheelRotateDeltaMin" />
+        public const float GrabWheelRotateDeltaMin = 1f;
+
+        /// <inheritdoc cref="ActivePhysicsConstants.RocketReelSpeed" />
+        public const float RocketReelSpeed = 200f;
+
+        /// <inheritdoc cref="ActivePhysicsConstants.CandyPartsMergeSpeed" />
+        public const float CandyPartsMergeSpeed = 200f;
+
         /// <inheritdoc cref="ActivePhysicsConstants.WaterSurfaceDetectionHeight" />
         public const float WaterSurfaceDetectionHeight = 2f;
 

--- a/CutTheRopeDX/Framework/MobilePhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/MobilePhysicsConstants.cs
@@ -186,13 +186,13 @@ namespace CutTheRopeDX.Framework
         public const float ElectroSpikesObjectWidth = 267f;
 
         /// <summary>
-        /// WP7 first-quad width of the small bouncer (obj_bouncer_01, quad 0).
+        /// WP7 first-quad width of the small bouncer (obj_bouncer_01, quad 0), subtract 20.
         /// </summary>
-        public const float BouncerSmallCollisionWidth = 66f;
+        public const float BouncerSmallCollisionWidth = 46f;
 
         /// <inheritdoc cref="ActivePhysicsConstants.BouncerCollisionWidth" />
-        /// <remarks>obj_bouncer_02 quad 0</remarks>
-        public const float BouncerLargeCollisionWidth = 111f;
+        /// <remarks>obj_bouncer_02 quad 0, subtract 20</remarks>
+        public const float BouncerLargeCollisionWidth = 91f;
 
         /// <summary>
         /// Rocket catch-slat box from the Experiments base assets: quad 10 is 116x58 centered

--- a/CutTheRopeDX/Framework/MobilePhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/MobilePhysicsConstants.cs
@@ -143,6 +143,9 @@ namespace CutTheRopeDX.Framework
         /// <inheritdoc cref="ActivePhysicsConstants.SpiderTraversalSpeed" />
         public const float SpiderTraversalSpeed = 135f; // 45 * 3
 
+        /// <inheritdoc cref="ActivePhysicsConstants.MouthOpenDistance" />
+        public const float MouthOpenDistance = 100f;
+
         /// <inheritdoc cref="ActivePhysicsConstants.SpikesCollisionBandHalfHeight" />
         public const float SpikesCollisionBandHalfHeight = 5f;
 

--- a/CutTheRopeDX/Framework/MobilePhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/MobilePhysicsConstants.cs
@@ -143,6 +143,12 @@ namespace CutTheRopeDX.Framework
         /// <inheritdoc cref="ActivePhysicsConstants.SpiderTraversalSpeed" />
         public const float SpiderTraversalSpeed = 135f; // 45 * 3
 
+        /// <inheritdoc cref="ActivePhysicsConstants.SpikesCollisionBandHalfHeight" />
+        public const float SpikesCollisionBandHalfHeight = 5f;
+
+        /// <inheritdoc cref="ActivePhysicsConstants.ElectroSpikesWidthReduction" />
+        public const float ElectroSpikesWidthReduction = 130f;
+
         /// <summary>
         /// Maximum rope length used by the mobile bungee renderer.
         /// </summary>

--- a/CutTheRopeDX/Framework/MobilePhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/MobilePhysicsConstants.cs
@@ -171,6 +171,30 @@ namespace CutTheRopeDX.Framework
         public const float ElectroSpikesWidthReduction = 130f;
 
         /// <summary>
+        /// WP7 base-asset quad widths for static spikes 1-4 (obj_spikes_01..04). The desktop
+        /// atlas is trimmed differently (214/335/455/568 at 3x), so mobile physics reads these.
+        /// </summary>
+        public static readonly float[] SpikesQuadWidths = [68f, 106f, 146f, 181f];
+
+        /// <inheritdoc cref="ActivePhysicsConstants.SpikesCollisionLineWidth" />
+        public static readonly float[] RotatableSpikesQuadWidths = [68f, 118f, 142f, 178f];
+
+        /// <summary>
+        /// WP7 pre-cut width of obj_electrodes; the electro zap length is this minus
+        /// <see cref="ElectroSpikesWidthReduction"/>. The dx electrodes sheet is 833 wide, not 267x3.
+        /// </summary>
+        public const float ElectroSpikesObjectWidth = 267f;
+
+        /// <summary>
+        /// WP7 quad widths of the small bouncer's animation frames (obj_bouncer_01, quads 0-4).
+        /// The collision width follows the current frame while the bounce animation plays.
+        /// </summary>
+        public static readonly float[] BouncerSmallQuadWidths = [66f, 68f, 70f, 66f, 66f];
+
+        /// <inheritdoc cref="ActivePhysicsConstants.BouncerCollisionWidth" />
+        public static readonly float[] BouncerLargeQuadWidths = [111f, 116f, 118f, 108f, 106f];
+
+        /// <summary>
         /// Maximum rope length used by the mobile bungee renderer.
         /// </summary>
         public const float MaxRopeLength = 600f; // 20 segments * 30 rest length

--- a/CutTheRopeDX/Framework/MobilePhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/MobilePhysicsConstants.cs
@@ -186,13 +186,13 @@ namespace CutTheRopeDX.Framework
         public const float ElectroSpikesObjectWidth = 267f;
 
         /// <summary>
-        /// WP7 quad widths of the small bouncer's animation frames (obj_bouncer_01, quads 0-4).
-        /// The collision width follows the current frame while the bounce animation plays.
+        /// WP7 first-quad width of the small bouncer (obj_bouncer_01, quad 0).
         /// </summary>
-        public static readonly float[] BouncerSmallQuadWidths = [66f, 68f, 70f, 66f, 66f];
+        public const float BouncerSmallCollisionWidth = 66f;
 
         /// <inheritdoc cref="ActivePhysicsConstants.BouncerCollisionWidth" />
-        public static readonly float[] BouncerLargeQuadWidths = [111f, 116f, 118f, 108f, 106f];
+        /// <remarks>obj_bouncer_02 quad 0</remarks>
+        public const float BouncerLargeCollisionWidth = 111f;
 
         /// <summary>
         /// Rocket catch-slat box from the Experiments base assets: quad 10 is 116x58 centered

--- a/CutTheRopeDX/Framework/MobilePhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/MobilePhysicsConstants.cs
@@ -146,6 +146,18 @@ namespace CutTheRopeDX.Framework
         /// <inheritdoc cref="ActivePhysicsConstants.SteamTubeOppositeGravityDivisor" />
         public const float SteamTubeOppositeGravityDivisor = 2f;
 
+        /// <inheritdoc cref="ActivePhysicsConstants.SteamTubeFalloffExponent" />
+        public const float SteamTubeFalloffExponent = -2f / 3f; // WP7 -2 per mobile unit
+
+        /// <inheritdoc cref="ActivePhysicsConstants.SteamTubeVelocityDeadzone" />
+        public const float SteamTubeVelocityDeadzone = 1f;
+
+        /// <inheritdoc cref="ActivePhysicsConstants.LanternCaptureRadius" />
+        public const float LanternCaptureRadius = 32f;
+
+        /// <inheritdoc cref="ActivePhysicsConstants.PumpFlowLength" />
+        public const float PumpFlowLength = 200f;
+
         /// <inheritdoc cref="ActivePhysicsConstants.SpiderTraversalSpeed" />
         public const float SpiderTraversalSpeed = 135f; // 45 * 3
 

--- a/CutTheRopeDX/Framework/PhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/PhysicsConstants.cs
@@ -59,6 +59,12 @@ namespace CutTheRopeDX.Framework
         /// <inheritdoc cref="ActivePhysicsConstants.SockSpeedKoeff" />
         public const float SockSpeedKoeff = 0.9f;
 
+        /// <inheritdoc cref="ActivePhysicsConstants.SockCatchHalfSize" />
+        public const float SockCatchHalfSize = 20f;
+
+        /// <inheritdoc cref="ActivePhysicsConstants.SockExitOffsetY" />
+        public const float SockExitOffsetY = -16f;
+
         /// <inheritdoc cref="ActivePhysicsConstants.GrabRopeRollMaxLength" />
         public const float GrabRopeRollMaxLength = 1650f;
 

--- a/CutTheRopeDX/Framework/PhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/PhysicsConstants.cs
@@ -171,6 +171,30 @@ namespace CutTheRopeDX.Framework
         public const float ElectroSpikesWidthReduction = 400f;
 
         /// <summary>
+        /// Original XML quad widths for static spikes 1-4 (obj_spikes_01..04). The JSON atlas is
+        /// re-trimmed (+2 px per frame), so collision reads these instead of the live texture.
+        /// </summary>
+        public static readonly float[] SpikesQuadWidths = [212f, 333f, 453f, 566f];
+
+        /// <inheritdoc cref="ActivePhysicsConstants.SpikesCollisionLineWidth" />
+        public static readonly float[] RotatableSpikesQuadWidths = [202f, 319f, 444f, 559f];
+
+        /// <summary>
+        /// Original XML pre-cut width of obj_electrodes; the electro zap length is this minus
+        /// <see cref="ElectroSpikesWidthReduction"/>.
+        /// </summary>
+        public const float ElectroSpikesObjectWidth = 833f;
+
+        /// <summary>
+        /// Original XML quad widths of the small bouncer's animation frames (obj_bouncer_01, quads 0-4).
+        /// The collision width follows the current frame while the bounce animation plays.
+        /// </summary>
+        public static readonly float[] BouncerSmallQuadWidths = [194f, 201f, 204f, 193f, 194f];
+
+        /// <inheritdoc cref="ActivePhysicsConstants.BouncerCollisionWidth" />
+        public static readonly float[] BouncerLargeQuadWidths = [302f, 319f, 322f, 292f, 302f];
+
+        /// <summary>
         /// Maximum rope length used to size rope drawing buffers.
         /// </summary>
         public const float MaxRopeLength = 2000f;

--- a/CutTheRopeDX/Framework/PhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/PhysicsConstants.cs
@@ -186,13 +186,13 @@ namespace CutTheRopeDX.Framework
         public const float ElectroSpikesObjectWidth = 833f;
 
         /// <summary>
-        /// Original XML quad widths of the small bouncer's animation frames (obj_bouncer_01, quads 0-4).
-        /// The collision width follows the current frame while the bounce animation plays.
+        /// Original XML first-quad width of the small bouncer (obj_bouncer_01, quad 0).
         /// </summary>
-        public static readonly float[] BouncerSmallQuadWidths = [194f, 201f, 204f, 193f, 194f];
+        public const float BouncerSmallCollisionWidth = 194f;
 
         /// <inheritdoc cref="ActivePhysicsConstants.BouncerCollisionWidth" />
-        public static readonly float[] BouncerLargeQuadWidths = [302f, 319f, 322f, 292f, 302f];
+        /// <remarks>obj_bouncer_02 quad 0.</remarks>
+        public const float BouncerLargeCollisionWidth = 302f;
 
         /// <summary>
         /// Rocket catch-slat box frozen from the JSON atlas: quad 10 is 358x179 centered at

--- a/CutTheRopeDX/Framework/PhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/PhysicsConstants.cs
@@ -143,6 +143,12 @@ namespace CutTheRopeDX.Framework
         /// <inheritdoc cref="ActivePhysicsConstants.SpiderTraversalSpeed" />
         public const float SpiderTraversalSpeed = 117f;
 
+        /// <inheritdoc cref="ActivePhysicsConstants.SpikesCollisionBandHalfHeight" />
+        public const float SpikesCollisionBandHalfHeight = 5f;
+
+        /// <inheritdoc cref="ActivePhysicsConstants.ElectroSpikesWidthReduction" />
+        public const float ElectroSpikesWidthReduction = 400f;
+
         /// <summary>
         /// Maximum rope length used to size rope drawing buffers.
         /// </summary>

--- a/CutTheRopeDX/Framework/PhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/PhysicsConstants.cs
@@ -143,6 +143,9 @@ namespace CutTheRopeDX.Framework
         /// <inheritdoc cref="ActivePhysicsConstants.SpiderTraversalSpeed" />
         public const float SpiderTraversalSpeed = 117f;
 
+        /// <inheritdoc cref="ActivePhysicsConstants.MouthOpenDistance" />
+        public const float MouthOpenDistance = 200f;
+
         /// <inheritdoc cref="ActivePhysicsConstants.SpikesCollisionBandHalfHeight" />
         public const float SpikesCollisionBandHalfHeight = 5f;
 

--- a/CutTheRopeDX/Framework/PhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/PhysicsConstants.cs
@@ -195,6 +195,22 @@ namespace CutTheRopeDX.Framework
         public static readonly float[] BouncerLargeQuadWidths = [302f, 319f, 322f, 292f, 302f];
 
         /// <summary>
+        /// Rocket catch-slat box frozen from the JSON atlas: quad 10 is 358x179 centered at
+        /// (288, 208.5) on the 619x418 obj_rocket sheet; the engine takes 0.6 x width and
+        /// 0.05 x height of that quad.
+        /// </summary>
+        public const float RocketCatchBoxWidth = 214.8f; // 358 * 0.6
+
+        /// <inheritdoc cref="ActivePhysicsConstants.RocketCatchBoxHeight" />
+        public const float RocketCatchBoxHeight = 8.95f; // 179 * 0.05
+
+        /// <inheritdoc cref="ActivePhysicsConstants.RocketCatchBoxCenterOffsetX" />
+        public const float RocketCatchBoxCenterOffsetX = -21.5f; // 288 - 619/2
+
+        /// <inheritdoc cref="ActivePhysicsConstants.RocketCatchBoxCenterOffsetY" />
+        public const float RocketCatchBoxCenterOffsetY = -0.5f; // 208.5 - 418/2
+
+        /// <summary>
         /// Maximum rope length used to size rope drawing buffers.
         /// </summary>
         public const float MaxRopeLength = 2000f;

--- a/CutTheRopeDX/Framework/PhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/PhysicsConstants.cs
@@ -65,6 +65,15 @@ namespace CutTheRopeDX.Framework
         /// <inheritdoc cref="ActivePhysicsConstants.GrabWheelRotateDeltaMax" />
         public const float GrabWheelRotateDeltaMax = 4.5f;
 
+        /// <inheritdoc cref="ActivePhysicsConstants.GrabWheelRotateDeltaMin" />
+        public const float GrabWheelRotateDeltaMin = 1f;
+
+        /// <inheritdoc cref="ActivePhysicsConstants.RocketReelSpeed" />
+        public const float RocketReelSpeed = 200f;
+
+        /// <inheritdoc cref="ActivePhysicsConstants.CandyPartsMergeSpeed" />
+        public const float CandyPartsMergeSpeed = 200f;
+
         /// <inheritdoc cref="ActivePhysicsConstants.WaterSurfaceDetectionHeight" />
         public const float WaterSurfaceDetectionHeight = 2f;
 

--- a/CutTheRopeDX/Framework/PhysicsConstants.cs
+++ b/CutTheRopeDX/Framework/PhysicsConstants.cs
@@ -146,6 +146,18 @@ namespace CutTheRopeDX.Framework
         /// <inheritdoc cref="ActivePhysicsConstants.SteamTubeOppositeGravityDivisor" />
         public const float SteamTubeOppositeGravityDivisor = 2f;
 
+        /// <inheritdoc cref="ActivePhysicsConstants.SteamTubeFalloffExponent" />
+        public const float SteamTubeFalloffExponent = -2f;
+
+        /// <inheritdoc cref="ActivePhysicsConstants.SteamTubeVelocityDeadzone" />
+        public const float SteamTubeVelocityDeadzone = 1f;
+
+        /// <inheritdoc cref="ActivePhysicsConstants.LanternCaptureRadius" />
+        public const float LanternCaptureRadius = 82f;
+
+        /// <inheritdoc cref="ActivePhysicsConstants.PumpFlowLength" />
+        public const float PumpFlowLength = 624f;
+
         /// <inheritdoc cref="ActivePhysicsConstants.SpiderTraversalSpeed" />
         public const float SpiderTraversalSpeed = 117f;
 

--- a/CutTheRopeDX/Framework/Visual/DrawHelper.cs
+++ b/CutTheRopeDX/Framework/Visual/DrawHelper.cs
@@ -509,15 +509,17 @@ namespace CutTheRopeDX.Framework.Visual
         /// <param name="color">Outline color.</param>
         public static void DrawRect(float x, float y, float w, float h, RGBAColor color)
         {
+            // Perimeter winding (TL, TR, BR, BL) so the closed line strip traces the rectangle
+            // edges. Triangle-strip order (TL, TR, BL, BR) would cross the diagonals into a bowtie.
             DrawPolygon(
             [
                 x,
                 y,
                 x + w,
                 y,
-                x,
-                y + h,
                 x + w,
+                y + h,
+                x,
                 y + h
             ], 4, color);
         }

--- a/CutTheRopeDX/GameMain/Bouncer.cs
+++ b/CutTheRopeDX/GameMain/Bouncer.cs
@@ -33,6 +33,8 @@ namespace CutTheRopeDX.GameMain
             {
                 return null;
             }
+            isLarge = w == LargeBouncerWidth;
+            firstQuadIndex = firstQuad;
             SetDrawQuad(firstQuad);
             rotation = an;
             x = px;
@@ -65,8 +67,9 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         public void UpdateRotation()
         {
-            t1.X = x - (width / 2);
-            t2.X = x + (width / 2);
+            float collisionWidth = ActivePhysicsConstants.BouncerCollisionWidth(isLarge, quadToDraw - firstQuadIndex, width);
+            t1.X = x - (collisionWidth / 2f);
+            t2.X = x + (collisionWidth / 2f);
             t1.Y = t2.Y = y - ActivePhysicsConstants.BouncerHeight;
             b1.X = t1.X;
             b2.X = t2.X;
@@ -172,6 +175,12 @@ namespace CutTheRopeDX.GameMain
         public bool IsDrawnByTransporter { get; set; }
 
         /// <summary>Width class value for the small bouncer variant.</summary>
+        /// <summary>Whether this is the large (type 2) bouncer; selects the WP7 collision width table.</summary>
+        private bool isLarge;
+
+        /// <summary>First atlas quad of this bouncer's animation, for frame-relative width lookup.</summary>
+        private int firstQuadIndex;
+
         private const int SmallBouncerWidth = 1;
 
         /// <summary>Width class value for the large bouncer variant.</summary>

--- a/CutTheRopeDX/GameMain/Bouncer.cs
+++ b/CutTheRopeDX/GameMain/Bouncer.cs
@@ -34,7 +34,6 @@ namespace CutTheRopeDX.GameMain
                 return null;
             }
             isLarge = w == LargeBouncerWidth;
-            firstQuadIndex = firstQuad;
             SetDrawQuad(firstQuad);
             rotation = an;
             x = px;
@@ -67,7 +66,7 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         public void UpdateRotation()
         {
-            float collisionWidth = ActivePhysicsConstants.BouncerCollisionWidth(isLarge, quadToDraw - firstQuadIndex);
+            float collisionWidth = ActivePhysicsConstants.BouncerCollisionWidth(isLarge);
             t1.X = x - (collisionWidth / 2f);
             t2.X = x + (collisionWidth / 2f);
             t1.Y = t2.Y = y - ActivePhysicsConstants.BouncerHeight;
@@ -175,11 +174,8 @@ namespace CutTheRopeDX.GameMain
         public bool IsDrawnByTransporter { get; set; }
 
         /// <summary>Width class value for the small bouncer variant.</summary>
-        /// <summary>Whether this is the large (type 2) bouncer; selects the WP7 collision width table.</summary>
+        /// <summary>Whether this is the large (type 2) bouncer; selects the collision width constant.</summary>
         private bool isLarge;
-
-        /// <summary>First atlas quad of this bouncer's animation, for frame-relative width lookup.</summary>
-        private int firstQuadIndex;
 
         private const int SmallBouncerWidth = 1;
 

--- a/CutTheRopeDX/GameMain/Bouncer.cs
+++ b/CutTheRopeDX/GameMain/Bouncer.cs
@@ -67,7 +67,7 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         public void UpdateRotation()
         {
-            float collisionWidth = ActivePhysicsConstants.BouncerCollisionWidth(isLarge, quadToDraw - firstQuadIndex, width);
+            float collisionWidth = ActivePhysicsConstants.BouncerCollisionWidth(isLarge, quadToDraw - firstQuadIndex);
             t1.X = x - (collisionWidth / 2f);
             t2.X = x + (collisionWidth / 2f);
             t1.Y = t2.Y = y - ActivePhysicsConstants.BouncerHeight;

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -132,7 +132,7 @@ namespace CutTheRopeDX.GameMain
             {
                 ctx.targetSock.light.PlayTimeline(0);
                 ctx.targetSock.light.visible = true;
-                Vector v = Vect(0f, -16f);
+                Vector v = Vect(0f, ActivePhysicsConstants.SockExitOffsetY);
                 v = VectRotate(v, DEGREES_TO_RADIANS(ctx.targetSock.rotation));
                 ctx.point.pos.X = ctx.targetSock.x;
                 ctx.point.pos.Y = ctx.targetSock.y;

--- a/CutTheRopeDX/GameMain/GameScene.Systems.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Systems.cs
@@ -18,7 +18,7 @@ namespace CutTheRopeDX.GameMain
         /// <param name="c">Game object tested against the pump flow area.</param>
         public static void HandlePumpFlowPtSkin(Pump p, ConstraintedPoint s, GameObject c)
         {
-            float flowLength = Pump.FlowLength;
+            float flowLength = ActivePhysicsConstants.PumpFlowLength;
             if (GameObject.RectInObject(p.x - flowLength, p.y - flowLength, p.x + flowLength, p.y + flowLength, c))
             {
                 Vector v = Vect(c.x, c.y);
@@ -31,8 +31,11 @@ namespace CutTheRopeDX.GameMain
                 {
                     v = VectRotateAround(v, 0 - p.angle, p.x, p.y);
                 }
-                // Use pump's bbox dimensions for all objects (not the object's bbox)
-                if (v.Y < vector.Y && RectInRect(v.X - (p.bb.w / 2), v.Y - (p.bb.h / 2), v.X + (p.bb.w / 2), v.Y + (p.bb.h / 2), vector.X, vector.Y - flowLength, vector2.X, vector2.Y))
+                // Desktop keeps the pump's bbox dimensions for all objects; mobile matches the
+                // reference, which tests the target object's own bbox against the flow column.
+                float flowBoxW = ActivePhysicsConstants.UseMobilePhysicsModel ? c.bb.w : p.bb.w;
+                float flowBoxH = ActivePhysicsConstants.UseMobilePhysicsModel ? c.bb.h : p.bb.h;
+                if (v.Y < vector.Y && RectInRect(v.X - (flowBoxW / 2), v.Y - (flowBoxH / 2), v.X + (flowBoxW / 2), v.Y + (flowBoxH / 2), vector.X, vector.Y - flowLength, vector2.X, vector2.Y))
                 {
                     float verticalImpulse = flowLength * 2f * (flowLength - (vector.Y - v.Y)) / flowLength;
                     Vector v2 = Vect(0f, 0f - verticalImpulse);
@@ -125,7 +128,7 @@ namespace CutTheRopeDX.GameMain
                         float deltaX = tube.x - position.X;
                         horizontalImpulse = ABS(deltaX) > tubeWidth / 4f
                             ? ((0f - velocity.X) / damping) + (0.25f * deltaX)
-                            : ABS(velocity.X) < 1f ? 0f - velocity.X : (0f - velocity.X) / damping;
+                            : ABS(velocity.X) < ActivePhysicsConstants.SteamTubeVelocityDeadzone ? 0f - velocity.X : (0f - velocity.X) / damping;
                     }
 
                     // Windows Phone force, mapped to world scale (tubeScale is world/Windows Phone transform).
@@ -178,7 +181,7 @@ namespace CutTheRopeDX.GameMain
                 float distanceBelowValve = tube.y - position.Y;
                 if (distanceBelowValve > currentHeight + collisionRadius)
                 {
-                    float attenuation = MathF.Exp(-2f * (distanceBelowValve - (currentHeight + collisionRadius)));
+                    float attenuation = MathF.Exp(ActivePhysicsConstants.SteamTubeFalloffExponent * (distanceBelowValve - (currentHeight + collisionRadius)));
                     impulse = VectMult(impulse, attenuation);
                 }
                 impulse = VectRotate(impulse, angle);
@@ -219,7 +222,7 @@ namespace CutTheRopeDX.GameMain
             p.PlayTimeline(0);
             CTRSoundMgr.PlayRandomSound(Resources.Snd.Pump1, Resources.Snd.Pump2, Resources.Snd.Pump3, Resources.Snd.Pump4);
             Image grid = Image.Image_createWithResID(Resources.Img.ObjPump);
-            float flowLength = MathF.Max(0f, Pump.FlowLength - Pump.MouthOffset);
+            float flowLength = MathF.Max(0f, ActivePhysicsConstants.PumpFlowLength - Pump.MouthOffset);
             PumpDirt pumpDirt = new PumpDirt().InitWithTotalParticlesAngleandImageGrid(5, RADIANS_TO_DEGREES(p.angle) - DEG_90, grid, flowLength);
             pumpDirt.particlesDelegate = new Particles.ParticlesFinished(aniPool.ParticlesFinished);
             Vector v = Vect(p.x + Pump.MouthOffset, p.y);

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -528,7 +528,7 @@ namespace CutTheRopeDX.GameMain
                         partsDist = 0f;
                         twoParts = 0;
                     }
-                    else if (Mover.MoveVariableToTarget(ref partsDist, 0, 200, delta))
+                    else if (Mover.MoveVariableToTarget(ref partsDist, 0, ActivePhysicsConstants.CandyPartsMergeSpeed, delta))
                     {
                         CTRSoundMgr.PlaySound(Resources.Snd.CandyLink);
                         twoParts = 2;
@@ -1291,7 +1291,7 @@ namespace CutTheRopeDX.GameMain
                     }
                     if (rocket.state == Rocket.STATE_ROCKET_DIST)
                     {
-                        if (handHoldingCandy || Mover.MoveVariableToTarget(ref dist, 0f, 200f, delta))
+                        if (handHoldingCandy || Mover.MoveVariableToTarget(ref dist, 0f, ActivePhysicsConstants.RocketReelSpeed, delta))
                         {
                             rocket.state = Rocket.STATE_ROCKET_FLY;
                         }

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1125,7 +1125,7 @@ namespace CutTheRopeDX.GameMain
                     candies[ci].carriedByMouse = carried != null && candies[ci].point == carried;
                 }
             }
-            float collisionHalfSize = RTPD(20);
+            float collisionHalfSize = ActivePhysicsConstants.SockCatchHalfSize;
             foreach (object obj11 in socks)
             {
                 Sock sock3 = (Sock)obj11;

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1720,7 +1720,7 @@ namespace CutTheRopeDX.GameMain
 
                 if (!t.mouthOpen && canInteractWithTarget)
                 {
-                    if (CandyDecisions.ShouldOpenMouth(targetPos, candyViews, 200f))
+                    if (CandyDecisions.ShouldOpenMouth(targetPos, candyViews, ActivePhysicsConstants.MouthOpenDistance))
                     {
                         t.mouthOpen = true;
                         t.controller?.PlayMouthOpening();
@@ -1735,7 +1735,7 @@ namespace CutTheRopeDX.GameMain
                     t.mouthCloseTimer = timer;
                     if (t.mouthCloseTimer <= 0)
                     {
-                        if (!CandyDecisions.ShouldOpenMouth(targetPos, candyViews, 200f))
+                        if (!CandyDecisions.ShouldOpenMouth(targetPos, candyViews, ActivePhysicsConstants.MouthOpenDistance))
                         {
                             t.mouthOpen = false;
                             t.controller?.PlayMouthClosing();

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1009,7 +1009,7 @@ namespace CutTheRopeDX.GameMain
                     {
                         continue;
                     }
-                    bool inRange = VectDistance(ctx.point.pos, Vect(lantern.x, lantern.y)) < 82f;
+                    bool inRange = VectDistance(ctx.point.pos, Vect(lantern.x, lantern.y)) < ActivePhysicsConstants.LanternCaptureRadius;
                     if (!LanternCapture.ShouldCapture(lanternInactive, groupOccupied, !ctx.noCandy, ctx.inLantern, inRange))
                     {
                         continue;

--- a/CutTheRopeDX/GameMain/GameScene.cs
+++ b/CutTheRopeDX/GameMain/GameScene.cs
@@ -53,7 +53,11 @@ namespace CutTheRopeDX.GameMain
         /// <returns><see langword="true"/> when the point is beyond the allowed bounds; otherwise, <see langword="false"/>.</returns>
         public bool PointOutOfScreen(ConstraintedPoint p)
         {
-            return p.pos.Y > mapHeight + 400f || p.pos.Y < -400f
+            // Mobile matches the WP7 kill bounds (+100/-50, scaled x3); the horizontal
+            // margin stays as a safety net in both modes (the reference kills on Y only).
+            float bottomMargin = ActivePhysicsConstants.UseMobilePhysicsModel ? 300f : 400f;
+            float topMargin = ActivePhysicsConstants.UseMobilePhysicsModel ? 150f : 400f;
+            return p.pos.Y > mapHeight + bottomMargin || p.pos.Y < -topMargin
                 || p.pos.X < -SCREEN_WIDTH || p.pos.X > mapWidth + SCREEN_WIDTH;
         }
 

--- a/CutTheRopeDX/GameMain/Grab.cs
+++ b/CutTheRopeDX/GameMain/Grab.cs
@@ -108,7 +108,8 @@ namespace CutTheRopeDX.GameMain
             wheelImage3.rotation += rotateDelta;
             wheelHighlight.rotation += rotateDelta;
             float maxWheelDelta = ActivePhysicsConstants.GrabWheelRotateDeltaMax;
-            rotateDelta = rotateDelta > 0f ? MIN(MAX(1, rotateDelta), maxWheelDelta) : MAX(MIN(-1, rotateDelta), 0f - maxWheelDelta);
+            float minWheelDelta = ActivePhysicsConstants.GrabWheelRotateDeltaMin;
+            rotateDelta = rotateDelta > 0f ? MIN(MAX(minWheelDelta, rotateDelta), maxWheelDelta) : MAX(MIN(0f - minWheelDelta, rotateDelta), 0f - maxWheelDelta);
             float ropeLength = 0f;
             if (rope != null)
             {

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadRockets.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadRockets.cs
@@ -1,6 +1,6 @@
 using System.Xml.Linq;
 
-using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.Framework;
 using CutTheRopeDX.Framework.Visual;
 
 using static CutTheRopeDX.Helpers.ParsingHelpers;
@@ -25,11 +25,13 @@ namespace CutTheRopeDX.GameMain
             rocket.DoRestoreCutTransparency();
             rocket.delegateRocketDelegate = this;
 
-            Vector quadCenter = Image.GetQuadCenter(Resources.Img.ObjRocket, 10);
-            Vector quadSize = Image.GetQuadSize(Resources.Img.ObjRocket, 10);
-            quadSize.X *= 0.6f;
-            quadSize.Y *= 0.05f;
-            rocket.bb = MakeRectangle(quadCenter.X - (quadSize.X / 2f), quadCenter.Y - (quadSize.Y / 2f), quadSize.X, quadSize.Y);
+            // Catch-slat bb (0.6 x quad width, 0.05 x quad height of the rocket body quad),
+            // pinned from original XML quad data and center-relative so atlas repacks can't move it.
+            float catchWidth = ActivePhysicsConstants.RocketCatchBoxWidth;
+            float catchHeight = ActivePhysicsConstants.RocketCatchBoxHeight;
+            float catchCenterX = (rocket.width / 2f) + ActivePhysicsConstants.RocketCatchBoxCenterOffsetX;
+            float catchCenterY = (rocket.height / 2f) + ActivePhysicsConstants.RocketCatchBoxCenterOffsetY;
+            rocket.bb = MakeRectangle(catchCenterX - (catchWidth / 2f), catchCenterY - (catchHeight / 2f), catchWidth, catchHeight);
 
             rocket.x = (ParseCoordinateIntOrZero(xmlNode.Attribute("x")?.Value) * scale) + offsetX + mapOffsetX;
             rocket.y = (ParseCoordinateIntOrZero(xmlNode.Attribute("y")?.Value) * scale) + offsetY + mapOffsetY;

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadTarget.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadTarget.cs
@@ -1,5 +1,6 @@
 using System.Xml.Linq;
 
+using CutTheRopeDX.Framework;
 using CutTheRopeDX.Framework.Core;
 using CutTheRopeDX.Framework.Helpers;
 using CutTheRopeDX.Framework.Visual;
@@ -53,9 +54,12 @@ namespace CutTheRopeDX.GameMain
             float transformedY = (sourceY * scale) + offsetY + mapOffsetY;
             targetObj.y = support.y = transformedY;
 
-            // Mouth hitbox: 56 px left of center, 30 px below center.
-            // Derived from classic char_animations (640x640): bb = (264, 350, 108, 2).
-            targetObj.bb = MakeRectangle((targetObj.width >> 1) - 56f, (targetObj.height >> 1) + 30f, 108f, 2f);
+            // Mouth hitbox, center-relative so skins of any size keep the same mouth line.
+            // Desktop: derived from classic char_animations (640x640): bb = (264, 350, 108, 2).
+            // Mobile: WP7 bb (90, 110, 25, 1) scaled x3 onto the same 640x640 sheet = (270, 330, 75, 3).
+            targetObj.bb = ActivePhysicsConstants.UseMobilePhysicsModel
+                ? MakeRectangle((targetObj.width >> 1) - 50f, (targetObj.height >> 1) + 10f, 75f, 3f)
+                : MakeRectangle((targetObj.width >> 1) - 56f, (targetObj.height >> 1) + 30f, 108f, 2f);
 
             controller.Initialize(this);
 

--- a/CutTheRopeDX/GameMain/Pump.cs
+++ b/CutTheRopeDX/GameMain/Pump.cs
@@ -10,11 +10,6 @@ namespace CutTheRopeDX.GameMain
     internal sealed class Pump : GameObject, ITransporterItem, ITransporterBindAware
     {
         /// <summary>
-        /// Length of the pump flow influence area in world units.
-        /// </summary>
-        public const float FlowLength = 624f;
-
-        /// <summary>
         /// Offset from the pump center to the mouth in local X before rotation.
         /// </summary>
         public const float MouthOffset = 80f;

--- a/CutTheRopeDX/GameMain/Sock.cs
+++ b/CutTheRopeDX/GameMain/Sock.cs
@@ -1,3 +1,4 @@
+using CutTheRopeDX.Framework;
 using CutTheRopeDX.Framework.Core;
 using CutTheRopeDX.Framework.Visual;
 
@@ -72,13 +73,28 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         public void UpdateRotation()
         {
-            float sockWidth = 140f;
-            t1.X = x - (sockWidth / 2f) - 20f;
-            t2.X = x + (sockWidth / 2f) - 20f;
+            float mouthHalfWidth;
+            float mouthOffsetX;
+            float mouthDepth;
+            if (ActivePhysicsConstants.UseMobilePhysicsModel)
+            {
+                // WP7 mouth: x +/- 15, y .. y + 1, scaled x3 into world units.
+                mouthHalfWidth = 45f;
+                mouthOffsetX = 0f;
+                mouthDepth = 3f;
+            }
+            else
+            {
+                mouthHalfWidth = 70f;
+                mouthOffsetX = -20f;
+                mouthDepth = 15f;
+            }
+            t1.X = x - mouthHalfWidth + mouthOffsetX;
+            t2.X = x + mouthHalfWidth + mouthOffsetX;
             t1.Y = t2.Y = y;
             b1.X = t1.X;
             b2.X = t2.X;
-            b1.Y = b2.Y = y + 15f;
+            b1.Y = b2.Y = y + mouthDepth;
             angle = DEGREES_TO_RADIANS(rotation);
             t1 = VectRotateAround(t1, angle, x, y);
             t2 = VectRotateAround(t2, angle, x, y);

--- a/CutTheRopeDX/GameMain/Spikes.cs
+++ b/CutTheRopeDX/GameMain/Spikes.cs
@@ -1,5 +1,6 @@
 using System;
 
+using CutTheRopeDX.Framework;
 using CutTheRopeDX.Framework.Core;
 using CutTheRopeDX.Framework.Helpers;
 using CutTheRopeDX.Framework.Visual;
@@ -73,14 +74,15 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         public void UpdateRotation()
         {
-            float halfWidth = !electro ? texture.quadRects[quadToDraw].w : width - RTPD(400);
+            float halfWidth = !electro ? texture.quadRects[quadToDraw].w : width - ActivePhysicsConstants.ElectroSpikesWidthReduction;
             halfWidth /= 2f;
+            float bandHalfHeight = ActivePhysicsConstants.SpikesCollisionBandHalfHeight;
             t1.X = x - halfWidth;
             t2.X = x + halfWidth;
-            t1.Y = t2.Y = y - 5f;
+            t1.Y = t2.Y = y - bandHalfHeight;
             b1.X = t1.X;
             b2.X = t2.X;
-            b1.Y = b2.Y = y + 5f;
+            b1.Y = b2.Y = y + bandHalfHeight;
             angle = DEGREES_TO_RADIANS(rotation);
             t1 = VectRotateAround(t1, angle, x, y);
             t2 = VectRotateAround(t2, angle, x, y);

--- a/CutTheRopeDX/GameMain/Spikes.cs
+++ b/CutTheRopeDX/GameMain/Spikes.cs
@@ -76,8 +76,8 @@ namespace CutTheRopeDX.GameMain
         public void UpdateRotation()
         {
             float halfWidth = !electro
-                ? ActivePhysicsConstants.SpikesCollisionLineWidth(toggled != -1, widthIndex, texture.quadRects[quadToDraw].w)
-                : ActivePhysicsConstants.ElectroSpikesCollisionObjectWidth(width) - ActivePhysicsConstants.ElectroSpikesWidthReduction;
+                ? ActivePhysicsConstants.SpikesCollisionLineWidth(toggled != -1, widthIndex)
+                : ActivePhysicsConstants.ElectroSpikesCollisionObjectWidth() - ActivePhysicsConstants.ElectroSpikesWidthReduction;
             halfWidth /= 2f;
             float bandHalfHeight = ActivePhysicsConstants.SpikesCollisionBandHalfHeight;
             t1.X = x - halfWidth;

--- a/CutTheRopeDX/GameMain/Spikes.cs
+++ b/CutTheRopeDX/GameMain/Spikes.cs
@@ -57,6 +57,7 @@ namespace CutTheRopeDX.GameMain
             origRotation = rotation = an;
             x = px;
             y = py;
+            widthIndex = w;
             SetToggled(t);
             UpdateRotation();
             if (w == ElectrodesWidthIndex)
@@ -74,7 +75,9 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         public void UpdateRotation()
         {
-            float halfWidth = !electro ? texture.quadRects[quadToDraw].w : width - ActivePhysicsConstants.ElectroSpikesWidthReduction;
+            float halfWidth = !electro
+                ? ActivePhysicsConstants.SpikesCollisionLineWidth(toggled != -1, widthIndex, texture.quadRects[quadToDraw].w)
+                : ActivePhysicsConstants.ElectroSpikesCollisionObjectWidth(width) - ActivePhysicsConstants.ElectroSpikesWidthReduction;
             halfWidth /= 2f;
             float bandHalfHeight = ActivePhysicsConstants.SpikesCollisionBandHalfHeight;
             t1.X = x - halfWidth;
@@ -222,6 +225,9 @@ namespace CutTheRopeDX.GameMain
 
         /// <summary>Toggle group id for rotating linked spike sets.</summary>
         private int toggled;
+
+        /// <summary>Spike width/type index (1-4, 5 = electrodes) used to resolve the WP7 collision width.</summary>
+        private int widthIndex;
 
         /// <summary>Current spike angle in radians.</summary>
         public float angle;


### PR DESCRIPTION
## Description

- Added support for more objects, physics interactions, and target adjustments in mobile physics.
- Added collision constants for spikes, electric sparks, toggleable spikes, and bouncers.
  - Reduced the bouncer's collision width by 20 for correctness.
- Fixed an issue where debug drawing rendered the bowtie hitbox incorrectly.