### PR TITLE
fix: adjust CJK box text & label positioning

### DIFF
--- a/CutTheRopeDX/GameMain/MenuController.cs
+++ b/CutTheRopeDX/GameMain/MenuController.cs
@@ -1017,6 +1017,11 @@ namespace CutTheRopeDX.GameMain
                     _ = image4.AddTimeline(timeline);
                 }
             }
+            bool isCJK = LanguageHelper.IsCurrentAny(
+                Language.LANGKO,
+                Language.LANGJA,
+                Language.LANGZH,
+                Language.LANGZHTW);
             // Add box label if defined in pack config
             string boxLabelTextKey = PackConfig.GetBoxLabelText(n);
             if (!string.IsNullOrEmpty(boxLabelTextKey))
@@ -1033,7 +1038,9 @@ namespace CutTheRopeDX.GameMain
                 labelText.scaleX = labelText.scaleY = 0.35f;
                 labelText.SetAlignment(1); // Center alignment
                 labelText.anchor = labelText.parentAnchor = 18; // center-center like buttons
-                labelText.rotation = -16f;
+                labelText.rotation = -15f;
+                const float CJKBoxLabelYOffset = 2f;
+                labelText.y = 2f + (isCJK ? CJKBoxLabelYOffset : 0f);
                 _ = boxLabel.AddChild(labelText);
             }
             Text text2 = new Text().InitWithFont(Application.GetFont(Resources.Fnt.BigFont));
@@ -1052,7 +1059,8 @@ namespace CutTheRopeDX.GameMain
             {
                 text2.SetStringandWidth(packTitle, 656);
             }
-            text2.y = 140f;
+            const float CJKPackTitleYOffset = 14f;
+            text2.y = 140f + (isCJK ? CJKPackTitleYOffset : 0f);
             _ = image.AddChild(text2);
             Timeline timeline2 = new Timeline().InitWithMaxKeyFramesOnTrack(4);
             timeline2.AddKeyFrame(KeyFrame.MakeScale(1, 1, KeyFrame.TransitionType.FRAME_TRANSITION_LINEAR, 0));


### PR DESCRIPTION
## Description

This PR adjusts the height of box titles (and the label for the last box) for Chinese, Japanese and Korean.

For other languages, it makes a minor correction to the label positioning of the last box.

## Before

<img width="330" height="320" alt="Pasted Graphic 19" src="https://github.com/user-attachments/assets/dc1e365f-23c4-42c9-8362-d2ebdd9fabff" />
<img width="330" height="320" alt="Pasted Graphic 18" src="https://github.com/user-attachments/assets/19965747-9bed-453a-9134-cf25dcd280f0" />
<img width="330" height="320" alt="Pasted Graphic 17" src="https://github.com/user-attachments/assets/b5a5afcc-45e4-41a4-9f41-0cc73e70a5a5" />
<img width="330" height="320" alt="Pasted Graphic 20" src="https://github.com/user-attachments/assets/b2bb9512-f9fb-4ed8-b38d-a294cd6df296" />

## After

<img width="330" height="320" alt="Pasted Graphic 14" src="https://github.com/user-attachments/assets/90f0aea4-2a6f-4965-bde8-e866add2eeee" />
<img width="330" height="320" alt="Pasted Graphic 15" src="https://github.com/user-attachments/assets/9d858700-af6e-4b99-acbf-28e05e7c0b70" />
<img width="330" height="320" alt="Pasted Graphic 16" src="https://github.com/user-attachments/assets/802459f5-4a8c-40e7-a249-d3b1c387976a" />
<img width="330" height="320" alt="Pasted Graphic 13" src="https://github.com/user-attachments/assets/2c84e567-c079-4391-ba22-710f64e8bb8e" />

