### PR TITLE
fix: ignore duplicate settings layers in level metadata

### DIFF
--- a/CutTheRopeDX.Tests/LevelMetadataLayerSelectionTests.cs
+++ b/CutTheRopeDX.Tests/LevelMetadataLayerSelectionTests.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using System.Xml.Linq;
+
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public class LevelMetadataLayerSelectionTests
+    {
+        [Fact]
+        public void SelectLayers_UsesOnlyFirstCaseInsensitiveSettingsLayer()
+        {
+            XElement map = XElement.Parse("""
+                <map>
+                  <layer name="settings">
+                    <map width="320" height="480" />
+                    <gameDesign special="1" />
+                  </layer>
+                  <layer name="Objects">
+                    <candy x="10" y="20" />
+                  </layer>
+                  <layer name="settings">
+                    <map width="999" height="999" />
+                    <gameDesign special="9" />
+                    <candy x="90" y="90" />
+                  </layer>
+                  <layer name="Settings">
+                    <map width="640" height="960" />
+                    <candy x="30" y="40" />
+                  </layer>
+                </map>
+                """);
+
+            XElement[] selected = [.. LevelMetadataLayerSelection.SelectLayers(map)];
+
+            Assert.Equal(["settings", "Objects"],
+                selected.Select(layer => layer.Attribute("name")?.Value));
+            Assert.Equal("320", selected[0].Element("map")?.Attribute("width")?.Value);
+            Assert.Equal("10", selected[1].Element("candy")?.Attribute("x")?.Value);
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/GameScene.LoadMetadata.cs
+++ b/CutTheRopeDX/GameMain/GameScene.LoadMetadata.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Xml.Linq;
 
 using CutTheRopeDX.Framework;
@@ -9,6 +11,44 @@ using static CutTheRopeDX.Helpers.ParsingHelpers;
 
 namespace CutTheRopeDX.GameMain
 {
+    /// <summary>Selects the level layers consumed by <see cref="GameScene"/> metadata loading.</summary>
+    internal static class LevelMetadataLayerSelection
+    {
+        /// <summary>
+        /// Returns only the first case-insensitive <c>settings</c> layer while retaining every
+        /// non-settings layer in document order.
+        /// </summary>
+        /// <param name="mapNode">Root XML node for the current map.</param>
+        /// <returns>Layers to inspect for metadata.</returns>
+        public static IEnumerable<XElement> SelectLayers(XElement mapNode)
+        {
+            bool settingsLayerSelected = false;
+            foreach (XElement layer in mapNode.Elements())
+            {
+                bool isSettingsLayer = layer.Name.LocalName == "layer" && IsSettingsLayer(layer);
+                if (isSettingsLayer)
+                {
+                    if (settingsLayerSelected)
+                    {
+                        continue;
+                    }
+
+                    settingsLayerSelected = true;
+                }
+
+                yield return layer;
+            }
+        }
+
+        private static bool IsSettingsLayer(XElement layer)
+        {
+            return string.Equals(
+                layer.Attribute("name")?.Value,
+                "settings",
+                StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
     internal sealed partial class GameScene
     {
         /// <summary>
@@ -31,8 +71,8 @@ namespace CutTheRopeDX.GameMain
 
             CTRRootController rc = (CTRRootController)Application.SharedRootController();
 
-            // Single pass through XML metadata nodes
-            foreach (XElement xmlnode in mapNode.Elements())
+            // Single pass through XML metadata nodes, ignoring duplicate settings layers.
+            foreach (XElement xmlnode in LevelMetadataLayerSelection.SelectLayers(mapNode))
             {
                 foreach (XElement item2 in xmlnode.Elements())
                 {


### PR DESCRIPTION
## Description

Prevents duplicate `settings` layers in level XML from overriding earlier settings. The game now uses the first `settings` layer and ignores subsequent duplicates.