### PR TITLE
fix: Make XNB smaller again

### DIFF
--- a/CutTheRopeDX/Desktop/DesktopContentManager.cs
+++ b/CutTheRopeDX/Desktop/DesktopContentManager.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+
+using CutTheRopeDX.Helpers;
+
+using Microsoft.Xna.Framework.Content;
+
+namespace CutTheRopeDX.Desktop
+{
+    /// <summary>
+    /// Loads compiled content through managed file streams.
+    /// </summary>
+    /// <remarks>
+    /// MonoGame 3.8.5's DesktopVK asset stream ignores the destination offset passed to
+    /// <see cref="Stream.Read(byte[], int, int)"/>. LZ4 content requires non-zero-offset
+    /// reads, so use a managed <see cref="FileStream"/> until the runtime implementation
+    /// is corrected.
+    /// </remarks>
+    internal sealed class DesktopContentManager(IServiceProvider serviceProvider)
+        : ContentManager(serviceProvider, ContentPaths.RootDirectory)
+    {
+        /// <inheritdoc />
+        protected override Stream OpenStream(string assetName)
+        {
+            return ContentPaths.OpenStream(assetName + ".xnb");
+        }
+    }
+}

--- a/CutTheRopeDX/Desktop/Images.cs
+++ b/CutTheRopeDX/Desktop/Images.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 
-using CutTheRopeDX.Helpers;
-
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 
@@ -23,7 +21,7 @@ namespace CutTheRopeDX.Desktop
             _ = _contentManagers.TryGetValue(imgName, out ContentManager value);
             if (value == null)
             {
-                value = new ContentManager(Global.XnaGame.Services, ContentPaths.RootDirectory);
+                value = new DesktopContentManager(Global.XnaGame.Services);
                 _contentManagers.Add(imgName, value);
             }
             return value;

--- a/CutTheRopeDX/Desktop/Images.cs
+++ b/CutTheRopeDX/Desktop/Images.cs
@@ -37,18 +37,15 @@ namespace CutTheRopeDX.Desktop
         public static Texture2D Get(string imgName)
         {
             ContentManager contentManager = GetContentManager(imgName);
-            Texture2D result = null;
-            Texture2D texture2D;
             try
             {
-                result = contentManager.Load<Texture2D>(imgName);
-                texture2D = result;
+                return contentManager.Load<Texture2D>(imgName);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                texture2D = result;
+                Console.WriteLine($"[Images] Failed to load '{imgName}': {ex}");
+                return null;
             }
-            return texture2D;
         }
 
         /// <summary>

--- a/CutTheRopeDX/Game1.cs
+++ b/CutTheRopeDX/Game1.cs
@@ -31,7 +31,8 @@ namespace CutTheRopeDX
         public Game1()
         {
             Global.XnaGame = this;
-            Content.RootDirectory = ContentPaths.RootDirectory;
+            Content.Dispose();
+            Content = new DesktopContentManager(Services);
             Global.GraphicsDeviceManager = new GraphicsDeviceManager(this);
             try
             {

--- a/content/Builder/BuildContent.targets
+++ b/content/Builder/BuildContent.targets
@@ -4,6 +4,8 @@
     <ContentSourceDir>$(MSBuildThisFileDirectory)..</ContentSourceDir>
     <ContentBuildOutput>$(MSBuildThisFileDirectory)bin/$(MonoGamePlatform)/content</ContentBuildOutput>
     <ContentBuildTemp>$(MSBuildThisFileDirectory)obj/$(MonoGamePlatform)</ContentBuildTemp>
+    <CompressContent Condition="'$(CompressContent)' == ''">true</CompressContent>
+    <ContentCompressionArgument Condition="'$(CompressContent)' == 'true'">--compress</ContentCompressionArgument>
   </PropertyGroup>
 
   <Target Name="BuildGameContent"
@@ -15,7 +17,7 @@
              RemoveProperties="Configuration;TargetFramework;RuntimeIdentifier;RuntimeIdentifiers;MonoGamePlatform;SelfContained;PublishSingleFile" />
     <Exec Condition="'$(CI)' != 'true'"
           Command="dotnet &quot;$(MSBuildThisFileDirectory)bin/Debug/CutTheRopeDX.Content.dll&quot; fetch -s &quot;$(ContentSourceDir)&quot;" />
-    <Exec Command="dotnet &quot;$(MSBuildThisFileDirectory)bin/Debug/CutTheRopeDX.Content.dll&quot; build -p $(MonoGamePlatform) -s &quot;$(ContentSourceDir)&quot; -o &quot;$(ContentBuildOutput)&quot; -i &quot;$(ContentBuildTemp)&quot;"
+    <Exec Command="dotnet &quot;$(MSBuildThisFileDirectory)bin/Debug/CutTheRopeDX.Content.dll&quot; build -p $(MonoGamePlatform) -s &quot;$(ContentSourceDir)&quot; -o &quot;$(ContentBuildOutput)&quot; -i &quot;$(ContentBuildTemp)&quot; $(ContentCompressionArgument)"
           CustomErrorRegularExpression="\[E\] .+" CustomWarningRegularExpression="\[W\] .+" />
   </Target>
 

--- a/content/Builder/Commands/AssetCommands.cs
+++ b/content/Builder/Commands/AssetCommands.cs
@@ -65,6 +65,7 @@ namespace CutTheRopeDX.Content.Commands
                     WorkingDirectory = $"{AppContext.BaseDirectory}../../",
                     SourceDirectory = "content",
                     Platform = TargetPlatform.DesktopVK,
+                    CompressContent = true,
                 });
             }
 


### PR DESCRIPTION
## Description

- Add XNB texture compression option in content builder.
- Workaround a bug in MonoGame v3.8.5 where native asset stream ignores non-zero read offsets, which prevents the game from loading compressed XNB textures.