### PR TITLE
enhancement: use fractional seconds in score calculation

### DIFF
--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -430,9 +430,7 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         public void CalculateScore()
         {
-            timeBonus = (int)MAX(0f, 30f - time) * 100;
-            timeBonus /= 10;
-            timeBonus *= 10;
+            timeBonus = (int)(MAX(0f, 30f - time) * 100f);
             starBonus = 1000 * starsCollected;
             score = (int)Ceil(timeBonus + starBonus);
         }


### PR DESCRIPTION
## Description

Use fractional seconds to calculate the final score, so the score shall no longer be limited to multiples of 100.

Fixes #173.

## Example

<img width="531" height="139" alt="Pasted Graphic 9" src="https://github.com/user-attachments/assets/7c1d8296-effb-4fd7-a657-11b26ff0aa71" />
