### PR TITLE
feat: Add CLI support for level playtesting

### DIFF
--- a/CutTheRopeDX.Tests/CustomLevelCommandLineTests.cs
+++ b/CutTheRopeDX.Tests/CustomLevelCommandLineTests.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 using CutTheRopeDX.GameMain;
 
 using Xunit;
@@ -31,7 +33,7 @@ namespace CutTheRopeDX.Tests
 
             Assert.True(result.IsCustomLevel);
             Assert.Null(result.ErrorMessage);
-            Assert.True(System.IO.Path.IsPathRooted(result.LevelPath));
+            Assert.True(Path.IsPathRooted(result.LevelPath));
             Assert.EndsWith("test.xml", result.LevelPath);
         }
 
@@ -54,13 +56,50 @@ namespace CutTheRopeDX.Tests
         }
 
         [Fact]
+        public void Parse_BareXmlPath_IsTreatedAsCustomLevel()
+        {
+            CustomLevelCommandLineResult result = CustomLevelCommandLine.Parse([@"C:\maps\dropped.xml"]);
+
+            Assert.True(result.IsCustomLevel);
+            Assert.Null(result.ErrorMessage);
+            Assert.EndsWith("dropped.xml", result.LevelPath);
+        }
+
+        [Fact]
+        public void Parse_BareXmlPath_IgnoresCase()
+        {
+            CustomLevelCommandLineResult result = CustomLevelCommandLine.Parse(["level.XML"]);
+
+            Assert.True(result.IsCustomLevel);
+            Assert.Equal(Path.GetFullPath("level.XML"), result.LevelPath);
+        }
+
+        [Fact]
+        public void Parse_BareNonXmlPath_IsNotCustomLevel()
+        {
+            CustomLevelCommandLineResult result = CustomLevelCommandLine.Parse(["notes.txt"]);
+
+            Assert.False(result.IsCustomLevel);
+            Assert.Null(result.ErrorMessage);
+        }
+
+        [Fact]
+        public void Parse_LevelSwitchTakesPrecedenceOverBarePath()
+        {
+            CustomLevelCommandLineResult result = CustomLevelCommandLine.Parse(["bare.xml", "--level", "chosen.xml"]);
+
+            Assert.True(result.IsCustomLevel);
+            Assert.EndsWith("chosen.xml", result.LevelPath);
+        }
+
+        [Fact]
         public void Parse_RelativePath_IsResolvedAgainstWorkingDirectory()
         {
             CustomLevelCommandLineResult result = CustomLevelCommandLine.Parse(["--level", "level.xml"]);
 
             Assert.True(result.IsCustomLevel);
             Assert.Equal(
-                System.IO.Path.GetFullPath("level.xml"),
+                Path.GetFullPath("level.xml"),
                 result.LevelPath);
         }
     }

--- a/CutTheRopeDX.Tests/CustomLevelCommandLineTests.cs
+++ b/CutTheRopeDX.Tests/CustomLevelCommandLineTests.cs
@@ -1,0 +1,67 @@
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public class CustomLevelCommandLineTests
+    {
+        [Fact]
+        public void Parse_NoArguments_IsNotCustomLevel()
+        {
+            CustomLevelCommandLineResult result = CustomLevelCommandLine.Parse([]);
+
+            Assert.False(result.IsCustomLevel);
+            Assert.Null(result.ErrorMessage);
+        }
+
+        [Fact]
+        public void Parse_UnrelatedArguments_IsNotCustomLevel()
+        {
+            CustomLevelCommandLineResult result = CustomLevelCommandLine.Parse(["--windowed"]);
+
+            Assert.False(result.IsCustomLevel);
+            Assert.Null(result.ErrorMessage);
+        }
+
+        [Fact]
+        public void Parse_LevelWithPath_ReturnsAbsolutePath()
+        {
+            CustomLevelCommandLineResult result = CustomLevelCommandLine.Parse(["--level", "/maps/test.xml"]);
+
+            Assert.True(result.IsCustomLevel);
+            Assert.Null(result.ErrorMessage);
+            Assert.True(System.IO.Path.IsPathRooted(result.LevelPath));
+            Assert.EndsWith("test.xml", result.LevelPath);
+        }
+
+        [Fact]
+        public void Parse_LevelWithoutValue_ReturnsError()
+        {
+            CustomLevelCommandLineResult result = CustomLevelCommandLine.Parse(["--level"]);
+
+            Assert.True(result.IsCustomLevel);
+            Assert.NotNull(result.ErrorMessage);
+        }
+
+        [Fact]
+        public void Parse_LevelWithEmptyValue_ReturnsError()
+        {
+            CustomLevelCommandLineResult result = CustomLevelCommandLine.Parse(["--level", "   "]);
+
+            Assert.True(result.IsCustomLevel);
+            Assert.NotNull(result.ErrorMessage);
+        }
+
+        [Fact]
+        public void Parse_RelativePath_IsResolvedAgainstWorkingDirectory()
+        {
+            CustomLevelCommandLineResult result = CustomLevelCommandLine.Parse(["--level", "level.xml"]);
+
+            Assert.True(result.IsCustomLevel);
+            Assert.Equal(
+                System.IO.Path.GetFullPath("level.xml"),
+                result.LevelPath);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/CustomLevelFileTests.cs
+++ b/CutTheRopeDX.Tests/CustomLevelFileTests.cs
@@ -1,0 +1,72 @@
+using System.IO;
+using System.Xml.Linq;
+
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public class CustomLevelFileTests
+    {
+        [Fact]
+        public void TryLoad_ValidXml_ReturnsRootElement()
+        {
+            string path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".xml");
+            File.WriteAllText(path, "<level><object name=\"candy\" /></level>");
+            try
+            {
+                bool loaded = CustomLevelFile.TryLoad(path, out XElement map, out string error);
+
+                Assert.True(loaded);
+                Assert.Null(error);
+                Assert.Equal("level", map.Name.LocalName);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void TryLoad_MissingFile_ReturnsErrorMentioningPath()
+        {
+            string path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".xml");
+
+            bool loaded = CustomLevelFile.TryLoad(path, out XElement map, out string error);
+
+            Assert.False(loaded);
+            Assert.Null(map);
+            Assert.Contains(path, error);
+        }
+
+        [Fact]
+        public void TryLoad_MalformedXml_ReturnsError()
+        {
+            string path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".xml");
+            File.WriteAllText(path, "<level><unclosed>");
+            try
+            {
+                bool loaded = CustomLevelFile.TryLoad(path, out XElement map, out string error);
+
+                Assert.False(loaded);
+                Assert.Null(map);
+                Assert.NotNull(error);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void TryLoad_EmptyPath_ReturnsError()
+        {
+            bool loaded = CustomLevelFile.TryLoad("  ", out XElement map, out string error);
+
+            Assert.False(loaded);
+            Assert.Null(map);
+            Assert.NotNull(error);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/CustomLevelReloadDecisionTests.cs
+++ b/CutTheRopeDX.Tests/CustomLevelReloadDecisionTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public class CustomLevelReloadDecisionTests
+    {
+        [Fact]
+        public void Decide_IdenticalResources_IsInstant()
+        {
+            CustomLevelReloadKind kind = CustomLevelReloadDecision.Decide(
+                ["spider", "sock"],
+                new HashSet<string> { "spider", "sock" });
+
+            Assert.Equal(CustomLevelReloadKind.Instant, kind);
+        }
+
+        [Fact]
+        public void Decide_SubsetOfLoaded_IsInstant()
+        {
+            CustomLevelReloadKind kind = CustomLevelReloadDecision.Decide(
+                ["spider"],
+                new HashSet<string> { "spider", "sock", "bouncer" });
+
+            Assert.Equal(CustomLevelReloadKind.Instant, kind);
+        }
+
+        [Fact]
+        public void Decide_NoRequirements_IsInstant()
+        {
+            CustomLevelReloadKind kind = CustomLevelReloadDecision.Decide(
+                [],
+                new HashSet<string> { "spider" });
+
+            Assert.Equal(CustomLevelReloadKind.Instant, kind);
+        }
+
+        [Fact]
+        public void Decide_OneNewResource_NeedsLoadingScreen()
+        {
+            CustomLevelReloadKind kind = CustomLevelReloadDecision.Decide(
+                ["spider", "rocket"],
+                new HashSet<string> { "spider", "sock" });
+
+            Assert.Equal(CustomLevelReloadKind.LoadingScreen, kind);
+        }
+
+        [Fact]
+        public void Decide_DisjointResources_NeedsLoadingScreen()
+        {
+            CustomLevelReloadKind kind = CustomLevelReloadDecision.Decide(
+                ["rocket"],
+                new HashSet<string> { "spider" });
+
+            Assert.Equal(CustomLevelReloadKind.LoadingScreen, kind);
+        }
+
+        [Fact]
+        public void Decide_NullRequirements_IsInstant()
+        {
+            CustomLevelReloadKind kind = CustomLevelReloadDecision.Decide(
+                null,
+                new HashSet<string> { "spider" });
+
+            Assert.Equal(CustomLevelReloadKind.Instant, kind);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/LevelLabelTests.cs
+++ b/CutTheRopeDX.Tests/LevelLabelTests.cs
@@ -1,0 +1,54 @@
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public class LevelLabelTests
+    {
+        [Fact]
+        public void Resolve_NormalLevelWithoutName_ShowsNumbersOverLevelWord()
+        {
+            LevelLabelText label = LevelLabel.Resolve(false, null, "Level", "1 - 1");
+
+            Assert.Equal("1 - 1", label.Primary);
+            Assert.Equal("Level", label.Secondary);
+        }
+
+        [Fact]
+        public void Resolve_NormalLevelWithName_ShowsNameOverLevelWordAndNumbers()
+        {
+            LevelLabelText label = LevelLabel.Resolve(false, "Sugar Rush", "Level", "1 - 1");
+
+            Assert.Equal("Sugar Rush", label.Primary);
+            Assert.Equal("Level 1 - 1", label.Secondary);
+        }
+
+        [Fact]
+        public void Resolve_CustomLevelWithName_ShowsNameWithoutNumbers()
+        {
+            LevelLabelText label = LevelLabel.Resolve(true, "My Test Level", "Level", "1 - 1");
+
+            Assert.Equal("My Test Level", label.Primary);
+            Assert.Null(label.Secondary);
+        }
+
+        [Fact]
+        public void Resolve_CustomLevelWithoutName_ShowsNoLabel()
+        {
+            LevelLabelText label = LevelLabel.Resolve(true, null, "Level", "1 - 1");
+
+            Assert.Null(label.Primary);
+            Assert.Null(label.Secondary);
+        }
+
+        [Fact]
+        public void Resolve_CustomLevelWithBlankName_ShowsNoLabel()
+        {
+            LevelLabelText label = LevelLabel.Resolve(true, "   ", "Level", "1 - 1");
+
+            Assert.Null(label.Primary);
+            Assert.Null(label.Secondary);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/LevelProgressPersistenceTests.cs
+++ b/CutTheRopeDX.Tests/LevelProgressPersistenceTests.cs
@@ -1,0 +1,45 @@
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public class LevelProgressPersistenceTests
+    {
+        [Fact]
+        public void ShouldPersist_TrueWhenImprovedInNormalPlay()
+        {
+            Assert.True(LevelProgressPersistence.ShouldPersist(
+                customLevelActive: false,
+                newValue: 1200,
+                storedValue: 900));
+        }
+
+        [Fact]
+        public void ShouldPersist_FalseWhenNotImprovedInNormalPlay()
+        {
+            Assert.False(LevelProgressPersistence.ShouldPersist(
+                customLevelActive: false,
+                newValue: 900,
+                storedValue: 900));
+        }
+
+        [Fact]
+        public void ShouldPersist_FalseInCustomLevelEvenWhenImproved()
+        {
+            Assert.False(LevelProgressPersistence.ShouldPersist(
+                customLevelActive: true,
+                newValue: 1200,
+                storedValue: 900));
+        }
+
+        [Fact]
+        public void ShouldPersist_FalseInCustomLevelFromZero()
+        {
+            Assert.False(LevelProgressPersistence.ShouldPersist(
+                customLevelActive: true,
+                newValue: 3,
+                storedValue: 0));
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/LocalizationFallbackTests.cs
+++ b/CutTheRopeDX.Tests/LocalizationFallbackTests.cs
@@ -1,0 +1,41 @@
+using CutTheRopeDX.Helpers;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public class LocalizationFallbackTests
+    {
+        [Fact]
+        public void GetString_KnownKey_ReturnsLocalizedText()
+        {
+            Assert.Equal("Level", LocalizationManager.GetString("LEVEL", "en"));
+        }
+
+        [Fact]
+        public void GetString_UnknownKey_ReturnsKeyVerbatim()
+        {
+            Assert.Equal("hi world", LocalizationManager.GetString("hi world", "en"));
+        }
+
+        [Fact]
+        public void GetString_UnknownKeyInUnknownLanguage_ReturnsKeyVerbatim()
+        {
+            Assert.Equal("My Test Level", LocalizationManager.GetString("My Test Level", "de"));
+        }
+
+        [Fact]
+        public void GetString_EmptyKey_ReturnsEmpty()
+        {
+            Assert.Equal(string.Empty, LocalizationManager.GetString("", "en"));
+            Assert.Equal(string.Empty, LocalizationManager.GetString(null, "en"));
+        }
+
+        [Fact]
+        public void HasString_RemainsTheExistenceTest()
+        {
+            Assert.True(LocalizationManager.HasString("LEVEL"));
+            Assert.False(LocalizationManager.HasString("hi world"));
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/PendingChangeGateTests.cs
+++ b/CutTheRopeDX.Tests/PendingChangeGateTests.cs
@@ -1,0 +1,69 @@
+using System;
+
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public class PendingChangeGateTests
+    {
+        private static readonly DateTime Start = new(2026, 7, 20, 12, 0, 0, DateTimeKind.Utc);
+
+        private static PendingChangeGate CreateGate()
+        {
+            return new PendingChangeGate(TimeSpan.FromMilliseconds(100));
+        }
+
+        [Fact]
+        public void TryConsume_NoChange_ReturnsFalse()
+        {
+            PendingChangeGate gate = CreateGate();
+
+            Assert.False(gate.TryConsume(Start));
+        }
+
+        [Fact]
+        public void TryConsume_BeforeQuietPeriodElapses_ReturnsFalse()
+        {
+            PendingChangeGate gate = CreateGate();
+            gate.NotifyChanged(Start);
+
+            Assert.False(gate.TryConsume(Start.AddMilliseconds(50)));
+        }
+
+        [Fact]
+        public void TryConsume_AfterQuietPeriodElapses_ReturnsTrue()
+        {
+            PendingChangeGate gate = CreateGate();
+            gate.NotifyChanged(Start);
+
+            Assert.True(gate.TryConsume(Start.AddMilliseconds(150)));
+        }
+
+        [Fact]
+        public void TryConsume_BurstOfChanges_YieldsSingleReload()
+        {
+            PendingChangeGate gate = CreateGate();
+            gate.NotifyChanged(Start);
+            gate.NotifyChanged(Start.AddMilliseconds(10));
+            gate.NotifyChanged(Start.AddMilliseconds(20));
+            gate.NotifyChanged(Start.AddMilliseconds(30));
+
+            Assert.False(gate.TryConsume(Start.AddMilliseconds(100)));
+            Assert.True(gate.TryConsume(Start.AddMilliseconds(200)));
+            Assert.False(gate.TryConsume(Start.AddMilliseconds(300)));
+        }
+
+        [Fact]
+        public void TryConsume_SecondChangeAfterConsume_ReturnsTrueAgain()
+        {
+            PendingChangeGate gate = CreateGate();
+            gate.NotifyChanged(Start);
+            Assert.True(gate.TryConsume(Start.AddMilliseconds(150)));
+
+            gate.NotifyChanged(Start.AddMilliseconds(200));
+            Assert.True(gate.TryConsume(Start.AddMilliseconds(400)));
+        }
+    }
+}

--- a/CutTheRopeDX/CutTheRopeDX.csproj
+++ b/CutTheRopeDX/CutTheRopeDX.csproj
@@ -7,10 +7,10 @@
 
     <!-- Default: cross-platform -->
     <TargetFrameworks>net10.0</TargetFrameworks>
-    <!-- macOS: add net10.0-macos for AVFoundation -->
-    <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('OSX'))">
-      net10.0;net10.0-macos
-    </TargetFrameworks>
+    <!-- macOS: add net10.0-macos for AVFoundation.
+         Set ExcludeMacOSTarget=true to drop it (used by the test project, which
+         only needs the portable target and must not require the macos workload). -->
+    <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('OSX')) AND '$(ExcludeMacOSTarget)' != 'true'">net10.0;net10.0-macos</TargetFrameworks>
     <LangVersion>preview</LangVersion>
 
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/CutTheRopeDX/GameMain/BoxOpenClose.cs
+++ b/CutTheRopeDX/GameMain/BoxOpenClose.cs
@@ -222,7 +222,8 @@ namespace CutTheRopeDX.GameMain
             _ = result.AddChild(stamp);
             Button button = MenuController.CreateShortButtonWithTextIDDelegate(Application.GetString("REPLAY"), 8, b);
             button.anchor = 18;
-            Image.SetElementPositionWithQuadOffset(button, Resources.Img.MenuResults, 11);
+            // Custom levels hide the NEXT/MENU buttons, so replay takes the centered menu slot instead.
+            Image.SetElementPositionWithQuadOffset(button, Resources.Img.MenuResults, CustomLevelSession.IsActive ? 9 : 11);
             _ = result.AddChild(button);
             if (!CustomLevelSession.IsActive)
             {

--- a/CutTheRopeDX/GameMain/BoxOpenClose.cs
+++ b/CutTheRopeDX/GameMain/BoxOpenClose.cs
@@ -224,14 +224,17 @@ namespace CutTheRopeDX.GameMain
             button.anchor = 18;
             Image.SetElementPositionWithQuadOffset(button, Resources.Img.MenuResults, 11);
             _ = result.AddChild(button);
-            Button button2 = MenuController.CreateShortButtonWithTextIDDelegate(Application.GetString("NEXT"), 9, b);
-            button2.anchor = 18;
-            Image.SetElementPositionWithQuadOffset(button2, Resources.Img.MenuResults, 10);
-            _ = result.AddChild(button2);
-            Button button3 = MenuController.CreateShortButtonWithTextIDDelegate(Application.GetString("MENU"), 5, b);
-            button3.anchor = 18;
-            Image.SetElementPositionWithQuadOffset(button3, Resources.Img.MenuResults, 9);
-            _ = result.AddChild(button3);
+            if (!CustomLevelSession.IsActive)
+            {
+                Button button2 = MenuController.CreateShortButtonWithTextIDDelegate(Application.GetString("NEXT"), 9, b);
+                button2.anchor = 18;
+                Image.SetElementPositionWithQuadOffset(button2, Resources.Img.MenuResults, 10);
+                _ = result.AddChild(button2);
+                Button button3 = MenuController.CreateShortButtonWithTextIDDelegate(Application.GetString("MENU"), 5, b);
+                button3.anchor = 18;
+                Image.SetElementPositionWithQuadOffset(button3, Resources.Img.MenuResults, 9);
+                _ = result.AddChild(button3);
+            }
             Text text2 = new Text().InitWithFont(Application.GetFont(Resources.Fnt.SmallFont));
             text2.SetName("dataTitle");
             text2.anchor = 18;

--- a/CutTheRopeDX/GameMain/CTRRootController.cs
+++ b/CutTheRopeDX/GameMain/CTRRootController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -123,6 +124,17 @@ namespace CutTheRopeDX.GameMain
             ctrresourceMgr.InitLoading();
             ctrresourceMgr.LoadPack(PackStartup);
             ctrresourceMgr.LoadImmediately();
+
+            if (CustomLevelSession.IsActive)
+            {
+                pack = 0;
+                level = 0;
+                LoadingController customLoading = new(this);
+                AddChildwithID(customLoading, 2);
+                viewTransition = -1;
+                return;
+            }
+
             StartupController startupController = new(this);
             AddChildwithID(startupController, 0);
             viewTransition = -1;
@@ -133,10 +145,39 @@ namespace CutTheRopeDX.GameMain
         {
             _ = CTRPreferences.IsFirstLaunch();
             base.Activate();
-            ActivateChild(0);
+
+            if (CustomLevelSession.IsActive)
+            {
+                BeginCustomLevelLoad();
+            }
+            else
+            {
+                ActivateChild(0);
+            }
+
             Application.SharedCanvas().BeforeRender();
             ActiveChild().ActiveView().Draw();
             GLCanvas.AfterRender();
+        }
+
+        /// <summary>
+        /// Loads gameplay resources for the externally supplied level and enters the loading screen.
+        /// </summary>
+        private void BeginCustomLevelLoad()
+        {
+            CTRResourceMgr resourceMgr = Application.SharedResourceMgr();
+            resourceMgr.resourcesDelegate = (LoadingController)GetChild(2);
+            ResetGameplayResourceSession();
+            EnsureCurrentMapLoaded();
+            string[] levelResources = LevelResourceScanner.GetRequiredResources(loadedMap);
+            TrackSessionResources(levelResources);
+            resourceMgr.InitLoading();
+            resourceMgr.LoadPack(PackGame);
+            resourceMgr.LoadPack(PackConfig.GetBoxBackgrounds(pack));
+            resourceMgr.LoadPack(levelResources);
+            resourceMgr.StartLoading();
+            ((LoadingController)GetChild(2)).nextController = 0;
+            ActivateChild(2);
         }
 
         /// <summary>Removes the menu child controller and frees menu resources.</summary>
@@ -466,6 +507,21 @@ namespace CutTheRopeDX.GameMain
         {
             if (loadedMap != null)
             {
+                return;
+            }
+
+            if (CustomLevelSession.IsActive)
+            {
+                if (CustomLevelFile.TryLoad(CustomLevelSession.LevelPath, out XElement customMap, out string error))
+                {
+                    loadedMap = customMap;
+                    mapName = CustomLevelSession.LevelPath;
+                }
+                else
+                {
+                    Console.Error.WriteLine(error);
+                }
+
                 return;
             }
 

--- a/CutTheRopeDX/GameMain/CTRRootController.cs
+++ b/CutTheRopeDX/GameMain/CTRRootController.cs
@@ -161,6 +161,37 @@ namespace CutTheRopeDX.GameMain
         }
 
         /// <summary>
+        /// Gets the resources loaded for the current gameplay session.
+        /// </summary>
+        /// <returns>The set of resource identifiers tracked for this session.</returns>
+        public ISet<string> GetSessionResources()
+        {
+            return sessionResources;
+        }
+
+        /// <summary>
+        /// Frees the previous level's resources, loads the edited level's resources through the
+        /// loading screen, and re-enters gameplay.
+        /// </summary>
+        /// <param name="resourceMgr">Shared resource manager.</param>
+        private void ReloadCustomLevelThroughLoadingScreen(CTRResourceMgr resourceMgr)
+        {
+            DeleteChild(3);
+
+            string[] levelResources = LevelResourceScanner.GetRequiredResources(loadedMap);
+            resourceMgr.FreePack([.. sessionResources]);
+            sessionResources.Clear();
+            TrackSessionResources(levelResources);
+
+            resourceMgr.resourcesDelegate = (LoadingController)GetChild(2);
+            resourceMgr.InitLoading();
+            resourceMgr.LoadPack(levelResources);
+            resourceMgr.StartLoading();
+            ((LoadingController)GetChild(2)).nextController = 0;
+            ActivateChild(2);
+        }
+
+        /// <summary>
         /// Loads gameplay resources for the externally supplied level and enters the loading screen.
         /// </summary>
         private void BeginCustomLevelLoad()
@@ -325,6 +356,13 @@ namespace CutTheRopeDX.GameMain
                         GameController gameController = (GameController)GetChild(3);
                         int exitCode = gameController.exitCode;
                         _ = (GameScene)gameController.GetView(0).GetChild(0);
+
+                        if (exitCode == GameController.EXIT_CODE_CUSTOM_RELOAD)
+                        {
+                            ReloadCustomLevelThroughLoadingScreen(resourceMgr);
+                            return;
+                        }
+
                         if (exitCode <= 2)
                         {
                             StopGameplayPrefetch();

--- a/CutTheRopeDX/GameMain/CustomLevelCommandLine.cs
+++ b/CutTheRopeDX/GameMain/CustomLevelCommandLine.cs
@@ -17,6 +17,10 @@ namespace CutTheRopeDX.GameMain
     /// <summary>
     /// Parses the custom-level command line switches. Performs no file access.
     /// </summary>
+    /// <remarks>
+    /// A bare <c>.xml</c> path is also accepted so a level file can be dropped onto the executable,
+    /// which is how Windows Explorer hands the path over.
+    /// </remarks>
     internal static class CustomLevelCommandLine
     {
         /// <summary>Command line switch that selects a custom level file.</summary>
@@ -47,6 +51,20 @@ namespace CutTheRopeDX.GameMain
                         null,
                         LevelSwitch + " requires a path to a level XML file.")
                     : new CustomLevelCommandLineResult(true, Path.GetFullPath(args[i + 1]), null);
+            }
+
+            for (int i = 0; i < args.Length; i++)
+            {
+                string arg = args[i];
+
+                if (string.IsNullOrWhiteSpace(arg)
+                    || arg.StartsWith('-')
+                    || !arg.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                return new CustomLevelCommandLineResult(true, Path.GetFullPath(arg), null);
             }
 
             return new CustomLevelCommandLineResult(false, null, null);

--- a/CutTheRopeDX/GameMain/CustomLevelCommandLine.cs
+++ b/CutTheRopeDX/GameMain/CustomLevelCommandLine.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// Outcome of parsing custom-level command line arguments.
+    /// </summary>
+    /// <param name="IsCustomLevel">Whether the <c>--level</c> switch was present.</param>
+    /// <param name="LevelPath">Absolute path to the requested level file, or <see langword="null"/> when unavailable.</param>
+    /// <param name="ErrorMessage">Reason the arguments are unusable, or <see langword="null"/> when they are valid.</param>
+    internal readonly record struct CustomLevelCommandLineResult(
+        bool IsCustomLevel,
+        string LevelPath,
+        string ErrorMessage);
+
+    /// <summary>
+    /// Parses the custom-level command line switches. Performs no file access.
+    /// </summary>
+    internal static class CustomLevelCommandLine
+    {
+        /// <summary>Command line switch that selects a custom level file.</summary>
+        public const string LevelSwitch = "--level";
+
+        /// <summary>
+        /// Parses command line arguments for the custom-level switch.
+        /// </summary>
+        /// <param name="args">Raw process arguments, excluding the executable name.</param>
+        /// <returns>The parse outcome.</returns>
+        public static CustomLevelCommandLineResult Parse(string[] args)
+        {
+            if (args == null)
+            {
+                return new CustomLevelCommandLineResult(false, null, null);
+            }
+
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (!string.Equals(args[i], LevelSwitch, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                {
+                    return new CustomLevelCommandLineResult(
+                        true,
+                        null,
+                        LevelSwitch + " requires a path to a level XML file.");
+                }
+
+                return new CustomLevelCommandLineResult(true, Path.GetFullPath(args[i + 1]), null);
+            }
+
+            return new CustomLevelCommandLineResult(false, null, null);
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/CustomLevelCommandLine.cs
+++ b/CutTheRopeDX/GameMain/CustomLevelCommandLine.cs
@@ -41,15 +41,12 @@ namespace CutTheRopeDX.GameMain
                     continue;
                 }
 
-                if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
-                {
-                    return new CustomLevelCommandLineResult(
+                return i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1])
+                    ? new CustomLevelCommandLineResult(
                         true,
                         null,
-                        LevelSwitch + " requires a path to a level XML file.");
-                }
-
-                return new CustomLevelCommandLineResult(true, Path.GetFullPath(args[i + 1]), null);
+                        LevelSwitch + " requires a path to a level XML file.")
+                    : new CustomLevelCommandLineResult(true, Path.GetFullPath(args[i + 1]), null);
             }
 
             return new CustomLevelCommandLineResult(false, null, null);

--- a/CutTheRopeDX/GameMain/CustomLevelFile.cs
+++ b/CutTheRopeDX/GameMain/CustomLevelFile.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// Reads and validates externally supplied level XML files.
+    /// </summary>
+    internal static class CustomLevelFile
+    {
+        /// <summary>
+        /// Attempts to read a level XML file from disk.
+        /// </summary>
+        /// <param name="path">Absolute path to the level file.</param>
+        /// <param name="map">Receives the parsed root element on success; otherwise <see langword="null"/>.</param>
+        /// <param name="error">Receives a human-readable failure reason on failure; otherwise <see langword="null"/>.</param>
+        /// <returns><see langword="true"/> when the file was read and parsed; otherwise <see langword="false"/>.</returns>
+        public static bool TryLoad(string path, out XElement map, out string error)
+        {
+            map = null;
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                error = "No level path was supplied.";
+                return false;
+            }
+
+            if (!File.Exists(path))
+            {
+                error = "Level file not found: " + path;
+                return false;
+            }
+
+            try
+            {
+                map = XDocument.Load(path).Root;
+            }
+            catch (Exception ex) when (ex is XmlException or IOException or UnauthorizedAccessException)
+            {
+                error = "Could not read level file " + path + ": " + ex.Message;
+                return false;
+            }
+
+            if (map == null)
+            {
+                error = "Level file " + path + " contains no root element.";
+                return false;
+            }
+
+            error = null;
+            return true;
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/CustomLevelReloadDecision.cs
+++ b/CutTheRopeDX/GameMain/CustomLevelReloadDecision.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// How a custom level change should be applied to the running game.
+    /// </summary>
+    internal enum CustomLevelReloadKind
+    {
+        /// <summary>Every required resource is already resident; restart the scene in place.</summary>
+        Instant,
+
+        /// <summary>New resources are required; load them through the loading screen first.</summary>
+        LoadingScreen
+    }
+
+    /// <summary>
+    /// Chooses how to apply a custom level change based on resource availability.
+    /// </summary>
+    internal static class CustomLevelReloadDecision
+    {
+        /// <summary>
+        /// Decides whether a reloaded level can restart in place.
+        /// </summary>
+        /// <param name="requiredResources">Resources the newly read level needs.</param>
+        /// <param name="loadedResources">Resources currently resident for this session.</param>
+        /// <returns>
+        /// <see cref="CustomLevelReloadKind.Instant"/> when every required resource is already loaded;
+        /// otherwise <see cref="CustomLevelReloadKind.LoadingScreen"/>.
+        /// </returns>
+        /// <remarks>
+        /// The comparison is one-way. Resources that are loaded but no longer required do not force a
+        /// loading pass; they are released during the next pass that happens for other reasons.
+        /// </remarks>
+        public static CustomLevelReloadKind Decide(
+            IEnumerable<string> requiredResources,
+            ISet<string> loadedResources)
+        {
+            if (requiredResources == null)
+            {
+                return CustomLevelReloadKind.Instant;
+            }
+
+            foreach (string resourceName in requiredResources)
+            {
+                if (string.IsNullOrWhiteSpace(resourceName))
+                {
+                    continue;
+                }
+
+                if (loadedResources == null || !loadedResources.Contains(resourceName))
+                {
+                    return CustomLevelReloadKind.LoadingScreen;
+                }
+            }
+
+            return CustomLevelReloadKind.Instant;
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/CustomLevelSession.cs
+++ b/CutTheRopeDX/GameMain/CustomLevelSession.cs
@@ -1,0 +1,34 @@
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// Tracks whether this process is running a single externally supplied level rather than the normal game.
+    /// </summary>
+    /// <remarks>
+    /// Custom level runs skip the splash and menu, never write progress, and reload their level from disk on change.
+    /// </remarks>
+    internal static class CustomLevelSession
+    {
+        /// <summary>Gets whether this process is running an externally supplied level.</summary>
+        public static bool IsActive { get; private set; }
+
+        /// <summary>Gets the absolute path to the level file being run, or <see langword="null"/> when inactive.</summary>
+        public static string LevelPath { get; private set; }
+
+        /// <summary>
+        /// Marks this process as a custom level run for the given file.
+        /// </summary>
+        /// <param name="levelPath">Absolute path to the level XML file.</param>
+        public static void Activate(string levelPath)
+        {
+            LevelPath = levelPath;
+            IsActive = !string.IsNullOrWhiteSpace(levelPath);
+        }
+
+        /// <summary>Clears custom level state.</summary>
+        public static void Clear()
+        {
+            LevelPath = null;
+            IsActive = false;
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/CustomLevelWatcher.cs
+++ b/CutTheRopeDX/GameMain/CustomLevelWatcher.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// Watches the externally supplied level file and reports debounced changes to the game loop.
+    /// </summary>
+    internal sealed class CustomLevelWatcher : IDisposable
+    {
+        /// <summary>
+        /// Starts watching a level file for changes.
+        /// </summary>
+        /// <param name="levelPath">Absolute path to the level file.</param>
+        /// <param name="quietPeriod">How long the file must be idle before a change is reported.</param>
+        public CustomLevelWatcher(string levelPath, TimeSpan quietPeriod)
+        {
+            gate = new PendingChangeGate(quietPeriod);
+
+            string directory = Path.GetDirectoryName(levelPath);
+            string fileName = Path.GetFileName(levelPath);
+            if (string.IsNullOrEmpty(directory) || string.IsNullOrEmpty(fileName))
+            {
+                return;
+            }
+
+            watcher = new FileSystemWatcher(directory, fileName)
+            {
+                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size | NotifyFilters.FileName
+            };
+            watcher.Changed += OnFileEvent;
+            watcher.Created += OnFileEvent;
+            watcher.Renamed += OnFileEvent;
+            watcher.EnableRaisingEvents = true;
+        }
+
+        /// <summary>
+        /// Takes a pending file change if the file has been quiet long enough.
+        /// </summary>
+        /// <param name="nowUtc">Current UTC time.</param>
+        /// <returns><see langword="true"/> when the level should be reloaded; otherwise <see langword="false"/>.</returns>
+        public bool TryConsumeChange(DateTime nowUtc)
+        {
+            return gate.TryConsume(nowUtc);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (watcher == null)
+            {
+                return;
+            }
+
+            watcher.EnableRaisingEvents = false;
+            watcher.Changed -= OnFileEvent;
+            watcher.Created -= OnFileEvent;
+            watcher.Renamed -= OnFileEvent;
+            watcher.Dispose();
+            watcher = null;
+        }
+
+        /// <summary>
+        /// Records a file system event. Runs on a threadpool thread, so it touches no engine state.
+        /// </summary>
+        /// <param name="sender">Event source.</param>
+        /// <param name="e">Event data.</param>
+        private void OnFileEvent(object sender, FileSystemEventArgs e)
+        {
+            gate.NotifyChanged(DateTime.UtcNow);
+        }
+
+        /// <summary>Debounces the raw file system events.</summary>
+        private readonly PendingChangeGate gate;
+
+        /// <summary>Underlying file system watcher, or <see langword="null"/> when the path could not be watched.</summary>
+        private FileSystemWatcher watcher;
+    }
+}

--- a/CutTheRopeDX/GameMain/GameController.cs
+++ b/CutTheRopeDX/GameMain/GameController.cs
@@ -55,7 +55,9 @@ namespace CutTheRopeDX.GameMain
                 {
                     LevelStart();
                 }
-                scene.animateRestartDim = false;
+                // Flash the restart dim, matching what the restart button does, so an
+                // external edit reads as a deliberate restart rather than a glitch.
+                scene.animateRestartDim = true;
                 scene.Reload();
                 SetPaused(false);
                 return;

--- a/CutTheRopeDX/GameMain/GameController.cs
+++ b/CutTheRopeDX/GameMain/GameController.cs
@@ -299,7 +299,7 @@ namespace CutTheRopeDX.GameMain
             int scoreForPackLevel = CTRPreferences.GetScoreForPackLevel(box, pack, level);
             int starsForPackLevel = CTRPreferences.GetStarsForPackLevel(box, pack, level);
             boxOpenClose.shouldShowImprovedResult = false;
-            if (gameScene.score > scoreForPackLevel)
+            if (LevelProgressPersistence.ShouldPersist(CustomLevelSession.IsActive, gameScene.score, scoreForPackLevel))
             {
                 CTRPreferences.SetScoreForPackLevel(box, gameScene.score, pack, level);
                 if (scoreForPackLevel > 0)
@@ -307,7 +307,7 @@ namespace CutTheRopeDX.GameMain
                     boxOpenClose.shouldShowImprovedResult = true;
                 }
             }
-            if (gameScene.starsCollected > starsForPackLevel)
+            if (LevelProgressPersistence.ShouldPersist(CustomLevelSession.IsActive, gameScene.starsCollected, starsForPackLevel))
             {
                 CTRPreferences.SetStarsForPackLevel(box, gameScene.starsCollected, pack, level);
                 if (starsForPackLevel > 0)
@@ -337,7 +337,10 @@ namespace CutTheRopeDX.GameMain
             CTRRootController ctrRoot = (CTRRootController)Application.SharedRootController();
             Game1.RPC.SetLevelPresence(ctrRoot.GetPack(), ctrRoot.GetLevel(), gameScene.starsCollected, true, gameScene.levelName, gameScene.score, (int)gameScene.time);
 
-            UnlockNextLevel();
+            if (!CustomLevelSession.IsActive)
+            {
+                UnlockNextLevel();
+            }
         }
 
         /// <summary>

--- a/CutTheRopeDX/GameMain/GameController.cs
+++ b/CutTheRopeDX/GameMain/GameController.cs
@@ -94,11 +94,15 @@ namespace CutTheRopeDX.GameMain
             VBox vBox = new VBox().InitWithOffsetAlignWidth(5, 2, SCREEN_WIDTH);
             Button c = MenuController.CreateButtonWithTextIDDelegate(Application.GetString("CONTINUE"), GameControllerButtonId.Continue, this);
             _ = vBox.AddChild(c);
-            Button c2 = MenuController.CreateButtonWithTextIDDelegate(Application.GetString("SKIP_LEVEL"), GameControllerButtonId.SkipLevel, this);
-            _ = vBox.AddChild(c2);
-            Button c3 = MenuController.CreateButtonWithTextIDDelegate(Application.GetString("LEVEL_SELECT"), GameControllerButtonId.LevelSelect, this);
-            _ = vBox.AddChild(c3);
-            Button c4 = MenuController.CreateButtonWithTextIDDelegate(Application.GetString("MAIN_MENU"), GameControllerButtonId.MainMenu, this);
+            if (!CustomLevelSession.IsActive)
+            {
+                Button c2 = MenuController.CreateButtonWithTextIDDelegate(Application.GetString("SKIP_LEVEL"), GameControllerButtonId.SkipLevel, this);
+                _ = vBox.AddChild(c2);
+                Button c3 = MenuController.CreateButtonWithTextIDDelegate(Application.GetString("LEVEL_SELECT"), GameControllerButtonId.LevelSelect, this);
+                _ = vBox.AddChild(c3);
+            }
+            string exitLabel = CustomLevelSession.IsActive ? "QUIT_BUTTON" : "MAIN_MENU";
+            Button c4 = MenuController.CreateButtonWithTextIDDelegate(Application.GetString(exitLabel), GameControllerButtonId.MainMenu, this);
             _ = vBox.AddChild(c4);
             vBox.anchor = vBox.parentAnchor = 10;
             ToggleButton toggleButton = MenuController.CreateAudioButtonWithQuadDelegateIDiconOffset(3, this, GameControllerButtonId.ToggleMusic);
@@ -437,6 +441,12 @@ namespace CutTheRopeDX.GameMain
                     CTRRootController.LogEvent("IM_LEVEL_SELECT_PRESSED");
                     return;
                 case var id when id == GameControllerButtonId.MainMenu:
+                    if (CustomLevelSession.IsActive)
+                    {
+                        CTRSoundMgr.StopAll();
+                        Global.XnaGame.Exit();
+                        return;
+                    }
                     exitCode = 0;
                     CTRSoundMgr.StopAll();
                     LevelQuit();

--- a/CutTheRopeDX/GameMain/GameController.cs
+++ b/CutTheRopeDX/GameMain/GameController.cs
@@ -26,6 +26,45 @@ namespace CutTheRopeDX.GameMain
                 OnButtonPressed(GameControllerButtonId.Restart);
             }
             base.Update(t);
+
+            if (levelWatcher != null && levelWatcher.TryConsumeChange(DateTime.UtcNow))
+            {
+                ApplyCustomLevelChange();
+            }
+        }
+
+        /// <summary>
+        /// Applies an external edit to the custom level, reloading in place when possible.
+        /// </summary>
+        private void ApplyCustomLevelChange()
+        {
+            if (!CustomLevelFile.TryLoad(CustomLevelSession.LevelPath, out System.Xml.Linq.XElement map, out string error))
+            {
+                Console.Error.WriteLine(error);
+                return;
+            }
+
+            CTRRootController root = (CTRRootController)Application.SharedRootController();
+            string[] required = LevelResourceScanner.GetRequiredResources(map);
+            CustomLevelReloadKind kind = CustomLevelReloadDecision.Decide(required, root.GetSessionResources());
+
+            if (kind == CustomLevelReloadKind.Instant)
+            {
+                GameScene scene = (GameScene)GetView(0).GetChild(0);
+                if (!scene.IsEnabled())
+                {
+                    LevelStart();
+                }
+                scene.animateRestartDim = false;
+                scene.Reload();
+                SetPaused(false);
+                return;
+            }
+
+            root.SetMap(map);
+            exitCode = EXIT_CODE_CUSTOM_RELOAD;
+            CTRSoundMgr.StopAll();
+            Deactivate();
         }
 
         /// <summary>
@@ -48,6 +87,24 @@ namespace CutTheRopeDX.GameMain
             PlayMusic();
             InitGameView();
             ShowView(0);
+
+            if (CustomLevelSession.IsActive && levelWatcher == null)
+            {
+                levelWatcher = new CustomLevelWatcher(
+                    CustomLevelSession.LevelPath,
+                    TimeSpan.FromMilliseconds(100));
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                levelWatcher?.Dispose();
+                levelWatcher = null;
+            }
+            base.Dispose(disposing);
         }
 
         /// <summary>
@@ -885,6 +942,12 @@ namespace CutTheRopeDX.GameMain
 
         /// <summary>Exit code for returning to level select and advancing to the next pack.</summary>
         public const int EXIT_CODE_FROM_PAUSE_MENU_LEVEL_SELECT_NEXT_PACK = 2;
+
+        /// <summary>Exit code: reload the custom level through the loading screen.</summary>
+        public const int EXIT_CODE_CUSTOM_RELOAD = 3;
+
+        /// <summary>Watches the custom level file for external edits, or <see langword="null"/> in normal play.</summary>
+        private CustomLevelWatcher levelWatcher;
 
         /// <summary>Whether gameplay is currently paused.</summary>
         private bool isGamePaused;

--- a/CutTheRopeDX/GameMain/GameScene.Init.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Init.cs
@@ -103,6 +103,22 @@ namespace CutTheRopeDX.GameMain
                 XmlLoaderFinishedWithfromwithSuccess(ContentPaths.LoadXml("mappicker://reload"), "mappicker://reload", true);
                 return;
             }
+
+            if (CustomLevelSession.IsActive)
+            {
+                string customPath = CustomLevelSession.LevelPath;
+                if (CustomLevelFile.TryLoad(customPath, out System.Xml.Linq.XElement customMap, out string error))
+                {
+                    XmlLoaderFinishedWithfromwithSuccess(customMap, customPath, true);
+                }
+                else
+                {
+                    System.Console.Error.WriteLine(error);
+                }
+
+                return;
+            }
+
             int pack = cTRRootController.GetPack();
             int level = cTRRootController.GetLevel();
             string mapPath = Path.Combine(ContentPaths.MapsDirectory, LevelsList.LEVEL_NAMES[pack, level]);

--- a/CutTheRopeDX/GameMain/GameScene.Show.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Show.cs
@@ -80,30 +80,40 @@ namespace CutTheRopeDX.GameMain
             ropeAtOnceTimer = 0f;
             dd.CallObjectSelectorParamafterDelay(new DelayedDispatcher.DispatchFunc(Selector_doCandyBlink), null, 1);
             string packAndLevelNumbers = (cTRRootController.GetPack() + 1).ToString(CultureInfo.InvariantCulture) + " - " + (cTRRootController.GetLevel() + 1).ToString(CultureInfo.InvariantCulture);
-            bool useCustomLevelName = levelName != null && Application.GetString(levelName) != string.Empty;
-            Text text = Text.CreateWithFontandString(Resources.Fnt.BigFont, useCustomLevelName ? Application.GetString(levelName) : packAndLevelNumbers);
-            Text text2 = Text.CreateWithFontandString(Resources.Fnt.BigFont, useCustomLevelName ? Application.GetString("LEVEL") + " " + packAndLevelNumbers : Application.GetString("LEVEL"));
-            text.anchor = 33;
-            text2.anchor = 33;
-            text2.parentAnchor = 9;
-            text.SetName("levelLabel");
-            text.x = 15f + Canvas.xOffsetScaled;
-            bool isChinese = LanguageHelper.IsCurrentAny(Language.LANGZH, Language.LANGZHTW);
-            text.y = isChinese ? SCREEN_HEIGHT : SCREEN_HEIGHT + 15f; // the box and level number or level name in game
-            text2.y = isChinese ? 3f : 30f; // the "Level" label in game
-            text2.rotationCenterX -= text2.width / 2f;
-            text2.scaleX = text2.scaleY = 0.7f;
-            _ = text.AddChild(text2);
-            Timeline timeline6 = new Timeline().InitWithMaxKeyFramesOnTrack(5);
-            timeline6.AddKeyFrame(KeyFrame.MakeColor(RGBAColor.transparentRGBA, KeyFrame.TransitionType.FRAME_TRANSITION_LINEAR, 0));
-            timeline6.AddKeyFrame(KeyFrame.MakeColor(RGBAColor.transparentRGBA, KeyFrame.TransitionType.FRAME_TRANSITION_LINEAR, 0.5f));
-            timeline6.AddKeyFrame(KeyFrame.MakeColor(RGBAColor.solidOpaqueRGBA, KeyFrame.TransitionType.FRAME_TRANSITION_LINEAR, 0.5f));
-            timeline6.AddKeyFrame(KeyFrame.MakeColor(RGBAColor.solidOpaqueRGBA, KeyFrame.TransitionType.FRAME_TRANSITION_LINEAR, 1));
-            timeline6.AddKeyFrame(KeyFrame.MakeColor(RGBAColor.transparentRGBA, KeyFrame.TransitionType.FRAME_TRANSITION_LINEAR, 0.5f));
-            text.AddTimelinewithID(timeline6, 0);
-            text.PlayTimeline(0);
-            timeline6.delegateTimelineDelegate = staticAniPool;
-            _ = staticAniPool.AddChild(text);
+            LevelLabelText levelLabel = LevelLabel.Resolve(
+                CustomLevelSession.IsActive,
+                ResolveLevelDisplayName(),
+                Application.GetString("LEVEL"),
+                packAndLevelNumbers);
+            if (levelLabel.Primary != null)
+            {
+                Text text = Text.CreateWithFontandString(Resources.Fnt.BigFont, levelLabel.Primary);
+                text.anchor = 33;
+                text.SetName("levelLabel");
+                text.x = 15f + Canvas.xOffsetScaled;
+                bool isChinese = LanguageHelper.IsCurrentAny(Language.LANGZH, Language.LANGZHTW);
+                text.y = isChinese ? SCREEN_HEIGHT : SCREEN_HEIGHT + 15f; // the box and level number or level name in game
+                if (levelLabel.Secondary != null)
+                {
+                    Text text2 = Text.CreateWithFontandString(Resources.Fnt.BigFont, levelLabel.Secondary);
+                    text2.anchor = 33;
+                    text2.parentAnchor = 9;
+                    text2.y = isChinese ? 3f : 30f; // the "Level" label in game
+                    text2.rotationCenterX -= text2.width / 2f;
+                    text2.scaleX = text2.scaleY = 0.7f;
+                    _ = text.AddChild(text2);
+                }
+                Timeline timeline6 = new Timeline().InitWithMaxKeyFramesOnTrack(5);
+                timeline6.AddKeyFrame(KeyFrame.MakeColor(RGBAColor.transparentRGBA, KeyFrame.TransitionType.FRAME_TRANSITION_LINEAR, 0));
+                timeline6.AddKeyFrame(KeyFrame.MakeColor(RGBAColor.transparentRGBA, KeyFrame.TransitionType.FRAME_TRANSITION_LINEAR, 0.5f));
+                timeline6.AddKeyFrame(KeyFrame.MakeColor(RGBAColor.solidOpaqueRGBA, KeyFrame.TransitionType.FRAME_TRANSITION_LINEAR, 0.5f));
+                timeline6.AddKeyFrame(KeyFrame.MakeColor(RGBAColor.solidOpaqueRGBA, KeyFrame.TransitionType.FRAME_TRANSITION_LINEAR, 1));
+                timeline6.AddKeyFrame(KeyFrame.MakeColor(RGBAColor.transparentRGBA, KeyFrame.TransitionType.FRAME_TRANSITION_LINEAR, 0.5f));
+                text.AddTimelinewithID(timeline6, 0);
+                text.PlayTimeline(0);
+                timeline6.delegateTimelineDelegate = staticAniPool;
+                _ = staticAniPool.AddChild(text);
+            }
             for (int m = 0; m < 5; m++)
             {
                 dragging[m] = false;
@@ -116,6 +126,19 @@ namespace CutTheRopeDX.GameMain
             }
             Global.MouseCursor.ReleaseButtons();
             CTRRootController.LogEvent("IG_SHOWN");
+        }
+
+        /// <summary>
+        /// Resolves the level's display name from its <c>levelName</c> attribute.
+        /// </summary>
+        /// <remarks>
+        /// Shipped packs use <c>levelName</c> as a localization key; hand-authored levels have no
+        /// entry in the string tables and fall through <see cref="Application.GetString"/> verbatim.
+        /// </remarks>
+        /// <returns>The name to display, or <see langword="null"/> when the level has none.</returns>
+        private string ResolveLevelDisplayName()
+        {
+            return string.IsNullOrWhiteSpace(levelName) ? null : Application.GetString(levelName);
         }
 
         /// <summary>

--- a/CutTheRopeDX/GameMain/LevelLabel.cs
+++ b/CutTheRopeDX/GameMain/LevelLabel.cs
@@ -1,0 +1,40 @@
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// Text for the in-game level label shown when a level starts.
+    /// </summary>
+    /// <param name="Primary">Large upper line, or <see langword="null"/> when no label should be shown.</param>
+    /// <param name="Secondary">Small lower line, or <see langword="null"/> when only the primary line applies.</param>
+    internal readonly record struct LevelLabelText(string Primary, string Secondary);
+
+    /// <summary>
+    /// Decides which lines the in-game level label shows. Performs no localization lookups.
+    /// </summary>
+    internal static class LevelLabel
+    {
+        /// <summary>
+        /// Builds the label lines for a level start.
+        /// </summary>
+        /// <param name="isCustomLevel">Whether a custom level is being playtested.</param>
+        /// <param name="displayName">Resolved level name, or <see langword="null"/>/empty when the level has none.</param>
+        /// <param name="levelWord">Localized word for "Level".</param>
+        /// <param name="packAndLevelNumbers">Pack and level numbers, such as <c>1 - 1</c>.</param>
+        /// <returns>The lines to render.</returns>
+        public static LevelLabelText Resolve(
+            bool isCustomLevel,
+            string displayName,
+            string levelWord,
+            string packAndLevelNumbers)
+        {
+            bool hasName = !string.IsNullOrWhiteSpace(displayName);
+
+            // Playtest runs have no meaningful pack or level number, so the numbering is dropped
+            // entirely and an unnamed level shows no label at all.
+            return isCustomLevel
+                ? hasName ? new LevelLabelText(displayName, null) : new LevelLabelText(null, null)
+                : hasName
+                    ? new LevelLabelText(displayName, levelWord + " " + packAndLevelNumbers)
+                    : new LevelLabelText(packAndLevelNumbers, levelWord);
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/LevelProgressPersistence.cs
+++ b/CutTheRopeDX/GameMain/LevelProgressPersistence.cs
@@ -1,0 +1,20 @@
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// Decides whether a completed level's result should be written to saved progress.
+    /// </summary>
+    internal static class LevelProgressPersistence
+    {
+        /// <summary>
+        /// Determines whether a new score or star count should replace the stored one.
+        /// </summary>
+        /// <param name="customLevelActive">Whether this process is running an externally supplied level.</param>
+        /// <param name="newValue">Score or star count achieved in the completed level.</param>
+        /// <param name="storedValue">Score or star count currently saved for the level.</param>
+        /// <returns><see langword="true"/> when the value should be persisted; otherwise <see langword="false"/>.</returns>
+        public static bool ShouldPersist(bool customLevelActive, int newValue, int storedValue)
+        {
+            return !customLevelActive && newValue > storedValue;
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadTutorials.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadTutorials.cs
@@ -32,9 +32,7 @@ namespace CutTheRopeDX.GameMain
                 tutorialText.special = ParseIntOrZero(xmlNode.Attribute("special")?.Value);
                 tutorialText.SetAlignment(2);
                 string textKey = xmlNode.Attribute("text")?.Value ?? string.Empty;
-                string newString = Helpers.LocalizationManager.HasString(textKey)
-                    ? Helpers.LocalizationManager.GetString(textKey)
-                    : textKey;
+                string newString = Helpers.LocalizationManager.GetString(textKey);
                 tutorialText.SetStringandWidth(newString, (int)(ParseIntOrZero(xmlNode.Attribute("width")?.Value) * scale));
                 tutorialText.color = RGBAColor.transparentRGBA;
                 Timeline timeline3 = new Timeline().InitWithMaxKeyFramesOnTrack(4);

--- a/CutTheRopeDX/GameMain/PendingChangeGate.cs
+++ b/CutTheRopeDX/GameMain/PendingChangeGate.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// Collapses a burst of change notifications into a single pending event, released once the source falls quiet.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="NotifyChanged"/> is safe to call from a background thread; <see cref="TryConsume"/> is
+    /// expected to be called from the game loop.
+    /// </remarks>
+    /// <param name="quietPeriod">How long the source must be idle before a change is released.</param>
+    internal sealed class PendingChangeGate(TimeSpan quietPeriod)
+    {
+        /// <summary>
+        /// Records that the watched source changed.
+        /// </summary>
+        /// <param name="nowUtc">Current UTC time.</param>
+        public void NotifyChanged(DateTime nowUtc)
+        {
+            lock (sync)
+            {
+                pending = true;
+                lastChangeUtc = nowUtc;
+            }
+        }
+
+        /// <summary>
+        /// Takes the pending change if the source has been quiet long enough.
+        /// </summary>
+        /// <param name="nowUtc">Current UTC time.</param>
+        /// <returns><see langword="true"/> when a change was released; otherwise <see langword="false"/>.</returns>
+        public bool TryConsume(DateTime nowUtc)
+        {
+            lock (sync)
+            {
+                if (!pending || nowUtc - lastChangeUtc < quietPeriod)
+                {
+                    return false;
+                }
+
+                pending = false;
+                return true;
+            }
+        }
+
+        /// <summary>Guards <see cref="pending"/> and <see cref="lastChangeUtc"/> across threads.</summary>
+        private readonly object sync = new();
+
+        /// <summary>Whether a change is waiting to be released.</summary>
+        private bool pending;
+
+        /// <summary>UTC timestamp of the most recent change notification.</summary>
+        private DateTime lastChangeUtc;
+    }
+}

--- a/CutTheRopeDX/GameMain/PendingChangeGate.cs
+++ b/CutTheRopeDX/GameMain/PendingChangeGate.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace CutTheRopeDX.GameMain
 {
@@ -45,7 +46,7 @@ namespace CutTheRopeDX.GameMain
         }
 
         /// <summary>Guards <see cref="pending"/> and <see cref="lastChangeUtc"/> across threads.</summary>
-        private readonly object sync = new();
+        private readonly Lock sync = new();
 
         /// <summary>Whether a change is waiting to be released.</summary>
         private bool pending;

--- a/CutTheRopeDX/Helpers/LocalizationManager.cs
+++ b/CutTheRopeDX/Helpers/LocalizationManager.cs
@@ -29,7 +29,12 @@ namespace CutTheRopeDX.Helpers
         /// </summary>
         /// <param name="key">The string key (e.g., <c>PLAY</c>, <c>OPTIONS</c>)</param>
         /// <param name="languageCode">The language code (e.g., <c>en</c>, <c>ru</c>, <c>de</c>, <c>fr</c>)</param>
-        /// <returns>The localized string, or empty string if not found.</returns>
+        /// <returns>
+        /// The localized string, or <paramref name="key"/> itself when it is absent from both the
+        /// requested language and English. Level and tutorial text authored in map XML is passed
+        /// through this method, so an unrecognized key is treated as literal text rather than
+        /// silently disappearing. Use <see cref="HasString"/> to test for a key's existence.
+        /// </returns>
         public static string GetString(string key, string languageCode)
         {
             if (string.IsNullOrEmpty(key))
@@ -53,14 +58,14 @@ namespace CutTheRopeDX.Helpers
                 }
             }
 
-            return string.Empty;
+            return key;
         }
 
         /// <summary>
         /// Gets a localized string for the given key using the current language.
         /// </summary>
         /// <param name="key">The string key (e.g., "PLAY", "OPTIONS")</param>
-        /// <returns>The localized string, or empty string if not found.</returns>
+        /// <returns>The localized string, or <paramref name="key"/> itself if not found.</returns>
         public static string GetString(string key)
         {
             string languageCode = LanguageHelper.CurrentCode;

--- a/CutTheRopeDX/Helpers/RPCHelpers.cs
+++ b/CutTheRopeDX/Helpers/RPCHelpers.cs
@@ -161,7 +161,7 @@ namespace CutTheRopeDX.Helpers
                 }
             }
 
-            bool useCustomLevelName = levelName != null && Application.GetString(levelName) != string.Empty;
+            bool useCustomLevelName = !string.IsNullOrWhiteSpace(levelName);
 
             client.SetActivity(
                 details: useCustomLevelName ? $"{Application.GetString($"BOX{pack + 1}_LABEL", forceEnglish: true)}: {Application.GetString(levelName, forceEnglish: true)}" : $"{Application.GetString($"BOX{pack + 1}_LABEL", forceEnglish: true)}: {Application.GetString($"LEVEL", forceEnglish: true)} {pack + 1}-{level + 1}",

--- a/CutTheRopeDX/Program.cs
+++ b/CutTheRopeDX/Program.cs
@@ -1,4 +1,28 @@
+using System;
+using System.Xml.Linq;
+
 using CutTheRopeDX;
+using CutTheRopeDX.GameMain;
+
+CustomLevelCommandLineResult cli = CustomLevelCommandLine.Parse(args);
+
+if (cli.IsCustomLevel)
+{
+    if (cli.ErrorMessage != null)
+    {
+        Console.Error.WriteLine(cli.ErrorMessage);
+        return 1;
+    }
+
+    if (!CustomLevelFile.TryLoad(cli.LevelPath, out XElement _, out string loadError))
+    {
+        Console.Error.WriteLine(loadError);
+        return 1;
+    }
+
+    CustomLevelSession.Activate(cli.LevelPath);
+}
 
 using Game1 game = new();
 game.Run();
+return 0;

--- a/README.md
+++ b/README.md
@@ -118,3 +118,44 @@ To test the game during the development process, follow these steps:
     > A native AOT binary built on Linux is only guaranteed to run on the same or newer Linux distribution version.
 
     If you encounter issues with native AOT, you can try removing the `-p:PublishAot=true` flag.
+
+4. To run the unit tests:
+
+    ```bash
+    dotnet test CutTheRopeDX.Tests/CutTheRopeDX.Tests.csproj -p:ExcludeMacOSTarget=true
+    ```
+
+    > Note:  
+    > On macOS the game project also targets `net10.0-macos`, which requires the `macos`
+    > workload. The tests only need the portable target, so `-p:ExcludeMacOSTarget=true`
+    > drops the macOS target and avoids that requirement. On Windows and Linux the flag
+    > has no effect and can be omitted.
+
+## Running a custom level
+
+_Cut the Rope: DX_ can launch straight into a level XML file instead of the normal game, which is intended for level editors and other external tools.
+
+```bash
+CutTheRopeDX --level <path-to-level.xml>
+```
+
+The path may be absolute or relative, and the file does not need to live under the content directory.
+
+**Behaviour**
+
+- The splash screen and menu are skipped; the level loads and plays immediately.
+- The pack is fixed at `0`, used only to resolve the background and music.
+- No scores, stars, or unlocks are written. A custom run never touches saved progress.
+- The pause menu offers **Continue**, **Quit**, and the sound and music toggles.
+- The result screen offers **Replay** only.
+
+**Exit codes**
+
+- `0` on normal exit.
+- Nonzero when the level file is missing, unreadable, or malformed. The reason is printed to stderr and no window is created.
+
+**Hot reloading**
+
+Rewriting the level file while the game is running reloads it automatically. If the edited level needs only resources that are already loaded, it restarts in place; otherwise it reloads through the loading screen.
+
+A malformed file is reported on stderr and leaves the running level untouched, so a partial write will not crash the game. Even so, writers should write atomically — write to a temp file, then move it over the target — so the game never reads a half-written file.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ CutTheRopeDX --level <path-to-level.xml>
 
 The path may be absolute or relative, and the file does not need to live under the content directory.
 
+You can also drag an `.xml` level file onto the executable — a bare `.xml` argument is treated the same as `--level <path>`. If both are given, `--level` wins.
+
 ### Behavior
 
 - The splash screen and menu are skipped; the level loads and plays immediately.

--- a/README.md
+++ b/README.md
@@ -125,12 +125,6 @@ To test the game during the development process, follow these steps:
     dotnet test CutTheRopeDX.Tests/CutTheRopeDX.Tests.csproj -p:ExcludeMacOSTarget=true
     ```
 
-    > Note:  
-    > On macOS the game project also targets `net10.0-macos`, which requires the `macos`
-    > workload. The tests only need the portable target, so `-p:ExcludeMacOSTarget=true`
-    > drops the macOS target and avoids that requirement. On Windows and Linux the flag
-    > has no effect and can be omitted.
-
 ## Running a custom level
 
 _Cut the Rope: DX_ can launch straight into a level XML file instead of the normal game, which is intended for level editors and other external tools.
@@ -141,21 +135,20 @@ CutTheRopeDX --level <path-to-level.xml>
 
 The path may be absolute or relative, and the file does not need to live under the content directory.
 
-**Behaviour**
+### Behavior
 
 - The splash screen and menu are skipped; the level loads and plays immediately.
-- The pack is fixed at `0`, used only to resolve the background and music.
 - No scores, stars, or unlocks are written. A custom run never touches saved progress.
 - The pause menu offers **Continue**, **Quit**, and the sound and music toggles.
 - The result screen offers **Replay** only.
 
-**Exit codes**
+### Exit codes
 
 - `0` on normal exit.
 - Nonzero when the level file is missing, unreadable, or malformed. The reason is printed to stderr and no window is created.
 
-**Hot reloading**
+### Hot reloading
 
 Rewriting the level file while the game is running reloads it automatically. If the edited level needs only resources that are already loaded, it restarts in place; otherwise it reloads through the loading screen.
 
-A malformed file is reported on stderr and leaves the running level untouched, so a partial write will not crash the game. Even so, writers should write atomically — write to a temp file, then move it over the target — so the game never reads a half-written file.
+A malformed file is reported on stderr and leaves the running level untouched, so a partial write will not crash the game. Even so, writers should write atomically—write to a temp file, then move it over the target—so the game never reads a half-written file.


### PR DESCRIPTION
## Description

Allows Cut the Rope: DX to be run from command line interface by running `CutTheRope --level <levelfile.xml>`.

This opens up a quick way to playtest the level without replacing the game's file.