### PR TITLE
enhancement: batch sprite quads and ring-buffer GPU uploads

### DIFF
--- a/CutTheRopeDX.Tests/BlendParamsSnapshotTests.cs
+++ b/CutTheRopeDX.Tests/BlendParamsSnapshotTests.cs
@@ -1,0 +1,61 @@
+using CutTheRopeDX.Desktop;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class BlendParamsSnapshotTests
+    {
+        [Fact]
+        public void DefaultConstructedSnapshotIsDefault()
+        {
+            BlendParams blend = new();
+            Assert.Equal(BlendParams.BlendType.Default, blend.Snapshot());
+        }
+
+        [Fact]
+        public void SrcAlphaInvSrcAlphaMapsToSourceAlphaInverseSourceAlpha()
+        {
+            BlendParams blend = new(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
+            Assert.Equal(BlendParams.BlendType.SourceAlpha_InverseSourceAlpha, blend.Snapshot());
+        }
+
+        [Fact]
+        public void OneInvSrcAlphaMapsToOneInverseSourceAlpha()
+        {
+            BlendParams blend = new(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
+            Assert.Equal(BlendParams.BlendType.One_InverseSourceAlpha, blend.Snapshot());
+        }
+
+        [Fact]
+        public void SrcAlphaOneMapsToSourceAlphaOne()
+        {
+            BlendParams blend = new(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONE);
+            Assert.Equal(BlendParams.BlendType.SourceAlpha_One, blend.Snapshot());
+        }
+
+        [Fact]
+        public void DisabledBlendSnapshotsAsDefault()
+        {
+            BlendParams blend = new(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
+            blend.Disable();
+            Assert.Equal(BlendParams.BlendType.Default, blend.Snapshot());
+        }
+
+        [Fact]
+        public void ReEnabledBlendSnapshotsAsItsFactors()
+        {
+            BlendParams blend = new(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONE);
+            blend.Disable();
+            blend.Enable();
+            Assert.Equal(BlendParams.BlendType.SourceAlpha_One, blend.Snapshot());
+        }
+
+        [Fact]
+        public void UnmappedFactorPairSnapshotsAsUnknown()
+        {
+            BlendParams blend = new(BlendingFactor.GLONE, BlendingFactor.GLONE);
+            Assert.Equal(BlendParams.BlendType.Unknown, blend.Snapshot());
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/QuadBakingTests.cs
+++ b/CutTheRopeDX.Tests/QuadBakingTests.cs
@@ -1,0 +1,89 @@
+using System;
+
+using CutTheRopeDX.Desktop;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class QuadBakingTests
+    {
+        private const float Tolerance = 1e-4f;
+
+        [Fact]
+        public void PremultipliedTintMatchesBasicEffectDiffuseConvention()
+        {
+            Color baked = QuadBaking.BakePremultipliedTint(new Color(200, 100, 50, 128));
+            Assert.Equal(Color.FromNonPremultiplied(200, 100, 50, 128), baked);
+            Assert.Equal(128, baked.A);
+            Assert.Equal((byte)(200 * 128 / 255), baked.R);
+        }
+
+        [Fact]
+        public void OpaqueWhiteTintBakesToWhite()
+        {
+            Assert.Equal(Color.White, QuadBaking.BakePremultipliedTint(Color.White));
+        }
+
+        [Fact]
+        public void ZeroAlphaIsInvisible()
+        {
+            Assert.True(QuadBaking.IsInvisible(new Color(255, 255, 255, 0)));
+            Assert.False(QuadBaking.IsInvisible(new Color(255, 255, 255, 1)));
+        }
+
+        [Fact]
+        public void TranslationBakesIntoPosition()
+        {
+            VertexPositionNormalTexture source = new(new Vector3(1f, 2f, 0f), Vector3.UnitZ, new Vector2(0.25f, 0.75f));
+            Matrix modelView = Matrix.CreateTranslation(10f, 20f, 0f);
+            VertexPositionColorTexture baked = QuadBaking.Bake(source, modelView, Color.White);
+            Assert.Equal(11f, baked.Position.X, Tolerance);
+            Assert.Equal(22f, baked.Position.Y, Tolerance);
+        }
+
+        [Fact]
+        public void RotationBakesIntoPosition()
+        {
+            VertexPositionNormalTexture source = new(new Vector3(1f, 0f, 0f), Vector3.UnitZ, Vector2.Zero);
+            Matrix modelView = Matrix.CreateRotationZ(MathHelper.PiOver2);
+            VertexPositionColorTexture baked = QuadBaking.Bake(source, modelView, Color.White);
+            Assert.Equal(0f, baked.Position.X, Tolerance);
+            Assert.Equal(1f, baked.Position.Y, Tolerance);
+        }
+
+        [Fact]
+        public void ScaleBakesIntoPosition()
+        {
+            VertexPositionNormalTexture source = new(new Vector3(2f, 3f, 0f), Vector3.UnitZ, Vector2.Zero);
+            Matrix modelView = Matrix.CreateScale(2f, 0.5f, 1f);
+            VertexPositionColorTexture baked = QuadBaking.Bake(source, modelView, Color.White);
+            Assert.Equal(4f, baked.Position.X, Tolerance);
+            Assert.Equal(1.5f, baked.Position.Y, Tolerance);
+        }
+
+        [Fact]
+        public void SkewBakesIntoPosition()
+        {
+            float cos45 = MathF.Cos(MathHelper.PiOver4);
+            Matrix skew = Matrix.Identity;
+            skew.M21 = -cos45;
+            skew.M22 = cos45;
+            VertexPositionNormalTexture source = new(new Vector3(0f, 1f, 0f), Vector3.UnitZ, Vector2.Zero);
+            VertexPositionColorTexture baked = QuadBaking.Bake(source, skew, Color.White);
+            Assert.Equal(-cos45, baked.Position.X, Tolerance);
+            Assert.Equal(cos45, baked.Position.Y, Tolerance);
+        }
+
+        [Fact]
+        public void UvCoordinatesPassThroughUnchanged()
+        {
+            VertexPositionNormalTexture source = new(Vector3.Zero, Vector3.UnitZ, new Vector2(0.25f, 0.75f));
+            VertexPositionColorTexture baked = QuadBaking.Bake(source, Matrix.CreateScale(3f), Color.White);
+            Assert.Equal(new Vector2(0.25f, 0.75f), baked.TextureCoordinate);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/QuadBatchTests.cs
+++ b/CutTheRopeDX.Tests/QuadBatchTests.cs
@@ -1,0 +1,111 @@
+using CutTheRopeDX.Desktop;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class QuadBatchTests
+    {
+        private static readonly object TextureA = new();
+        private static readonly object TextureB = new();
+
+        private static QuadBatchKey MakeKey(object texture = null)
+        {
+            return new QuadBatchKey(
+                texture ?? TextureA,
+                BlendParams.BlendType.SourceAlpha_InverseSourceAlpha,
+                new Rectangle(0, 0, 1024, 576),
+                Matrix.CreateOrthographicOffCenter(0f, 1024f, 576f, 0f, -1f, 1f));
+        }
+
+        private static VertexPositionNormalTexture[] MakeQuad(float x)
+        {
+            return
+            [
+                new VertexPositionNormalTexture(new Vector3(x, 0f, 0f), Vector3.UnitZ, new Vector2(0f, 0f)),
+                new VertexPositionNormalTexture(new Vector3(x + 1f, 0f, 0f), Vector3.UnitZ, new Vector2(1f, 0f)),
+                new VertexPositionNormalTexture(new Vector3(x, 1f, 0f), Vector3.UnitZ, new Vector2(0f, 1f)),
+                new VertexPositionNormalTexture(new Vector3(x + 1f, 1f, 0f), Vector3.UnitZ, new Vector2(1f, 1f)),
+            ];
+        }
+
+        [Fact]
+        public void EmptyBatchAcceptsAnyKey()
+        {
+            QuadBatch batch = new();
+            Assert.True(batch.CanAccept(MakeKey()));
+            Assert.True(batch.CanAccept(MakeKey(TextureB)));
+        }
+
+        [Fact]
+        public void NonEmptyBatchAcceptsOnlyMatchingKey()
+        {
+            QuadBatch batch = new();
+            batch.Append(MakeQuad(0f), MakeKey(), Matrix.Identity, Color.White);
+            Assert.True(batch.CanAccept(MakeKey()));
+            Assert.False(batch.CanAccept(MakeKey(TextureB)));
+        }
+
+        [Fact]
+        public void DifferentBlendScissorOrProjectionRejects()
+        {
+            QuadBatch batch = new();
+            QuadBatchKey key = MakeKey();
+            batch.Append(MakeQuad(0f), key, Matrix.Identity, Color.White);
+
+            QuadBatchKey otherBlend = new(TextureA, BlendParams.BlendType.SourceAlpha_One, key.Scissor, key.Projection);
+            QuadBatchKey otherScissor = new(TextureA, key.Blend, new Rectangle(0, 0, 100, 100), key.Projection);
+            QuadBatchKey otherProjection = new(TextureA, key.Blend, key.Scissor, Matrix.Identity);
+            Assert.False(batch.CanAccept(otherBlend));
+            Assert.False(batch.CanAccept(otherScissor));
+            Assert.False(batch.CanAccept(otherProjection));
+        }
+
+        [Fact]
+        public void AppendPreservesSubmissionOrderAndTransforms()
+        {
+            QuadBatch batch = new();
+            batch.Append(MakeQuad(0f), MakeKey(), Matrix.CreateTranslation(100f, 0f, 0f), Color.White);
+            batch.Append(MakeQuad(0f), MakeKey(), Matrix.CreateTranslation(200f, 0f, 0f), Color.White);
+            Assert.Equal(2, batch.QuadCount);
+            Assert.Equal(100f, batch.StagingArray[0].Position.X);
+            Assert.Equal(200f, batch.StagingArray[4].Position.X);
+            Assert.Equal(new Vector2(1f, 1f), batch.StagingArray[7].TextureCoordinate);
+        }
+
+        [Fact]
+        public void AppendBakesPremultipliedTint()
+        {
+            QuadBatch batch = new();
+            Color premultiplied = QuadBaking.BakePremultipliedTint(new Color(255, 255, 255, 128));
+            batch.Append(MakeQuad(0f), MakeKey(), Matrix.Identity, premultiplied);
+            Assert.Equal(premultiplied, batch.StagingArray[0].Color);
+        }
+
+        [Fact]
+        public void BatchIsFullAtCapacity()
+        {
+            QuadBatch batch = new();
+            VertexPositionNormalTexture[] quad = MakeQuad(0f);
+            QuadBatchKey key = MakeKey();
+            for (int i = 0; i < QuadBatch.Capacity; i++)
+            {
+                batch.Append(quad, key, Matrix.Identity, Color.White);
+            }
+            Assert.True(batch.IsFull);
+        }
+
+        [Fact]
+        public void ClearResetsCountAndAcceptsNewKey()
+        {
+            QuadBatch batch = new();
+            batch.Append(MakeQuad(0f), MakeKey(), Matrix.Identity, Color.White);
+            batch.Clear();
+            Assert.True(batch.IsEmpty);
+            Assert.True(batch.CanAccept(MakeKey(TextureB)));
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/QuadIndexPatternTests.cs
+++ b/CutTheRopeDX.Tests/QuadIndexPatternTests.cs
@@ -1,0 +1,32 @@
+using CutTheRopeDX.Desktop;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class QuadIndexPatternTests
+    {
+        [Fact]
+        public void FirstQuadMatchesTriangleStripDecomposition()
+        {
+            short[] indices = QuadIndexPattern.Build(1);
+            // Strip vertices 0,1,2,3 decompose to triangles (0,1,2) and (2,1,3).
+            Assert.Equal(new short[] { 0, 1, 2, 2, 1, 3 }, indices);
+        }
+
+        [Fact]
+        public void SecondQuadIsRebasedByFourVertices()
+        {
+            short[] indices = QuadIndexPattern.Build(2);
+            Assert.Equal(new short[] { 4, 5, 6, 6, 5, 7 }, indices[6..12]);
+        }
+
+        [Fact]
+        public void FullCapacityStaysWithinSixteenBitRange()
+        {
+            short[] indices = QuadIndexPattern.Build(QuadIndexPattern.MaxQuads);
+            Assert.Equal(QuadIndexPattern.MaxQuads * 6, indices.Length);
+            Assert.Equal((short)((QuadIndexPattern.MaxQuads * 4) - 1), indices[^1]);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/RingAllocatorTests.cs
+++ b/CutTheRopeDX.Tests/RingAllocatorTests.cs
@@ -1,0 +1,70 @@
+using CutTheRopeDX.Desktop;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class RingAllocatorTests
+    {
+        [Fact]
+        public void SequentialAllocationsAdvanceContiguously()
+        {
+            RingAllocator ring = new(100);
+            Assert.True(ring.TryAllocate(30, out int a, out bool wrappedA));
+            Assert.True(ring.TryAllocate(30, out int b, out bool wrappedB));
+            Assert.Equal(0, a);
+            Assert.Equal(30, b);
+            Assert.False(wrappedA);
+            Assert.False(wrappedB);
+        }
+
+        [Fact]
+        public void ExactFitDoesNotWrap()
+        {
+            RingAllocator ring = new(100);
+            Assert.True(ring.TryAllocate(60, out _, out _));
+            Assert.True(ring.TryAllocate(40, out int start, out bool wrapped));
+            Assert.Equal(60, start);
+            Assert.False(wrapped);
+        }
+
+        [Fact]
+        public void OverflowWrapsToZeroWithWrapFlag()
+        {
+            RingAllocator ring = new(100);
+            Assert.True(ring.TryAllocate(80, out _, out _));
+            Assert.True(ring.TryAllocate(30, out int start, out bool wrapped));
+            Assert.Equal(0, start);
+            Assert.True(wrapped);
+            Assert.Equal(30, ring.Cursor);
+        }
+
+        [Fact]
+        public void AllocationAfterWrapContinuesFromWrappedRegion()
+        {
+            RingAllocator ring = new(100);
+            Assert.True(ring.TryAllocate(80, out _, out _));
+            Assert.True(ring.TryAllocate(30, out _, out _));
+            Assert.True(ring.TryAllocate(20, out int start, out bool wrapped));
+            Assert.Equal(30, start);
+            Assert.False(wrapped);
+        }
+
+        [Fact]
+        public void RequestLargerThanCapacityFails()
+        {
+            RingAllocator ring = new(100);
+            Assert.False(ring.TryAllocate(101, out _, out _));
+            Assert.Equal(0, ring.Cursor);
+        }
+
+        [Fact]
+        public void FullCapacityRequestSucceeds()
+        {
+            RingAllocator ring = new(100);
+            Assert.True(ring.TryAllocate(100, out int start, out bool wrapped));
+            Assert.Equal(0, start);
+            Assert.False(wrapped);
+        }
+    }
+}

--- a/CutTheRopeDX/Desktop/BlendParams.cs
+++ b/CutTheRopeDX/Desktop/BlendParams.cs
@@ -1,3 +1,5 @@
+using System;
+
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
@@ -50,84 +52,106 @@ namespace CutTheRopeDX.Desktop
         /// </summary>
         public static void ApplyDefault()
         {
-            if (states[0] == null)
-            {
-                states[0] = BlendState.Opaque;
-            }
-            Global.GraphicsDevice.BlendState = states[0];
-            Global.GraphicsDevice.BlendFactor = Color.White;
+            ApplySnapshot(BlendType.Default);
         }
 
         /// <summary>
-        /// Applies the current blend configuration to the graphics device.
+        /// Applies the current blend configuration to the graphics device, skipping the
+        /// device write when the same type was already applied and nothing external
+        /// invalidated the cache.
         /// </summary>
         public void Apply()
         {
-            if (defaultBlending || !enabled)
+            BlendType snapshot = Snapshot();
+            if (snapshot == BlendType.Unknown || snapshot == s_lastApplied)
             {
-                if (lastBlend != BlendType.Default)
-                {
-                    lastBlend = BlendType.Default;
-                    ApplyDefault();
-                    return;
-                }
+                return;
             }
-            else if (sfactor == BlendingFactor.GLSRCALPHA && dfactor == BlendingFactor.GLONEMINUSSRCALPHA)
+            ApplySnapshot(snapshot);
+        }
+
+        /// <summary>
+        /// Computes the effective blend type from this configuration without touching the device.
+        /// </summary>
+        /// <returns>The effective blend type; Unknown for factor pairs with no cached state.</returns>
+        public BlendType Snapshot()
+        {
+            return (defaultBlending || !enabled, sfactor, dfactor) switch
             {
-                if (lastBlend != BlendType.SourceAlpha_InverseSourceAlpha)
-                {
-                    lastBlend = BlendType.SourceAlpha_InverseSourceAlpha;
-                    if (states[(int)lastBlend] == null)
-                    {
-                        BlendState blendState = new()
-                        {
-                            AlphaSourceBlend = Blend.SourceAlpha,
-                            AlphaDestinationBlend = Blend.InverseSourceAlpha
-                        };
-                        blendState.ColorDestinationBlend = blendState.AlphaDestinationBlend;
-                        blendState.ColorSourceBlend = blendState.AlphaSourceBlend;
-                        states[(int)lastBlend] = blendState;
-                    }
-                    Global.GraphicsDevice.BlendState = states[(int)lastBlend];
-                    return;
-                }
-            }
-            else if (sfactor == BlendingFactor.GLONE && dfactor == BlendingFactor.GLONEMINUSSRCALPHA)
+                (true, _, _) => BlendType.Default,
+                (false, BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA) => BlendType.SourceAlpha_InverseSourceAlpha,
+                (false, BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA) => BlendType.One_InverseSourceAlpha,
+                (false, BlendingFactor.GLSRCALPHA, BlendingFactor.GLONE) => BlendType.SourceAlpha_One,
+                _ => BlendType.Unknown
+            };
+        }
+
+        /// <summary>
+        /// Applies the given blend type to the graphics device unconditionally and records it.
+        /// Used by the quad-batch flush, which must not trust the lazy cache.
+        /// </summary>
+        /// <param name="snapshot">The blend type to apply. Unknown is ignored.</param>
+        public static void ApplySnapshot(BlendType snapshot)
+        {
+            if (snapshot == BlendType.Unknown)
             {
-                if (lastBlend != BlendType.One_InverseSourceAlpha)
-                {
-                    lastBlend = BlendType.One_InverseSourceAlpha;
-                    if (states[(int)lastBlend] == null)
-                    {
-                        BlendState blendState2 = new()
-                        {
-                            AlphaSourceBlend = Blend.One,
-                            AlphaDestinationBlend = Blend.InverseSourceAlpha
-                        };
-                        blendState2.ColorDestinationBlend = blendState2.AlphaDestinationBlend;
-                        blendState2.ColorSourceBlend = blendState2.AlphaSourceBlend;
-                        states[(int)lastBlend] = blendState2;
-                    }
-                    Global.GraphicsDevice.BlendState = states[(int)lastBlend];
-                    return;
-                }
+                return;
             }
-            else if (sfactor == BlendingFactor.GLSRCALPHA && dfactor == BlendingFactor.GLONE && lastBlend != BlendType.SourceAlpha_One)
+            Global.GraphicsDevice.BlendState = GetState(snapshot);
+            if (snapshot == BlendType.Default)
             {
-                lastBlend = BlendType.SourceAlpha_One;
-                if (states[(int)lastBlend] == null)
-                {
-                    BlendState blendState3 = new()
-                    {
-                        AlphaSourceBlend = Blend.SourceAlpha,
-                        AlphaDestinationBlend = Blend.One
-                    };
-                    blendState3.ColorDestinationBlend = blendState3.AlphaDestinationBlend;
-                    blendState3.ColorSourceBlend = blendState3.AlphaSourceBlend;
-                    states[(int)lastBlend] = blendState3;
-                }
-                Global.GraphicsDevice.BlendState = states[(int)lastBlend];
+                Global.GraphicsDevice.BlendFactor = Color.White;
             }
+            s_lastApplied = snapshot;
+        }
+
+        /// <summary>
+        /// Marks the cached device blend state as unknown. Call after any code outside this
+        /// class changes GraphicsDevice.BlendState (SpriteBatch.Begin does).
+        /// </summary>
+        public static void InvalidateDeviceCache()
+        {
+            s_lastApplied = BlendType.Unknown;
+        }
+
+        /// <summary>
+        /// Returns the cached BlendState for a blend type, building it on first use.
+        /// </summary>
+        /// <param name="type">The blend type to look up.</param>
+        /// <returns>The cached blend state.</returns>
+        private static BlendState GetState(BlendType type)
+        {
+            int index = (int)type;
+            if (states[index] == null)
+            {
+                states[index] = type switch
+                {
+                    BlendType.Default => BlendState.Opaque,
+                    BlendType.SourceAlpha_InverseSourceAlpha => NewState(Blend.SourceAlpha, Blend.InverseSourceAlpha),
+                    BlendType.One_InverseSourceAlpha => NewState(Blend.One, Blend.InverseSourceAlpha),
+                    BlendType.SourceAlpha_One => NewState(Blend.SourceAlpha, Blend.One),
+                    BlendType.Unknown => throw new InvalidOperationException("Unknown blend snapshots cannot be applied."),
+                    _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+                };
+            }
+            return states[index];
+        }
+
+        /// <summary>
+        /// Builds a blend state with identical color and alpha factors.
+        /// </summary>
+        /// <param name="source">Source blend factor.</param>
+        /// <param name="destination">Destination blend factor.</param>
+        /// <returns>The new blend state.</returns>
+        private static BlendState NewState(Blend source, Blend destination)
+        {
+            return new BlendState
+            {
+                AlphaSourceBlend = source,
+                AlphaDestinationBlend = destination,
+                ColorSourceBlend = source,
+                ColorDestinationBlend = destination
+            };
         }
 
         /// <summary>
@@ -147,9 +171,10 @@ namespace CutTheRopeDX.Desktop
         private static readonly BlendState[] states = new BlendState[4];
 
         /// <summary>
-        /// Tracks the last applied blend mode to avoid redundant state changes.
+        /// The blend type last applied to the graphics device through this class.
+        /// Static because it mirrors global device state, not per-instance state.
         /// </summary>
-        private BlendType lastBlend = BlendType.Unknown;
+        private static BlendType s_lastApplied = BlendType.Unknown;
 
         /// <summary>
         /// Indicates whether the custom blend parameters are enabled.
@@ -174,7 +199,7 @@ namespace CutTheRopeDX.Desktop
         /// <summary>
         /// Identifies the cached blend-state variants supported by the desktop renderer.
         /// </summary>
-        private enum BlendType
+        internal enum BlendType
         {
             /// <summary>
             /// No cached blend state has been applied yet.

--- a/CutTheRopeDX/Desktop/IndexBufferRing.cs
+++ b/CutTheRopeDX/Desktop/IndexBufferRing.cs
@@ -1,0 +1,40 @@
+using Microsoft.Xna.Framework.Graphics;
+
+namespace CutTheRopeDX.Desktop
+{
+    /// <summary>
+    /// A ring-buffered DynamicIndexBuffer for 16-bit indices. Same write discipline as
+    /// <see cref="VertexBufferRing{T}"/>: NoOverwrite at advancing offsets, Discard at zero.
+    /// </summary>
+    /// <param name="capacityIndices">Total index capacity of the ring.</param>
+    internal sealed class IndexBufferRing(int capacityIndices)
+    {
+        /// <summary>
+        /// The underlying GPU buffer to bind for draws.
+        /// </summary>
+        public DynamicIndexBuffer Buffer { get; } = new(Global.GraphicsDevice, IndexElementSize.SixteenBits, capacityIndices, BufferUsage.WriteOnly);
+
+        /// <summary>
+        /// Uploads <paramref name="count"/> indices and returns the start index to draw from.
+        /// </summary>
+        /// <param name="data">Source index data.</param>
+        /// <param name="count">Number of indices to upload.</param>
+        /// <returns>The start index offset, or -1 when the write exceeds the ring's
+        /// total capacity and the caller must use a fallback upload.</returns>
+        public int Write(short[] data, int count)
+        {
+            if (!_allocator.TryAllocate(count, out int start, out _))
+            {
+                return -1;
+            }
+            SetDataOptions options = start == 0 ? SetDataOptions.Discard : SetDataOptions.NoOverwrite;
+            Buffer.SetData(start * sizeof(short), data, 0, count, options);
+            return start;
+        }
+
+        /// <summary>
+        /// Cursor arithmetic for the ring.
+        /// </summary>
+        private readonly RingAllocator _allocator = new(capacityIndices);
+    }
+}

--- a/CutTheRopeDX/Desktop/QuadBaking.cs
+++ b/CutTheRopeDX/Desktop/QuadBaking.cs
@@ -1,0 +1,43 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace CutTheRopeDX.Desktop
+{
+    /// <summary>
+    /// Pure CPU conversion of immediate-mode sprite draws into batchable vertices.
+    /// </summary>
+    internal static class QuadBaking
+    {
+        /// <summary>
+        /// Bakes the renderer tint into a premultiplied vertex color.
+        /// </summary>
+        /// <param name="tint">The renderer's current draw color.</param>
+        /// <returns>The premultiplied vertex color.</returns>
+        public static Color BakePremultipliedTint(Color tint)
+        {
+            return Color.FromNonPremultiplied(tint.R, tint.G, tint.B, tint.A);
+        }
+
+        /// <summary>
+        /// Whether a draw with this tint is skipped entirely.
+        /// </summary>
+        /// <param name="tint">The renderer's current draw color.</param>
+        /// <returns><see langword="true"/> when the draw must be skipped.</returns>
+        public static bool IsInvisible(Color tint)
+        {
+            return tint.A == 0;
+        }
+
+        /// <summary>
+        /// Transforms one sprite vertex by the model-view matrix and attaches the
+        /// premultiplied tint, preserving UV coordinates.
+        /// </summary>
+        public static VertexPositionColorTexture Bake(in VertexPositionNormalTexture source, in Matrix modelView, Color premultipliedTint)
+        {
+            return new VertexPositionColorTexture(
+                Vector3.Transform(source.Position, modelView),
+                premultipliedTint,
+                source.TextureCoordinate);
+        }
+    }
+}

--- a/CutTheRopeDX/Desktop/QuadBatch.cs
+++ b/CutTheRopeDX/Desktop/QuadBatch.cs
@@ -1,0 +1,56 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace CutTheRopeDX.Desktop
+{
+    /// <summary>
+    /// Pure CPU accumulator for compatible sprite quads.
+    /// </summary>
+    internal sealed class QuadBatch
+    {
+        /// <summary>Maximum quads per batch.</summary>
+        public const int Capacity = QuadIndexPattern.MaxQuads;
+
+        /// <summary>Number of quads currently staged.</summary>
+        public int QuadCount { get; private set; }
+
+        /// <summary>Whether no quads are staged.</summary>
+        public bool IsEmpty => QuadCount == 0;
+
+        /// <summary>Whether the batch is at capacity.</summary>
+        public bool IsFull => QuadCount == Capacity;
+
+        /// <summary>The compatibility key of the accumulated batch.</summary>
+        public QuadBatchKey Key { get; private set; }
+
+        /// <summary>The reusable vertex staging array.</summary>
+        public VertexPositionColorTexture[] StagingArray { get; } = new VertexPositionColorTexture[Capacity * 4];
+
+        /// <summary>Whether a quad with the given key may join the current batch.</summary>
+        public bool CanAccept(in QuadBatchKey key)
+        {
+            return QuadCount == 0 || Key.Equals(key);
+        }
+
+        /// <summary>Transforms and stages one four-vertex sprite quad.</summary>
+        public void Append(VertexPositionNormalTexture[] vertices, in QuadBatchKey key, in Matrix modelView, Color premultipliedTint)
+        {
+            if (QuadCount == 0)
+            {
+                Key = key;
+            }
+            int baseIndex = QuadCount * 4;
+            for (int i = 0; i < 4; i++)
+            {
+                StagingArray[baseIndex + i] = QuadBaking.Bake(vertices[i], modelView, premultipliedTint);
+            }
+            QuadCount++;
+        }
+
+        /// <summary>Empties the batch without releasing the staging array.</summary>
+        public void Clear()
+        {
+            QuadCount = 0;
+        }
+    }
+}

--- a/CutTheRopeDX/Desktop/QuadBatchKey.cs
+++ b/CutTheRopeDX/Desktop/QuadBatchKey.cs
@@ -1,0 +1,49 @@
+using System;
+
+using Microsoft.Xna.Framework;
+
+namespace CutTheRopeDX.Desktop
+{
+    /// <summary>
+    /// GPU-visible state that must match for two sprite quads to share a batch.
+    /// </summary>
+    /// <param name="texture">Texture identity, compared by reference.</param>
+    /// <param name="blend">Effective blend snapshot.</param>
+    /// <param name="scissor">Device scissor rectangle.</param>
+    /// <param name="projection">Projection matrix.</param>
+    internal readonly struct QuadBatchKey(object texture, BlendParams.BlendType blend, Rectangle scissor, Matrix projection) : IEquatable<QuadBatchKey>
+    {
+        /// <summary>Texture identity, compared by reference.</summary>
+        public readonly object Texture = texture;
+
+        /// <summary>Effective blend snapshot at submission.</summary>
+        public readonly BlendParams.BlendType Blend = blend;
+
+        /// <summary>Device scissor rectangle at submission.</summary>
+        public readonly Rectangle Scissor = scissor;
+
+        /// <summary>Projection matrix at submission.</summary>
+        public readonly Matrix Projection = projection;
+
+        /// <inheritdoc />
+        public bool Equals(QuadBatchKey other)
+        {
+            return ReferenceEquals(Texture, other.Texture)
+                && Blend == other.Blend
+                && Scissor == other.Scissor
+                && Projection == other.Projection;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            return obj is QuadBatchKey other && Equals(other);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Texture, Blend, Scissor);
+        }
+    }
+}

--- a/CutTheRopeDX/Desktop/QuadBatchKey.cs
+++ b/CutTheRopeDX/Desktop/QuadBatchKey.cs
@@ -43,7 +43,7 @@ namespace CutTheRopeDX.Desktop
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            return HashCode.Combine(Texture, Blend, Scissor);
+            return HashCode.Combine(Texture, Blend, Scissor, Projection);
         }
     }
 }

--- a/CutTheRopeDX/Desktop/QuadIndexPattern.cs
+++ b/CutTheRopeDX/Desktop/QuadIndexPattern.cs
@@ -1,0 +1,39 @@
+namespace CutTheRopeDX.Desktop
+{
+    /// <summary>
+    /// Generates the immutable triangle-list index pattern for batched quads. Each quad's
+    /// four strip-ordered vertices decompose to triangles (0,1,2) and (2,1,3), matching
+    /// what DrawTriangleStrip renders for a four-vertex strip (cull mode is None, so
+    /// winding is irrelevant).
+    /// </summary>
+    internal static class QuadIndexPattern
+    {
+        /// <summary>
+        /// Maximum quads per batch. 2,048 quads use vertex indices up to 8,191,
+        /// comfortably within 16-bit index range.
+        /// </summary>
+        public const int MaxQuads = 2048;
+
+        /// <summary>
+        /// Builds the index pattern for <paramref name="quadCount"/> quads.
+        /// </summary>
+        /// <param name="quadCount">Number of quads to index.</param>
+        /// <returns>Six indices per quad, rebased by four vertices per quad.</returns>
+        public static short[] Build(int quadCount)
+        {
+            short[] indices = new short[quadCount * 6];
+            for (int i = 0; i < quadCount; i++)
+            {
+                int vertex = i * 4;
+                int index = i * 6;
+                indices[index] = (short)vertex;
+                indices[index + 1] = (short)(vertex + 1);
+                indices[index + 2] = (short)(vertex + 2);
+                indices[index + 3] = (short)(vertex + 2);
+                indices[index + 4] = (short)(vertex + 1);
+                indices[index + 5] = (short)(vertex + 3);
+            }
+            return indices;
+        }
+    }
+}

--- a/CutTheRopeDX/Desktop/Renderer.cs
+++ b/CutTheRopeDX/Desktop/Renderer.cs
@@ -80,6 +80,17 @@ namespace CutTheRopeDX.Desktop
                 View = Matrix.Identity
             };
             s_indexRing = new IndexBufferRing(IndexRingCapacity);
+            s_quadIndexBuffer = new IndexBuffer(Global.GraphicsDevice, IndexElementSize.SixteenBits, QuadIndexPattern.MaxQuads * 6, BufferUsage.WriteOnly);
+            s_quadIndexBuffer.SetData(QuadIndexPattern.Build(QuadIndexPattern.MaxQuads));
+            s_quadBatchEffect = new BasicEffect(Global.GraphicsDevice)
+            {
+                VertexColorEnabled = true,
+                TextureEnabled = true,
+                View = Matrix.Identity,
+                World = Matrix.Identity,
+                Alpha = 1f,
+                DiffuseColor = Vector3.One
+            };
         }
 
         /// <summary>
@@ -149,6 +160,7 @@ namespace CutTheRopeDX.Desktop
             {
                 return;
             }
+            FlushQuads();
 
             s_Viewport.X = x;
             s_Viewport.Y = y;
@@ -171,6 +183,7 @@ namespace CutTheRopeDX.Desktop
         /// <returns>The detached render target, or <see langword="null"/> when no render target is active.</returns>
         public static RenderTarget2D DetachRenderTarget()
         {
+            FlushQuads();
             RenderTarget2D renderTarget2D = s_RenderTarget;
             s_RenderTarget = null;
             return renderTarget2D;
@@ -182,6 +195,7 @@ namespace CutTheRopeDX.Desktop
         /// </summary>
         public static void CopyFromRenderTargetToScreen()
         {
+            FlushQuads();
             if (s_RenderTarget != null)
             {
                 Global.GraphicsDevice.Clear(Color.Black);
@@ -365,6 +379,7 @@ namespace CutTheRopeDX.Desktop
         /// <param name="_">OpenGL clear mask (ignored, always clears color buffer).</param>
         public static void Clear(int _)
         {
+            FlushQuads();
             BlendParams.ApplyDefault();
             Global.GraphicsDevice.Clear(s_glClearColor);
         }
@@ -405,6 +420,7 @@ namespace CutTheRopeDX.Desktop
         /// <param name="height">The scissor rectangle height.</param>
         public static void SetScissor(float x, float y, float width, float height)
         {
+            FlushQuads();
             try
             {
                 Rectangle bounds = Global.XnaGame.GraphicsDevice.Viewport.Bounds;
@@ -438,6 +454,7 @@ namespace CutTheRopeDX.Desktop
         /// <param name="vertexCount">The number of vertices from <paramref name="vertices"/> to submit.</param>
         public static void DrawTriangleStrip(VertexPositionColor[] vertices, int vertexCount)
         {
+            FlushQuads();
             if (vertexCount < 3)
             {
                 return;
@@ -471,6 +488,11 @@ namespace CutTheRopeDX.Desktop
         /// <param name="vertexCount">The number of vertices from <paramref name="vertices"/> to submit.</param>
         public static void DrawTriangleStrip(VertexPositionNormalTexture[] vertices, int vertexCount)
         {
+            if (QuadBatchingEnabled && TrySubmitQuad(vertices, vertexCount))
+            {
+                return;
+            }
+            FlushQuads();
             if (vertexCount < 3)
             {
                 return;
@@ -504,6 +526,7 @@ namespace CutTheRopeDX.Desktop
         /// <param name="vertexCount">The number of vertices from <paramref name="vertices"/> to submit.</param>
         public static void DrawTriangleStrip(VertexPositionColorTexture[] vertices, int vertexCount)
         {
+            FlushQuads();
             if (vertexCount < 3)
             {
                 return;
@@ -527,6 +550,7 @@ namespace CutTheRopeDX.Desktop
         /// <param name="indices">The index buffer describing triangle order.</param>
         public static void DrawTriangleList(VertexPositionNormalTexture[] vertices, short[] indices)
         {
+            FlushQuads();
             BasicEffect effect = GetEffect(true, false);
             if (effect.Alpha == 0f)
             {
@@ -548,6 +572,7 @@ namespace CutTheRopeDX.Desktop
         /// <param name="indexCount">The number of indices from <paramref name="indices"/> to submit.</param>
         public static void DrawTriangleList(VertexPositionNormalTexture[] vertices, short[] indices, int indexCount)
         {
+            FlushQuads();
             BasicEffect effect = GetEffect(true, false);
             if (effect.Alpha == 0f)
             {
@@ -569,6 +594,7 @@ namespace CutTheRopeDX.Desktop
         /// <param name="indexCount">The number of indices from <paramref name="indices"/> to submit.</param>
         public static void DrawTriangleList(VertexPositionColorTexture[] vertices, short[] indices, int indexCount)
         {
+            FlushQuads();
             if (indexCount == 0)
             {
                 return;
@@ -601,6 +627,7 @@ namespace CutTheRopeDX.Desktop
         /// <param name="vertexCount">The number of vertices from <paramref name="vertices"/> to submit.</param>
         public static void DrawLineStrip(VertexPositionColor[] vertices, int vertexCount)
         {
+            FlushQuads();
             if (vertexCount < 2)
             {
                 return;
@@ -757,6 +784,89 @@ namespace CutTheRopeDX.Desktop
 
         #endregion
 
+        #region Quad Batching
+
+        /// <summary>
+        /// Establishes a frame boundary and discards stray queued quads from a faulted previous frame.
+        /// </summary>
+        public static void BeginFrame()
+        {
+            s_quadBatch.Clear();
+        }
+
+        /// <summary>
+        /// Flushes remaining queued quads at the end of the frame.
+        /// </summary>
+        public static void EndFrame()
+        {
+            FlushQuads();
+        }
+
+        /// <summary>
+        /// Draws all queued quads as one indexed draw call, reapplying captured state unconditionally.
+        /// </summary>
+        public static void FlushQuads()
+        {
+            if (s_quadBatch.IsEmpty)
+            {
+                return;
+            }
+            QuadBatchKey key = s_quadBatch.Key;
+            BlendParams.ApplySnapshot(key.Blend);
+            Global.GraphicsDevice.RasterizerState = s_rasterizerStateTexture;
+            Global.GraphicsDevice.SamplerStates[0] = SamplerState.LinearClamp;
+            Global.GraphicsDevice.ScissorRectangle = key.Scissor;
+            s_quadBatchEffect.Texture = (Texture2D)key.Texture;
+            s_quadBatchEffect.Projection = key.Projection;
+            int vertexCount = s_quadBatch.QuadCount * 4;
+            VertexBufferRing<VertexPositionColorTexture> ring = GetVertexRing<VertexPositionColorTexture>();
+            int baseVertex = ring.Write(s_quadBatch.StagingArray, vertexCount);
+            Global.GraphicsDevice.SetVertexBuffer(ring.Buffer);
+            Global.GraphicsDevice.Indices = s_quadIndexBuffer;
+            foreach (EffectPass pass in s_quadBatchEffect.CurrentTechnique.Passes)
+            {
+                pass.Apply();
+                Global.GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, baseVertex, 0, s_quadBatch.QuadCount * 2);
+            }
+            Global.GraphicsDevice.SetVertexBuffer(null);
+            Global.GraphicsDevice.Indices = null;
+            s_quadBatch.Clear();
+        }
+
+        /// <summary>
+        /// Attempts to queue a four-vertex textured sprite.
+        /// </summary>
+        private static bool TrySubmitQuad(VertexPositionNormalTexture[] vertices, int vertexCount)
+        {
+            if (vertexCount != 4)
+            {
+                return false;
+            }
+            if (s_Texture == null || s_Texture.xnaTexture_ == null || s_Texture.xnaTexture_.IsDisposed)
+            {
+                return false;
+            }
+            if (QuadBaking.IsInvisible(s_Color))
+            {
+                return true;
+            }
+            BlendParams.BlendType blend = s_Blend.Snapshot();
+            if (blend == BlendParams.BlendType.Unknown)
+            {
+                return false;
+            }
+            QuadBatchKey key = new(s_Texture.xnaTexture_, blend, Global.GraphicsDevice.ScissorRectangle, s_matrixProjection);
+            if (s_quadBatch.IsFull || !s_quadBatch.CanAccept(key))
+            {
+                FlushQuads();
+            }
+            s_quadBatch.Append(vertices, key, s_matrixModelView, QuadBaking.BakePremultipliedTint(s_Color));
+            s_LastVertices_PositionNormalTexture = vertices;
+            return true;
+        }
+
+        #endregion
+
         #region Private Rendering Implementation
 
         /// <summary>
@@ -904,6 +1014,26 @@ namespace CutTheRopeDX.Desktop
         #endregion
 
         #region Static Fields
+
+        /// <summary>
+        /// Whether four-vertex textured sprite draws are batched. Set false to use immediate rendering.
+        /// </summary>
+        public static bool QuadBatchingEnabled;
+
+        /// <summary>
+        /// The accumulating sprite quad batch.
+        /// </summary>
+        private static readonly QuadBatch s_quadBatch = new();
+
+        /// <summary>
+        /// Immutable index buffer holding the full quad index pattern.
+        /// </summary>
+        private static IndexBuffer s_quadIndexBuffer;
+
+        /// <summary>
+        /// Dedicated effect for batch flushes.
+        /// </summary>
+        private static BasicEffect s_quadBatchEffect;
 
         /// <summary>
         /// Holds the off-screen render target used before the final screen blit.

--- a/CutTheRopeDX/Desktop/Renderer.cs
+++ b/CutTheRopeDX/Desktop/Renderer.cs
@@ -1018,7 +1018,7 @@ namespace CutTheRopeDX.Desktop
         /// <summary>
         /// Whether four-vertex textured sprite draws are batched. Set false to use immediate rendering.
         /// </summary>
-        public static bool QuadBatchingEnabled;
+        public static bool QuadBatchingEnabled = true;
 
         /// <summary>
         /// The accumulating sprite quad batch.

--- a/CutTheRopeDX/Desktop/Renderer.cs
+++ b/CutTheRopeDX/Desktop/Renderer.cs
@@ -488,7 +488,7 @@ namespace CutTheRopeDX.Desktop
         /// <param name="vertexCount">The number of vertices from <paramref name="vertices"/> to submit.</param>
         public static void DrawTriangleStrip(VertexPositionNormalTexture[] vertices, int vertexCount)
         {
-            if (QuadBatchingEnabled && TrySubmitQuad(vertices, vertexCount))
+            if (TrySubmitQuad(vertices, vertexCount))
             {
                 return;
             }
@@ -1014,11 +1014,6 @@ namespace CutTheRopeDX.Desktop
         #endregion
 
         #region Static Fields
-
-        /// <summary>
-        /// Whether four-vertex textured sprite draws are batched. Set false to use immediate rendering.
-        /// </summary>
-        public static bool QuadBatchingEnabled = true;
 
         /// <summary>
         /// The accumulating sprite quad batch.

--- a/CutTheRopeDX/Desktop/Renderer.cs
+++ b/CutTheRopeDX/Desktop/Renderer.cs
@@ -79,6 +79,7 @@ namespace CutTheRopeDX.Desktop
                 Texture = null,
                 View = Matrix.Identity
             };
+            s_indexRing = new IndexBufferRing(IndexRingCapacity);
         }
 
         /// <summary>
@@ -187,6 +188,7 @@ namespace CutTheRopeDX.Desktop
                 Global.SpriteBatch.Begin(SpriteSortMode.Deferred, null, null, null, null, null, null);
                 Global.SpriteBatch.Draw(s_RenderTarget, Global.ScreenSizeManager.ScaledViewRect, Color.White);
                 Global.SpriteBatch.End();
+                BlendParams.InvalidateDeviceCache();
             }
         }
 
@@ -789,7 +791,8 @@ namespace CutTheRopeDX.Desktop
         }
 
         /// <summary>
-        /// Uploads vertex data and issues a non-indexed primitive draw call.
+        /// Uploads vertex data through the shared ring and issues a non-indexed primitive draw call.
+        /// Falls back to the legacy grow-and-discard buffer for writes larger than the ring.
         /// </summary>
         /// <typeparam name="T">The vertex type being uploaded.</typeparam>
         /// <param name="primitiveType">The primitive topology to draw.</param>
@@ -798,15 +801,26 @@ namespace CutTheRopeDX.Desktop
         /// <param name="primitiveCount">The number of primitives to render.</param>
         private static void DrawPrimitives<T>(PrimitiveType primitiveType, T[] vertices, int vertexCount, int primitiveCount) where T : struct, IVertexType
         {
-            DynamicVertexBuffer vertexBuffer = GetVertexBuffer<T>(vertexCount);
-            vertexBuffer.SetData(vertices, 0, vertexCount, SetDataOptions.Discard);
-            Global.GraphicsDevice.SetVertexBuffer(vertexBuffer);
-            Global.GraphicsDevice.DrawPrimitives(primitiveType, 0, primitiveCount);
+            VertexBufferRing<T> ring = GetVertexRing<T>();
+            int vertexStart = ring.Write(vertices, vertexCount);
+            if (vertexStart < 0)
+            {
+                DynamicVertexBuffer fallback = GetOversizeVertexBuffer<T>(vertexCount);
+                fallback.SetData(vertices, 0, vertexCount, SetDataOptions.Discard);
+                Global.GraphicsDevice.SetVertexBuffer(fallback);
+                Global.GraphicsDevice.DrawPrimitives(primitiveType, 0, primitiveCount);
+            }
+            else
+            {
+                Global.GraphicsDevice.SetVertexBuffer(ring.Buffer);
+                Global.GraphicsDevice.DrawPrimitives(primitiveType, vertexStart, primitiveCount);
+            }
             Global.GraphicsDevice.SetVertexBuffer(null);
         }
 
         /// <summary>
-        /// Uploads vertex and index data and issues an indexed primitive draw call.
+        /// Uploads vertex and index data through the shared rings and issues an indexed draw call.
+        /// Falls back to the legacy grow-and-discard buffers for writes larger than a ring.
         /// </summary>
         /// <typeparam name="T">The vertex type being uploaded.</typeparam>
         /// <param name="primitiveType">The primitive topology to draw.</param>
@@ -816,49 +830,75 @@ namespace CutTheRopeDX.Desktop
         /// <param name="primitiveCount">The number of primitives to render.</param>
         private static void DrawIndexedPrimitives<T>(PrimitiveType primitiveType, T[] vertices, short[] indices, int indexCount, int primitiveCount) where T : struct, IVertexType
         {
-            DynamicVertexBuffer vertexBuffer = GetVertexBuffer<T>(vertices.Length);
-            vertexBuffer.SetData(vertices, 0, vertices.Length, SetDataOptions.Discard);
-            IndexBuffer indexBuffer = GetIndexBuffer(indexCount, indices);
-            Global.GraphicsDevice.SetVertexBuffer(vertexBuffer);
-            Global.GraphicsDevice.Indices = indexBuffer;
-            Global.GraphicsDevice.DrawIndexedPrimitives(primitiveType, 0, 0, primitiveCount);
+            VertexBufferRing<T> ring = GetVertexRing<T>();
+            int baseVertex = ring.Write(vertices, vertices.Length);
+            int startIndex = baseVertex < 0 ? -1 : s_indexRing.Write(indices, indexCount);
+            if (baseVertex < 0 || startIndex < 0)
+            {
+                DynamicVertexBuffer fallbackVertices = GetOversizeVertexBuffer<T>(vertices.Length);
+                fallbackVertices.SetData(vertices, 0, vertices.Length, SetDataOptions.Discard);
+                DynamicIndexBuffer fallbackIndices = GetOversizeIndexBuffer(indexCount);
+                fallbackIndices.SetData(indices, 0, indexCount, SetDataOptions.Discard);
+                Global.GraphicsDevice.SetVertexBuffer(fallbackVertices);
+                Global.GraphicsDevice.Indices = fallbackIndices;
+                Global.GraphicsDevice.DrawIndexedPrimitives(primitiveType, 0, 0, primitiveCount);
+            }
+            else
+            {
+                Global.GraphicsDevice.SetVertexBuffer(ring.Buffer);
+                Global.GraphicsDevice.Indices = s_indexRing.Buffer;
+                Global.GraphicsDevice.DrawIndexedPrimitives(primitiveType, baseVertex, startIndex, primitiveCount);
+            }
             Global.GraphicsDevice.SetVertexBuffer(null);
             Global.GraphicsDevice.Indices = null;
         }
 
         /// <summary>
-        /// Returns a reusable dynamic vertex buffer sized for the requested vertex type and count.
+        /// Returns the shared vertex ring for the requested vertex type, creating it on first use.
+        /// </summary>
+        /// <typeparam name="T">The vertex type stored in the buffer.</typeparam>
+        /// <returns>The shared ring for <typeparamref name="T"/>.</returns>
+        private static VertexBufferRing<T> GetVertexRing<T>() where T : struct, IVertexType
+        {
+            if (!s_vertexRings.TryGetValue(typeof(T), out object ring))
+            {
+                ring = new VertexBufferRing<T>(VertexRingCapacity);
+                s_vertexRings[typeof(T)] = ring;
+            }
+            return (VertexBufferRing<T>)ring;
+        }
+
+        /// <summary>
+        /// Returns a legacy grow-and-discard vertex buffer for writes larger than the ring.
         /// </summary>
         /// <typeparam name="T">The vertex type stored in the buffer.</typeparam>
         /// <param name="vertexCount">The minimum vertex capacity required.</param>
         /// <returns>A reusable dynamic vertex buffer for <typeparamref name="T"/>.</returns>
-        private static DynamicVertexBuffer GetVertexBuffer<T>(int vertexCount) where T : struct, IVertexType
+        private static DynamicVertexBuffer GetOversizeVertexBuffer<T>(int vertexCount) where T : struct, IVertexType
         {
             Type vertexType = typeof(T);
-            if (!s_vertexBuffers.TryGetValue(vertexType, out DynamicVertexBuffer vertexBuffer) || vertexBuffer.VertexCount < vertexCount)
+            if (!s_oversizeVertexBuffers.TryGetValue(vertexType, out DynamicVertexBuffer vertexBuffer) || vertexBuffer.VertexCount < vertexCount)
             {
                 vertexBuffer?.Dispose();
                 vertexBuffer = new DynamicVertexBuffer(Global.GraphicsDevice, default(T).VertexDeclaration, vertexCount, BufferUsage.WriteOnly);
-                s_vertexBuffers[vertexType] = vertexBuffer;
+                s_oversizeVertexBuffers[vertexType] = vertexBuffer;
             }
             return vertexBuffer;
         }
 
         /// <summary>
-        /// Returns a reusable index buffer filled with the provided <paramref name="indices"/>.
+        /// Returns a legacy grow-and-discard index buffer for writes larger than the ring.
         /// </summary>
-        /// <param name="indexCount">The number of indices to upload.</param>
-        /// <param name="indices">The source index data.</param>
-        /// <returns>An index buffer containing the requested index data.</returns>
-        private static DynamicIndexBuffer GetIndexBuffer(int indexCount, short[] indices)
+        /// <param name="indexCount">The minimum index capacity required.</param>
+        /// <returns>A reusable dynamic index buffer.</returns>
+        private static DynamicIndexBuffer GetOversizeIndexBuffer(int indexCount)
         {
-            if (s_indexBuffer == null || s_indexBuffer.IndexCount < indexCount)
+            if (s_oversizeIndexBuffer == null || s_oversizeIndexBuffer.IndexCount < indexCount)
             {
-                s_indexBuffer?.Dispose();
-                s_indexBuffer = new DynamicIndexBuffer(Global.GraphicsDevice, IndexElementSize.SixteenBits, indexCount, BufferUsage.WriteOnly);
+                s_oversizeIndexBuffer?.Dispose();
+                s_oversizeIndexBuffer = new DynamicIndexBuffer(Global.GraphicsDevice, IndexElementSize.SixteenBits, indexCount, BufferUsage.WriteOnly);
             }
-            s_indexBuffer.SetData(indices, 0, indexCount, SetDataOptions.Discard);
-            return s_indexBuffer;
+            return s_oversizeIndexBuffer;
         }
 
         #endregion
@@ -941,14 +981,35 @@ namespace CutTheRopeDX.Desktop
         private static RasterizerState s_rasterizerStateTexture;
 
         /// <summary>
-        /// Reusable dynamic vertex buffers keyed by vertex type.
+        /// Vertex ring capacity per vertex type. 16,384 vertices covers several frames of
+        /// worst-case usage per the pre-implementation baselines; wraps should be rare.
         /// </summary>
-        private static readonly Dictionary<Type, DynamicVertexBuffer> s_vertexBuffers = [];
+        private const int VertexRingCapacity = 16384;
 
         /// <summary>
-        /// Reusable index buffer for indexed draw calls.
+        /// Index ring capacity. 49,152 indices matches three frames of ring capacity in quads.
         /// </summary>
-        private static DynamicIndexBuffer s_indexBuffer;
+        private const int IndexRingCapacity = 49152;
+
+        /// <summary>
+        /// Shared vertex rings keyed by vertex type (values are VertexBufferRing&lt;T&gt;).
+        /// </summary>
+        private static readonly Dictionary<Type, object> s_vertexRings = [];
+
+        /// <summary>
+        /// Shared index ring for all indexed draws.
+        /// </summary>
+        private static IndexBufferRing s_indexRing;
+
+        /// <summary>
+        /// Legacy grow-and-discard vertex buffers, used only for writes larger than a ring.
+        /// </summary>
+        private static readonly Dictionary<Type, DynamicVertexBuffer> s_oversizeVertexBuffers = [];
+
+        /// <summary>
+        /// Legacy grow-and-discard index buffer, used only for writes larger than the ring.
+        /// </summary>
+        private static DynamicIndexBuffer s_oversizeIndexBuffer;
 
         /// <summary>
         /// Captures the last submitted colored vertices for debugging.

--- a/CutTheRopeDX/Desktop/Renderer.cs
+++ b/CutTheRopeDX/Desktop/Renderer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 using CutTheRopeDX.Framework;
 using CutTheRopeDX.Framework.Visual;
@@ -821,6 +822,15 @@ namespace CutTheRopeDX.Desktop
             int vertexCount = s_quadBatch.QuadCount * 4;
             VertexBufferRing<VertexPositionColorTexture> ring = GetVertexRing<VertexPositionColorTexture>();
             int baseVertex = ring.Write(s_quadBatch.StagingArray, vertexCount);
+            // A full batch is MaxQuads * 4 vertices, well under the ring capacity, so the ring
+            // never rejects a batch write. Guard the invariant instead of feeding a negative
+            // base vertex to the GPU should MaxQuads ever be raised past the ring's capacity.
+            if (baseVertex < 0)
+            {
+                Debug.Assert(false, "Quad batch exceeded vertex ring capacity; raise VertexRingCapacity or lower MaxQuads.");
+                s_quadBatch.Clear();
+                return;
+            }
             Global.GraphicsDevice.SetVertexBuffer(ring.Buffer);
             Global.GraphicsDevice.Indices = s_quadIndexBuffer;
             foreach (EffectPass pass in s_quadBatchEffect.CurrentTechnique.Passes)

--- a/CutTheRopeDX/Desktop/RingAllocator.cs
+++ b/CutTheRopeDX/Desktop/RingAllocator.cs
@@ -1,0 +1,51 @@
+namespace CutTheRopeDX.Desktop
+{
+    /// <summary>
+    /// Pure-CPU cursor arithmetic for ring-buffer allocation. Hands out contiguous
+    /// element regions, wrapping to offset zero when the remaining space is too small.
+    /// A wrapped region signals the caller to orphan the GPU buffer with Discard.
+    /// </summary>
+    /// <param name="capacity">Total element capacity of the ring.</param>
+    internal sealed class RingAllocator(int capacity)
+    {
+        /// <summary>
+        /// Total element capacity of the ring.
+        /// </summary>
+        public int Capacity { get; } = capacity;
+
+        /// <summary>
+        /// Next free element offset.
+        /// </summary>
+        public int Cursor { get; private set; }
+
+        /// <summary>
+        /// Allocates a contiguous region of <paramref name="count"/> elements.
+        /// </summary>
+        /// <param name="count">Number of elements to allocate.</param>
+        /// <param name="start">Start offset of the allocated region.</param>
+        /// <param name="wrapped">Whether the ring wrapped to offset zero for this region;
+        /// the caller must use Discard for the corresponding GPU write.</param>
+        /// <returns><see langword="false"/> when <paramref name="count"/> exceeds the ring's
+        /// total capacity; the caller must use a fallback upload path.</returns>
+        public bool TryAllocate(int count, out int start, out bool wrapped)
+        {
+            if (count > Capacity)
+            {
+                start = 0;
+                wrapped = false;
+                return false;
+            }
+            if (Cursor + count > Capacity)
+            {
+                start = 0;
+                Cursor = count;
+                wrapped = true;
+                return true;
+            }
+            start = Cursor;
+            Cursor += count;
+            wrapped = false;
+            return true;
+        }
+    }
+}

--- a/CutTheRopeDX/Desktop/VertexBufferRing.cs
+++ b/CutTheRopeDX/Desktop/VertexBufferRing.cs
@@ -1,0 +1,47 @@
+using Microsoft.Xna.Framework.Graphics;
+
+namespace CutTheRopeDX.Desktop
+{
+    /// <summary>
+    /// A ring-buffered DynamicVertexBuffer for one vertex type. Writes advance through
+    /// the buffer with NoOverwrite so no upload rewrites a region the GPU may still be
+    /// reading; writes at offset zero (first use or wrap) orphan the buffer with Discard.
+    /// </summary>
+    /// <typeparam name="T">The vertex type stored in the buffer.</typeparam>
+    /// <param name="capacityVertices">Total vertex capacity of the ring.</param>
+    internal sealed class VertexBufferRing<T>(int capacityVertices) where T : struct, IVertexType
+    {
+        /// <summary>
+        /// The underlying GPU buffer to bind for draws.
+        /// </summary>
+        public DynamicVertexBuffer Buffer { get; } = new(Global.GraphicsDevice, default(T).VertexDeclaration, capacityVertices, BufferUsage.WriteOnly);
+
+        /// <summary>
+        /// Uploads <paramref name="count"/> vertices and returns the start vertex to draw from.
+        /// </summary>
+        /// <param name="data">Source vertex data.</param>
+        /// <param name="count">Number of vertices to upload.</param>
+        /// <returns>The start vertex offset, or -1 when the write exceeds the ring's
+        /// total capacity and the caller must use a fallback upload.</returns>
+        public int Write(T[] data, int count)
+        {
+            if (!_allocator.TryAllocate(count, out int start, out _))
+            {
+                return -1;
+            }
+            SetDataOptions options = start == 0 ? SetDataOptions.Discard : SetDataOptions.NoOverwrite;
+            Buffer.SetData(start * _stride, data, 0, count, _stride, options);
+            return start;
+        }
+
+        /// <summary>
+        /// Cursor arithmetic for the ring.
+        /// </summary>
+        private readonly RingAllocator _allocator = new(capacityVertices);
+
+        /// <summary>
+        /// Vertex stride in bytes.
+        /// </summary>
+        private readonly int _stride = default(T).VertexDeclaration.VertexStride;
+    }
+}

--- a/CutTheRopeDX/Framework/Visual/Text.cs
+++ b/CutTheRopeDX/Framework/Visual/Text.cs
@@ -533,6 +533,7 @@ namespace CutTheRopeDX.Framework.Visual
             }
 
             spriteBatch.End();
+            BlendParams.InvalidateDeviceCache();
 
             if (isPingPonging)
             {
@@ -565,6 +566,7 @@ namespace CutTheRopeDX.Framework.Visual
                 );
                 spriteBatch.Draw(textCompositeTarget, Vector2.Zero, blitColor);
                 spriteBatch.End();
+                BlendParams.InvalidateDeviceCache();
 
                 // SpriteBatch leaves its texture in slot zero. Mark it unbound so the next
                 // composite pass cannot retain a sampled binding for a writable target.

--- a/CutTheRopeDX/Framework/Visual/Text.cs
+++ b/CutTheRopeDX/Framework/Visual/Text.cs
@@ -382,6 +382,8 @@ namespace CutTheRopeDX.Framework.Visual
             int lineHeight = (int)(internalFont.LineHeight + font.GetLineOffset());
 
             GraphicsDevice graphicsDevice = Global.GraphicsDevice;
+            // Queued sprite quads must render before text draws above them or changes render targets.
+            Renderer.FlushQuads();
             Viewport viewport = graphicsDevice.Viewport;
 
             float viewportScaleX = viewport.Width / SCREEN_WIDTH;

--- a/CutTheRopeDX/Game1.cs
+++ b/CutTheRopeDX/Game1.cs
@@ -298,6 +298,7 @@ namespace CutTheRopeDX
         /// </summary>
         public void DrawMovie()
         {
+            Renderer.FlushQuads();
             _DrawMovie = true;
             GraphicsDevice.Clear(Color.Black);
             if (!Application.SharedMovieMgr().IsTextureReady())
@@ -340,7 +341,15 @@ namespace CutTheRopeDX
             Global.ScreenSizeManager.FullScreenCropWidth = true;
             Global.ScreenSizeManager.ApplyViewportToDevice();
             _DrawMovie = false;
-            CtrRenderer.OnDrawFrame();
+            Renderer.BeginFrame();
+            try
+            {
+                CtrRenderer.OnDrawFrame();
+            }
+            finally
+            {
+                Renderer.EndFrame();
+            }
             Global.MouseCursor.Draw();
             Global.GraphicsDevice.SetRenderTarget(null);
             if (bFirstFrame)

--- a/CutTheRopeDX/Game1.cs
+++ b/CutTheRopeDX/Game1.cs
@@ -329,6 +329,7 @@ namespace CutTheRopeDX
             Global.SpriteBatch.Begin(SpriteSortMode.Deferred, null, null, null, null, null, null);
             Global.SpriteBatch.Draw(texture, destinationRectangle, Color.White);
             Global.SpriteBatch.End();
+            BlendParams.InvalidateDeviceCache();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Description

- Replace per-draw dynamic vertex/index buffer discards with ring-buffered uploads using `NoOverwrite`, with oversize fallbacks.
- Batch compatible four-vertex textured sprites by texture, blend state, scissor rectangle, and projection.
- Bake model-view transforms and premultiplied tint into batched vertices while preserving draw order and visual behavior.
- Add a device-wide blend-state cache with invalidation around external `SpriteBatch` rendering.
- Flush queued quads at immediate draws, scissor changes, render-target operations, text/movie rendering, and frame boundaries.
- Generate and reuse a static quad index buffer.

### Performance results

Representative renderer draw calls per frame:

| Scene | Before | After | Reduction |
|---|---:|---:|---:|
| Main menu | 10.6 | 3.3 | ~69% |
| Level select | 42.0 | 18.1 | ~57% |
| Normal gameplay | 72.8 | 40.8 | ~44% |
| Particle-heavy gameplay | 193.9 | 146.9 | ~24% |

Measured batching-enabled upload traffic:

| Scene | Vertex upload/frame | Index upload/frame |
|---|---:|---:|
| Main menu | 0.9 KiB | 0.0 KiB |
| Level select | 2.1 KiB | 0.0 KiB |
| Sprite-heavy gameplay | 17.8 KiB | 0.8 KiB |
| Active particles | 24.5 KiB | 0.1 KiB |

The largest observed batch contained at least 70 quads.