### PR TITLE
fix: prevent clipping during ping-pong text scrolling

### DIFF
--- a/CutTheRopeDX.Tests/TextPingPongScissorTests.cs
+++ b/CutTheRopeDX.Tests/TextPingPongScissorTests.cs
@@ -1,0 +1,22 @@
+using CutTheRopeDX.Framework.Visual;
+
+using Microsoft.Xna.Framework;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public class TextPingPongScissorTests
+    {
+        [Fact]
+        public void CalculatePingPongScissorRectangle_RoundsOutwardAndPreservesVerticalBounds()
+        {
+            Rectangle previousScissor = new(10, 20, 300, 200);
+
+            Rectangle result = Text.CalculatePingPongScissorRectangle(
+                50.25f, 80f, 99.5f, Matrix.Identity, previousScissor);
+
+            Assert.Equal(new Rectangle(50, 20, 100, 200), result);
+        }
+    }
+}

--- a/CutTheRopeDX/Framework/Visual/Text.cs
+++ b/CutTheRopeDX/Framework/Visual/Text.cs
@@ -433,18 +433,16 @@ namespace CutTheRopeDX.Framework.Visual
             if (isPingPonging)
             {
                 float clipW = EffectivePingPongClipWidth;
-                float clipH = maxHeight > 0f ? maxHeight : height;
-                // Clip to the parent element's bounds (e.g., button background image)
                 float clipX = HasParent ? parent.drawX + pingPongPadding : drawX;
                 float clipY = drawY;
-                // Transform clip rect corners through the full transform matrix (model-view + viewport scale)
+                // Transform the horizontal clip bounds through the full transform matrix
                 Vector2 topLeft = Vector2.Transform(new Vector2(clipX, clipY), transformMatrix);
-                Vector2 bottomRight = Vector2.Transform(new Vector2(clipX + clipW, clipY + clipH), transformMatrix);
-                int sx = (int)topLeft.X;
-                int sy = (int)topLeft.Y;
-                int sw = (int)(bottomRight.X - topLeft.X);
-                int sh = (int)(bottomRight.Y - topLeft.Y);
-                graphicsDevice.ScissorRectangle = new Rectangle(sx, sy, sw, sh);
+                Vector2 topRight = Vector2.Transform(new Vector2(clipX + clipW, clipY), transformMatrix);
+                int scissorLeft = System.Math.Clamp((int)System.MathF.Floor(System.MathF.Min(topLeft.X, topRight.X)), previousScissor.Left, previousScissor.Right);
+                int scissorRight = System.Math.Clamp((int)System.MathF.Ceiling(System.MathF.Max(topLeft.X, topRight.X)), scissorLeft, previousScissor.Right);
+                int scissorWidth = scissorRight - scissorLeft;
+                // Preserve the previous vertical range so tall glyphs and effects are not clipped
+                graphicsDevice.ScissorRectangle = new Rectangle(scissorLeft, previousScissor.Y, scissorWidth, previousScissor.Height);
             }
 
             // Render each formatted line

--- a/CutTheRopeDX/Framework/Visual/Text.cs
+++ b/CutTheRopeDX/Framework/Visual/Text.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -306,6 +307,30 @@ namespace CutTheRopeDX.Framework.Visual
         }
 
         /// <summary>
+        /// Calculates the screen-space horizontal scissor bounds for ping-pong text.
+        /// </summary>
+        /// <param name="clipX">Local X coordinate of the clip area.</param>
+        /// <param name="clipY">Local Y coordinate of the clip area.</param>
+        /// <param name="clipWidth">Local width of the clip area.</param>
+        /// <param name="transformMatrix">Transform from local coordinates to screen space.</param>
+        /// <param name="previousScissor">Scissor rectangle to intersect horizontally.</param>
+        /// <returns>The horizontally intersected scissor rectangle.</returns>
+        internal static Rectangle CalculatePingPongScissorRectangle(
+            float clipX,
+            float clipY,
+            float clipWidth,
+            Matrix transformMatrix,
+            Rectangle previousScissor)
+        {
+            Vector2 leftEndpoint = Vector2.Transform(new Vector2(clipX, clipY), transformMatrix);
+            Vector2 rightEndpoint = Vector2.Transform(new Vector2(clipX + clipWidth, clipY), transformMatrix);
+            int scissorLeft = Math.Clamp((int)MathF.Floor(MathF.Min(leftEndpoint.X, rightEndpoint.X)), previousScissor.Left, previousScissor.Right);
+            int scissorRight = Math.Clamp((int)MathF.Ceiling(MathF.Max(leftEndpoint.X, rightEndpoint.X)), scissorLeft, previousScissor.Right);
+
+            return new Rectangle(scissorLeft, previousScissor.Y, scissorRight - scissorLeft, previousScissor.Height);
+        }
+
+        /// <summary>
         /// Renders text using FontStashSharp with stroke, shadow, and color modulation.
         /// When fading, all layers are first composited at full opacity onto a render target,
         /// then drawn to screen with the fade alpha so shadow/stroke/fill fade in sync.
@@ -435,14 +460,8 @@ namespace CutTheRopeDX.Framework.Visual
                 float clipW = EffectivePingPongClipWidth;
                 float clipX = HasParent ? parent.drawX + pingPongPadding : drawX;
                 float clipY = drawY;
-                // Transform the horizontal clip bounds through the full transform matrix
-                Vector2 topLeft = Vector2.Transform(new Vector2(clipX, clipY), transformMatrix);
-                Vector2 topRight = Vector2.Transform(new Vector2(clipX + clipW, clipY), transformMatrix);
-                int scissorLeft = System.Math.Clamp((int)System.MathF.Floor(System.MathF.Min(topLeft.X, topRight.X)), previousScissor.Left, previousScissor.Right);
-                int scissorRight = System.Math.Clamp((int)System.MathF.Ceiling(System.MathF.Max(topLeft.X, topRight.X)), scissorLeft, previousScissor.Right);
-                int scissorWidth = scissorRight - scissorLeft;
-                // Preserve the previous vertical range so tall glyphs and effects are not clipped
-                graphicsDevice.ScissorRectangle = new Rectangle(scissorLeft, previousScissor.Y, scissorWidth, previousScissor.Height);
+                graphicsDevice.ScissorRectangle = CalculatePingPongScissorRectangle(
+                    clipX, clipY, clipW, transformMatrix, previousScissor);
             }
 
             // Render each formatted line


### PR DESCRIPTION
## Summary

Fix PingPong text clipping by restricting the scissor adjustment to the horizontal axis while preserving the existing vertical scissor range.

Previously, the scrolling path replaced the complete scissor rectangle with bounds derived from the text position and height. This introduced an additional vertical clipping range that could cut off tall glyphs, strokes, and shadows.

The updated calculation transforms and intersects only the horizontal clip bounds while retaining `previousScissor.Y` and `previousScissor.Height`. The horizontal bounds are rounded outward to avoid clipping fractional edge pixels.

This calculation is used only when PingPong scrolling is enabled and the text actually overflows. Text that fits within the available width, the animation timing, and scrolling position are unchanged.

## Before

<img width="229" height="98" alt="image" src="https://github.com/user-attachments/assets/64aadff9-d294-4757-a88d-bc31103fed6f" />

The scrolling text is clipped vertically (the letter `P` here) when, for instance, the interface language is set to Chinese.

## After

<img width="231" height="93" alt="Portugues" src="https://github.com/user-attachments/assets/5fe638b5-2dcf-4274-92c0-48bcc1815521" />

With the same interface font and scrolling label, the text is no longer clipped vertically.

## Testing

- Verified that the previous vertical scissor bounds are preserved and fractional horizontal bounds are rounded outward.
- Verified that scrolling text has no vertical or horizontal clipping, including with CJK fonts.
- Verified that text which fits within the available width remains static.