### PR TITLE
fix: robohand candy interactions with snail and bouncer

### DIFF
--- a/CutTheRopeDX.Tests/SnailWeightTests.cs
+++ b/CutTheRopeDX.Tests/SnailWeightTests.cs
@@ -1,0 +1,36 @@
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public class SnailWeightTests
+    {
+        [Fact]
+        public void AfterForceDetach_RestoresBaseWeightWhenSingleSnailRemoved()
+        {
+            // Base candy (weight 1) + one snail (+3) -> back to 1 once the snail is force-detached.
+            Assert.Equal(1f, SnailWeight.AfterForceDetach(4f, 1));
+        }
+
+        [Fact]
+        public void AfterForceDetach_RemovesEachSnailsContribution()
+        {
+            // Two snails stacked (+6) come off together.
+            Assert.Equal(1f, SnailWeight.AfterForceDetach(7f, 2));
+        }
+
+        [Fact]
+        public void AfterForceDetach_PreservesHeavierBaseWeight()
+        {
+            // Rocket candy (base 2.5) + one snail (+3 = 5.5) must return to 2.5, not a flat minimum.
+            Assert.Equal(2.5f, SnailWeight.AfterForceDetach(5.5f, 1));
+        }
+
+        [Fact]
+        public void AfterForceDetach_NeverDropsBelowMinimum()
+        {
+            Assert.Equal(SnailWeight.MinWeight, SnailWeight.AfterForceDetach(1f, 1));
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -852,6 +852,30 @@ namespace CutTheRopeDX.GameMain
             }
         }
 
+        /// <summary>
+        /// Number of active snails currently riding the given candy point.
+        /// </summary>
+        /// <param name="point">Candy physics point to count attached snails for.</param>
+        /// <returns>The count of snails in the active state whose attached point is <paramref name="point"/>; 0 if none or <paramref name="point"/> is null.</returns>
+        public int ActiveSnailCountForPoint(ConstraintedPoint point)
+        {
+            if (snailobjects == null || snailobjects.Count <= 0 || point == null)
+            {
+                return 0;
+            }
+
+            int count = 0;
+            foreach (Snail snail in snailobjects)
+            {
+                if (snail != null && snail.state == Snail.SNAIL_STATE_ACTIVE && snail.AttachedPoint() == point)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
         /// <summary>Detaches active snails riding the given candy point (no-op if null).</summary>
         public void DetachSnailsForPoint(ConstraintedPoint point)
         {

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -2063,6 +2063,12 @@ namespace CutTheRopeDX.GameMain
                     heldCandy.candy.drawY += hand.cPoint.pos.Y - heldCandy.point.pos.Y;
                     heldCandy.point.pos = hand.cPoint.pos;
 
+                    // Pin prevPos to the claw as well. Otherwise prevPos keeps the candy's pre-grab
+                    // physics position while pos is teleported to the claw, so Verlet reads the teleport
+                    // gap (e.g. the rope still pulling the candy up) as a fake velocity. A bouncer sitting
+                    // at the claw amplifies that phantom velocity into a huge impulse and launches the candy.
+                    heldCandy.point.prevPos = heldCandy.point.pos;
+
                     if (hand.doRotateCandy)
                     {
                         if (hand.rotatingSegment != null)
@@ -2177,7 +2183,16 @@ namespace CutTheRopeDX.GameMain
                         }
                     }
 
+                    // A snail riding this candy added weight to drag it down. Force-detaching the snail
+                    // here must give that weight back, otherwise the released candy keeps falling as if the
+                    // snail were still attached. Gate on real snail presence so a heavier rocket candy grabbed
+                    // without a snail keeps its own weight.
+                    int detachedSnails = ActiveSnailCountForPoint(ctx.point);
                     DetachSnailsForPoint(ctx.point);
+                    if (detachedSnails > 0)
+                    {
+                        ctx.point.SetWeight(SnailWeight.AfterForceDetach(ctx.point.weight, detachedSnails));
+                    }
                     miceManager?.ForceDropCandy();
                     RestoreCandyProperties(ctx);
                     hand.AnimateCatchWithCandyPartsandAnimationsPool(ctx.HandCatchVisuals(), ctx.HandCatchScale, aniPool);

--- a/CutTheRopeDX/GameMain/SnailWeight.cs
+++ b/CutTheRopeDX/GameMain/SnailWeight.cs
@@ -1,0 +1,30 @@
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// Pure weight bookkeeping for snails riding a candy point. Each attached snail adds
+    /// <see cref="PerSnailWeight"/> to the point so the candy is dragged down; force-detaching a snail
+    /// (hand grab, capture, etc.) must remove that exact amount, otherwise the candy keeps falling as if
+    /// the snail were still attached. The result never drops below <see cref="MinWeight"/>, so a base
+    /// candy weight (including a heavier rocket candy) is preserved rather than clobbered to a flat value.
+    /// </summary>
+    internal static class SnailWeight
+    {
+        /// <summary>Weight each attached snail adds to the candy point (see GameScene snail attach).</summary>
+        public const float PerSnailWeight = 3f;
+
+        /// <summary>Lowest weight a candy point retains after its snails are removed.</summary>
+        public const float MinWeight = 1f;
+
+        /// <summary>
+        /// Weight a candy point should carry after <paramref name="detachedSnails"/> snails are removed.
+        /// </summary>
+        /// <param name="weight">Current point weight (base weight plus each attached snail's contribution).</param>
+        /// <param name="detachedSnails">Number of snails being force-detached from the point.</param>
+        /// <returns>The restored point weight, floored at <see cref="MinWeight"/>.</returns>
+        public static float AfterForceDetach(float weight, int detachedSnails)
+        {
+            float restored = weight - (PerSnailWeight * detachedSnails);
+            return restored < MinWeight ? MinWeight : restored;
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Restore the snail's +3 point weight when a hand grabs the candy, so a released candy no longer keeps falling as if the snail were still riding it. Gated on real snail presence so a rocket candy keeps its base weight.
- Pin the held candy's prevPos to the claw so Verlet integration stops reading the teleport gap as a fake velocity, which a bouncer at the claw amplified into a huge launch.