### PR TITLE
fix: implement individual stopping of looped sounds for rockets (and electric sparks)

### DIFF
--- a/CutTheRopeDX/Framework/Media/SoundMgr.cs
+++ b/CutTheRopeDX/Framework/Media/SoundMgr.cs
@@ -170,6 +170,34 @@ namespace CutTheRopeDX.Framework.Media
         }
 
         /// <summary>
+        /// Stops a single active looped sound <paramref name="instance"/> and drops its tracking
+        /// entry, leaving every other looped sound and all one-shot effects untouched. Used by
+        /// callers that own an individual loop (e.g. a rocket's fly loop) so stopping one source
+        /// does not silence unrelated audio.
+        /// </summary>
+        /// <param name="instance">The looped instance to stop; ignored when <see langword="null"/>.</param>
+        public void StopLoopedSound(SoundEffectInstance instance)
+        {
+            if (instance == null)
+            {
+                return;
+            }
+
+            try
+            {
+                if (instance.State != SoundState.Stopped)
+                {
+                    instance.Stop();
+                }
+            }
+            catch (Exception)
+            {
+            }
+
+            _ = activeLoopedSounds.RemoveAll(entry => ReferenceEquals(entry.Instance, instance));
+        }
+
+        /// <summary>
         /// Stops all currently playing sound effects, including looped sounds.
         /// Resets the pause and SFX-suspension state so subsequent audio starts from a clean slate.
         /// </summary>

--- a/CutTheRopeDX/GameMain/CTRSoundMgr.cs
+++ b/CutTheRopeDX/GameMain/CTRSoundMgr.cs
@@ -203,6 +203,16 @@ namespace CutTheRopeDX.GameMain
         }
 
         /// <summary>
+        /// Stops a single looped sound instance previously returned by
+        /// <see cref="PlaySoundLooped(string)"/>, leaving other looped and one-shot sounds playing.
+        /// </summary>
+        /// <param name="instance">The looped instance to stop; ignored when <see langword="null"/>.</param>
+        public static void StopLoopedSound(SoundEffectInstance instance)
+        {
+            Application.SharedSoundMgr().StopLoopedSound(instance);
+        }
+
+        /// <summary>
         /// Stops all currently playing sound effects.
         /// </summary>
         public static void StopSounds()

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1341,7 +1341,7 @@ namespace CutTheRopeDX.GameMain
                             }
 
                             CTRSoundMgr.PlaySound(Resources.Snd.ExpRocketStart);
-                            _ = CTRSoundMgr.PlaySoundLooped(Resources.Snd.ExpRocketFlyLooped);
+                            rocket.flyLoopSound = CTRSoundMgr.PlaySoundLooped(Resources.Snd.ExpRocketFlyLooped);
                             ctx.activeRocket = rocket;
                             rocket.isOperating = -1;
                             rocket.startCandyRotation = ctx.candyMain.rotation;

--- a/CutTheRopeDX/GameMain/Rocket.cs
+++ b/CutTheRopeDX/GameMain/Rocket.cs
@@ -6,6 +6,8 @@ using CutTheRopeDX.Framework.Core;
 using CutTheRopeDX.Framework.Physics;
 using CutTheRopeDX.Framework.Visual;
 
+using Microsoft.Xna.Framework.Audio;
+
 using static CutTheRopeDX.Helpers.ParsingHelpers;
 
 namespace CutTheRopeDX.GameMain
@@ -282,7 +284,8 @@ namespace CutTheRopeDX.GameMain
 
         /// <summary>
         /// Stops the rocket animation by playing the scale-down timeline, stopping the spark
-        /// animation, stopping and releasing both particle systems, and stopping all sounds.
+        /// animation, stopping and releasing both particle systems, and silencing this rocket's
+        /// own fly loop.
         /// </summary>
         public void StopAnimation()
         {
@@ -297,7 +300,8 @@ namespace CutTheRopeDX.GameMain
             cloudParticles?.StopSystem();
             particles = null;
             cloudParticles = null;
-            CTRSoundMgr.StopSounds();
+            CTRSoundMgr.StopLoopedSound(flyLoopSound);
+            flyLoopSound = null;
         }
 
         /// <summary>The rocket is idle and not in use.</summary>
@@ -407,6 +411,14 @@ namespace CutTheRopeDX.GameMain
 
         /// <summary>Particle system for the rocket's cloud exhaust trail.</summary>
         public RocketClouds cloudParticles;
+
+        /// <summary>
+        /// This rocket's own looping fly sound instance. Held so it can be stopped individually
+        /// via <see cref="CTRSoundMgr.StopLoopedSound"/> without silencing other rockets' loops or
+        /// unrelated one-shot effects. <see langword="null"/> when looped sounds are disabled or
+        /// the sound failed to start.
+        /// </summary>
+        public SoundEffectInstance flyLoopSound;
 
         /// <summary>Delegate that receives rocket lifecycle callbacks (e.g., exhaustion).</summary>
         public IRocketDelegate delegateRocketDelegate;

--- a/CutTheRopeDX/GameMain/Spikes.cs
+++ b/CutTheRopeDX/GameMain/Spikes.cs
@@ -101,7 +101,7 @@ namespace CutTheRopeDX.GameMain
             electroOn = false;
             PlayTimeline(0);
             electroTimer = offTime;
-            sndElectric?.Stop();
+            CTRSoundMgr.StopLoopedSound(sndElectric);
             sndElectric = null;
         }
 


### PR DESCRIPTION
## Description

This PR makes rocket exhaust stop only the owning rocket's loop instead of all sounds.

`Rocket.StopAnimation` called the global `StopSounds`, which stopped every looped sound and one-shot effect. That was harmless with a single active rocket, but with per-candy rockets, exhausting one rocket silenced other flying rockets' loops and cut in-flight one-shots like the star-collect sound.

Adds a generic `SoundMgr.StopLoopedSound(instance)` to stop a single loop, tracks each rocket's fly loop in `Rocket.flyLoopSound`, and routes both the rocket and the electric spark loop through the new API.