### PR TITLE
fix: Post fixes some edge cases related to multi-candy rework

### DIFF
--- a/CutTheRopeDX.Tests/ConveyorRopeCutTests.cs
+++ b/CutTheRopeDX.Tests/ConveyorRopeCutTests.cs
@@ -1,0 +1,58 @@
+using CutTheRopeDX.Framework.Physics;
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    /// <summary>
+    /// When a grab wraps around a conveyor edge, the other ropes on the SAME candy are cut. Multi-candy
+    /// identity is the rope's tail (candy physics point), not <c>Grab.candyNumber</c> — the loader hands
+    /// every candy-bound grab the number 0, so matching on it would cut other candies' ropes too.
+    /// </summary>
+    public class ConveyorRopeCutTests
+    {
+        [Fact]
+        public void ShouldCut_TrueForAnotherUncutRopeOnTheSameCandy()
+        {
+            ConstraintedPoint candy = new();
+            Assert.True(ConveyorRopeCut.ShouldCut(
+                ropeTail: candy, wrappedCandyPoint: candy, isWrappedGrab: false, ropeUncut: true));
+        }
+
+        [Fact]
+        public void ShouldCut_FalseForARopeOnADifferentCandy()
+        {
+            // The multi-candy isolation invariant: wrapping a grab on candy A must not cut candy B's rope.
+            ConstraintedPoint candyA = new();
+            ConstraintedPoint candyB = new();
+            Assert.False(ConveyorRopeCut.ShouldCut(
+                ropeTail: candyB, wrappedCandyPoint: candyA, isWrappedGrab: false, ropeUncut: true));
+        }
+
+        [Fact]
+        public void ShouldCut_FalseForTheWrappedGrabItself()
+        {
+            // The wrapped grab keeps its own rope; only its siblings are cut.
+            ConstraintedPoint candy = new();
+            Assert.False(ConveyorRopeCut.ShouldCut(
+                ropeTail: candy, wrappedCandyPoint: candy, isWrappedGrab: true, ropeUncut: true));
+        }
+
+        [Fact]
+        public void ShouldCut_FalseWhenRopeAlreadyCut()
+        {
+            ConstraintedPoint candy = new();
+            Assert.False(ConveyorRopeCut.ShouldCut(
+                ropeTail: candy, wrappedCandyPoint: candy, isWrappedGrab: false, ropeUncut: false));
+        }
+
+        [Fact]
+        public void ShouldCut_FalseWhenGrabHasNoRope()
+        {
+            ConstraintedPoint candy = new();
+            Assert.False(ConveyorRopeCut.ShouldCut(
+                ropeTail: null, wrappedCandyPoint: candy, isWrappedGrab: false, ropeUncut: true));
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/HandStealTests.cs
+++ b/CutTheRopeDX.Tests/HandStealTests.cs
@@ -1,0 +1,43 @@
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    /// <summary>
+    /// When a mechanical hand grabs a candy, any OTHER hand already holding that SAME candy must let go.
+    /// The decision is per candy: a hand holding a different candy keeps it, so multi-hand, multi-candy
+    /// levels don't drop unrelated candies when one hand grabs.
+    /// </summary>
+    public class HandStealTests
+    {
+        [Fact]
+        public void ShouldReleaseOtherHand_TrueWhenAnotherHandHoldsThisCandy()
+        {
+            Assert.True(HandSteal.ShouldReleaseOtherHand(
+                isDifferentHand: true, otherHandHoldingCandy: true, otherHandHoldsThisCandy: true));
+        }
+
+        [Fact]
+        public void ShouldReleaseOtherHand_FalseWhenTheOtherHandHoldsADifferentCandy()
+        {
+            // Multi-candy isolation: grabbing candy A must not release a hand holding candy B.
+            Assert.False(HandSteal.ShouldReleaseOtherHand(
+                isDifferentHand: true, otherHandHoldingCandy: true, otherHandHoldsThisCandy: false));
+        }
+
+        [Fact]
+        public void ShouldReleaseOtherHand_FalseForTheGrabbingHandItself()
+        {
+            Assert.False(HandSteal.ShouldReleaseOtherHand(
+                isDifferentHand: false, otherHandHoldingCandy: true, otherHandHoldsThisCandy: true));
+        }
+
+        [Fact]
+        public void ShouldReleaseOtherHand_FalseWhenTheOtherHandHoldsNothing()
+        {
+            Assert.False(HandSteal.ShouldReleaseOtherHand(
+                isDifferentHand: true, otherHandHoldingCandy: false, otherHandHoldsThisCandy: false));
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/MouseOwnershipTests.cs
+++ b/CutTheRopeDX.Tests/MouseOwnershipTests.cs
@@ -1,0 +1,39 @@
+using CutTheRopeDX.Framework.Physics;
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    /// <summary>
+    /// Per-candy mouse ownership. The multi-candy work must decide "does the mouse hold THIS candy"
+    /// by physics-point identity, not the old global "does the mouse hold any candy" flag, which
+    /// wrongly coupled unrelated candies (a mouse carrying candy A blocked interactions on candy B).
+    /// </summary>
+    public class MouseOwnershipTests
+    {
+        [Fact]
+        public void CarriesCandy_TrueWhenActiveMouseCarriesThisPoint()
+        {
+            ConstraintedPoint candy = new();
+            Assert.True(MouseOwnership.CarriesCandy(carriedByActiveMouse: candy, candyPoint: candy));
+        }
+
+        [Fact]
+        public void CarriesCandy_FalseForADifferentCandyPoint()
+        {
+            // The mouse carries candy A; candy B must be reported as not-carried so its own
+            // rocket bind / rope attach is unaffected. This is the multi-candy isolation invariant.
+            ConstraintedPoint candyA = new();
+            ConstraintedPoint candyB = new();
+            Assert.False(MouseOwnership.CarriesCandy(carriedByActiveMouse: candyA, candyPoint: candyB));
+        }
+
+        [Fact]
+        public void CarriesCandy_FalseWhenMouseCarriesNothing()
+        {
+            ConstraintedPoint candy = new();
+            Assert.False(MouseOwnership.CarriesCandy(carriedByActiveMouse: null, candyPoint: candy));
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/SnailAttachTests.cs
+++ b/CutTheRopeDX.Tests/SnailAttachTests.cs
@@ -1,0 +1,43 @@
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    /// <summary>
+    /// Gate for an inactive snail landing on a candy. Each candy is judged on its own state, so in a
+    /// multi-candy level the snail skips a gone or non-draggable candy and rides the next one it hits.
+    /// </summary>
+    public class SnailAttachTests
+    {
+        [Fact]
+        public void ShouldAttach_TrueForAPresentDraggableCandyItTouches()
+        {
+            Assert.True(SnailAttach.ShouldAttach(
+                candyGone: false, canBeDraggedBySnail: true, snailIntersectsCandy: true));
+        }
+
+        [Fact]
+        public void ShouldAttach_FalseForAGoneCandy()
+        {
+            // Multi-candy: candy A already eaten/off-screen is skipped so the snail can ride candy B instead.
+            Assert.False(SnailAttach.ShouldAttach(
+                candyGone: true, canBeDraggedBySnail: true, snailIntersectsCandy: true));
+        }
+
+        [Fact]
+        public void ShouldAttach_FalseForABodyThatCannotBeDragged()
+        {
+            // A light bulb and other non-candy bodies opt out via CanBeDraggedBySnail.
+            Assert.False(SnailAttach.ShouldAttach(
+                candyGone: false, canBeDraggedBySnail: false, snailIntersectsCandy: true));
+        }
+
+        [Fact]
+        public void ShouldAttach_FalseWhenNotTouching()
+        {
+            Assert.False(SnailAttach.ShouldAttach(
+                candyGone: false, canBeDraggedBySnail: true, snailIntersectsCandy: false));
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/SnailDetachSelectionTests.cs
+++ b/CutTheRopeDX.Tests/SnailDetachSelectionTests.cs
@@ -1,0 +1,50 @@
+using CutTheRopeDX.Framework.Physics;
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    /// <summary>
+    /// When a candy leaves play (eaten, broken, transported), only the snails riding THAT candy detach.
+    /// A single-candy engine could tear every snail down at once; with several candies alive, detaching
+    /// must be keyed to the candy's physics point so an eaten candy does not drop another candy's snail.
+    /// </summary>
+    public class SnailDetachSelectionTests
+    {
+        [Fact]
+        public void ShouldDetach_TrueForAnActiveSnailRidingThisCandy()
+        {
+            ConstraintedPoint candy = new();
+            Assert.True(SnailDetachSelection.ShouldDetach(
+                snailActive: true, snailAttachedPoint: candy, targetPoint: candy));
+        }
+
+        [Fact]
+        public void ShouldDetach_FalseForASnailRidingADifferentCandy()
+        {
+            // The multi-candy isolation invariant: detaching snails from candy A must leave candy B's snail on.
+            ConstraintedPoint candyA = new();
+            ConstraintedPoint candyB = new();
+            Assert.False(SnailDetachSelection.ShouldDetach(
+                snailActive: true, snailAttachedPoint: candyB, targetPoint: candyA));
+        }
+
+        [Fact]
+        public void ShouldDetach_FalseForAnInactiveSnail()
+        {
+            // Only riding (active) snails detach; one that is spawning or already vanishing is left alone.
+            ConstraintedPoint candy = new();
+            Assert.False(SnailDetachSelection.ShouldDetach(
+                snailActive: false, snailAttachedPoint: candy, targetPoint: candy));
+        }
+
+        [Fact]
+        public void ShouldDetach_FalseWhenSnailRidesNothing()
+        {
+            ConstraintedPoint candy = new();
+            Assert.False(SnailDetachSelection.ShouldDetach(
+                snailActive: true, snailAttachedPoint: null, targetPoint: candy));
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/ConveyorBelt.cs
+++ b/CutTheRopeDX/GameMain/ConveyorBelt.cs
@@ -569,7 +569,7 @@ namespace CutTheRopeDX.GameMain
                 {
                     if (item is Grab grab && grab.rope != null && grab.candyNumber != -1)
                     {
-                        OnDestroyRopesForCandy?.Invoke(grab.candyNumber, grab);
+                        OnDestroyRopesForCandy?.Invoke(grab);
                     }
                     if (item is ITransporterSideSwitchAware sideSwitchAware)
                     {
@@ -972,9 +972,9 @@ namespace CutTheRopeDX.GameMain
         /// <summary>
         /// Callback invoked when a Grab wraps around the belt edge, requesting all other
         /// ropes for the same candy to be cut.
-        /// Parameters: candyNumber, the Grab that wrapped (excluded from cutting).
+        /// Parameter: the Grab that wrapped (identifies the candy, and is excluded from cutting).
         /// </summary>
-        public Action<int, Grab> OnDestroyRopesForCandy;
+        public Action<Grab> OnDestroyRopesForCandy;
 
         /// <summary>
         /// The list of items currently bound to this belt.

--- a/CutTheRopeDX/GameMain/ConveyorBelt.cs
+++ b/CutTheRopeDX/GameMain/ConveyorBelt.cs
@@ -655,6 +655,26 @@ namespace CutTheRopeDX.GameMain
         }
 
         /// <summary>
+        /// Force-releases an in-progress manual drag without a matching pointer-up, and clears the
+        /// leftover drag delta. Needed because a belt still holding a pointer never reaches the
+        /// inertia/stop branch in <see cref="Update"/>, so its last <c>offsetDelta</c> keeps the belt
+        /// flagged active and re-triggers the manual move sound every frame.
+        /// </summary>
+        public void CancelDrag()
+        {
+            if (!IsManual)
+            {
+                return;
+            }
+
+            activePointerId = -1;
+            offsetDelta = 0f;
+            manualTravelDistance = 0f;
+            active = false;
+            needsAlignment = false;
+        }
+
+        /// <summary>
         /// Handles pointer move events to drag the manual belt.
         /// </summary>
         /// <param name="pointerX">The x-coordinate of the pointer in world space.</param>

--- a/CutTheRopeDX/GameMain/ConveyorBeltObject.cs
+++ b/CutTheRopeDX/GameMain/ConveyorBeltObject.cs
@@ -264,6 +264,18 @@ namespace CutTheRopeDX.GameMain
         }
 
         /// <summary>
+        /// Force-releases any in-progress manual drag on every belt. Called when gameplay input is
+        /// cut off mid-drag (win/loss transition), where no pointer-up ever reaches the belts.
+        /// </summary>
+        public void CancelAllDrags()
+        {
+            foreach (ConveyorBelt belt in list)
+            {
+                belt?.CancelDrag();
+            }
+        }
+
+        /// <summary>
         /// Handles pointer move events.
         /// </summary>
         /// <param name="pointerX">The x-coordinate of the pointer.</param>

--- a/CutTheRopeDX/GameMain/ConveyorBeltObject.cs
+++ b/CutTheRopeDX/GameMain/ConveyorBeltObject.cs
@@ -19,9 +19,9 @@ namespace CutTheRopeDX.GameMain
 
         /// <summary>
         /// Set by <see cref="GameScene"/>. Called when a Grab wraps and other ropes for the same candy should be cut.
-        /// Parameters: candyNumber, the Grab that wrapped.
+        /// Parameter: the Grab that wrapped.
         /// </summary>
-        public Action<int, Grab> OnDestroyRopesForCandy;
+        public Action<Grab> OnDestroyRopesForCandy;
 
         /// <summary>
         /// Gets the number of conveyor belts in this collection.

--- a/CutTheRopeDX/GameMain/ConveyorRopeCut.cs
+++ b/CutTheRopeDX/GameMain/ConveyorRopeCut.cs
@@ -1,0 +1,32 @@
+using CutTheRopeDX.Framework.Physics;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// Decides which ropes are cut when a grab wraps around a conveyor edge. The candy is identified by
+    /// the rope's tail (physics point) rather than <see cref="Grab.candyNumber"/>: the multi-candy loader
+    /// assigns every candy-bound grab the number 0, so matching on it would cut ropes on other candies.
+    /// </summary>
+    internal static class ConveyorRopeCut
+    {
+        /// <summary>
+        /// True when a sibling rope should be cut: it hangs from the same candy point as the wrapped
+        /// grab, it is not the wrapped grab's own rope, and it is still uncut.
+        /// </summary>
+        /// <param name="ropeTail">Tail point of the candidate rope, or null when the grab has no rope.</param>
+        /// <param name="wrappedCandyPoint">Candy point of the grab that wrapped.</param>
+        /// <param name="isWrappedGrab">True when the candidate is the wrapped grab itself.</param>
+        /// <param name="ropeUncut">True when the candidate rope is still uncut.</param>
+        public static bool ShouldCut(
+            ConstraintedPoint ropeTail,
+            ConstraintedPoint wrappedCandyPoint,
+            bool isWrappedGrab,
+            bool ropeUncut)
+        {
+            return !isWrappedGrab
+                && ropeUncut
+                && ropeTail != null
+                && ReferenceEquals(ropeTail, wrappedCandyPoint);
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/GameScene.Draw.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Draw.cs
@@ -190,6 +190,9 @@ namespace CutTheRopeDX.GameMain
             }
 
             Renderer.SetBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
+            // Two passes, as in the reference engine: every grab's backing layer (the rail a
+            // moveable grab slides along, the hook back plate) is drawn before any rope. A single
+            // interleaved pass lets a later grab's rail paint over an earlier grab's rope.
             foreach (object bungeeObj in bungees)
             {
                 Grab grab = (Grab)bungeeObj;
@@ -200,6 +203,11 @@ namespace CutTheRopeDX.GameMain
                     grab.SetGunDisabled(GunAvailability.IsDisabled(candies[0].inLantern));
                 }
                 grab.DrawBack();
+            }
+            foreach (object bungeeObj in bungees)
+            {
+                Grab grab = (Grab)bungeeObj;
+                Renderer.SetBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
                 grab.Draw();
             }
 

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -383,6 +383,7 @@ namespace CutTheRopeDX.GameMain
             outcomeTransitionActive = true;
 
             EndActiveFingerTraces();
+            conveyors?.CancelAllDrags();
             dd.CancelAllDispatches();
 
             // Hide and reset sleep state for every Om Nom except one mid post-eat sleep: that
@@ -469,6 +470,7 @@ namespace CutTheRopeDX.GameMain
             outcomeTransitionActive = true;
 
             EndActiveFingerTraces();
+            conveyors?.CancelAllDrags();
             dd.CancelAllDispatches();
 
             // Hide and reset sleep state for every Om Nom except one mid post-eat sleep: that

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -823,7 +823,8 @@ namespace CutTheRopeDX.GameMain
             for (int i = 0; i < bungees.Count; i++)
             {
                 Grab grab = bungees[i];
-                if (grab != except && grab.rope != null && grab.rope.tail == candyPoint && grab.rope.cut == -1)
+                bool ropeUncut = grab.rope != null && grab.rope.cut == -1;
+                if (ConveyorRopeCut.ShouldCut(grab.rope?.tail, candyPoint, grab == except, ropeUncut))
                 {
                     grab.rope.SetCut(grab.rope.parts.Count - 2);
                 }

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -901,7 +901,8 @@ namespace CutTheRopeDX.GameMain
             for (int i = snailobjects.Count - 1; i >= 0; i--)
             {
                 Snail snail = snailobjects[i];
-                if (snail != null && snail.state == Snail.SNAIL_STATE_ACTIVE && snail.AttachedPoint() == point)
+                if (snail != null && SnailDetachSelection.ShouldDetach(
+                        snail.state == Snail.SNAIL_STATE_ACTIVE, snail.AttachedPoint(), point))
                 {
                     snail.Detach();
                 }

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -800,17 +800,28 @@ namespace CutTheRopeDX.GameMain
         }
 
         /// <summary>
-        /// Cuts all ropes for the specified candy number, except the one belonging to the given Grab.
-        /// Matches iOS destroyRopesForCandy:except:.
+        /// Cuts all ropes attached to the same candy as <paramref name="except"/>, sparing that grab's
+        /// own rope. Matches iOS destroyRopesForCandy:except:.
         /// </summary>
-        /// <param name="candyNumber">Candy number whose ropes should be destroyed.</param>
-        /// <param name="except">Grab whose rope should be preserved.</param>
-        private void DestroyRopesForCandy(int candyNumber, Grab except)
+        /// <remarks>
+        /// Candies are identified by the rope's tail point rather than by <see cref="Grab.candyNumber"/>.
+        /// The legacy numbering only distinguished whole candy (0) from the split halves (1/2), so the
+        /// multi-candy loader hands every candy-bound grab the same number 0 — matching on it would cut
+        /// ropes belonging to *other* candies. Tail identity is exact for all three cases.
+        /// </remarks>
+        /// <param name="except">Grab whose candy is targeted and whose own rope is preserved.</param>
+        private void DestroyRopesForCandy(Grab except)
         {
+            ConstraintedPoint candyPoint = except?.rope?.tail;
+            if (candyPoint == null)
+            {
+                return;
+            }
+
             for (int i = 0; i < bungees.Count; i++)
             {
                 Grab grab = bungees[i];
-                if (grab != except && grab.candyNumber == candyNumber && grab.rope != null && grab.rope.cut == -1)
+                if (grab != except && grab.rope != null && grab.rope.tail == candyPoint && grab.rope.cut == -1)
                 {
                     grab.rope.SetCut(grab.rope.parts.Count - 2);
                 }

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1122,7 +1122,7 @@ namespace CutTheRopeDX.GameMain
                 ConstraintedPoint carried = miceManager.ActiveMouseCarriedStar();
                 for (int ci = 0; ci < candies.Count; ci++)
                 {
-                    candies[ci].carriedByMouse = carried != null && candies[ci].point == carried;
+                    candies[ci].carriedByMouse = MouseOwnership.CarriesCandy(carried, candies[ci].point);
                 }
             }
             float collisionHalfSize = ActivePhysicsConstants.SockCatchHalfSize;
@@ -1310,7 +1310,9 @@ namespace CutTheRopeDX.GameMain
                                 continue;
                             }
                             bool intersects = GameObject.ObjectsIntersectRotatedWithUnrotated(rocket, ctx.candy);
-                            bool mouseHasCandy = miceManager?.ActiveMouseHasCandy() ?? false;
+                            // Per-candy: only the candy the mouse actually holds is blocked from binding,
+                            // not every candy while the mouse holds any one of them.
+                            bool mouseHasCandy = ctx.carriedByMouse;
                             if (!RocketBind.ShouldBind(rocket.state == Rocket.STATE_ROCKET_IDLE, !ctx.noCandy, ctx.inLantern, mouseHasCandy, intersects))
                             {
                                 continue;
@@ -2026,8 +2028,9 @@ namespace CutTheRopeDX.GameMain
                 ctx.activeRocket.additionalAngle = 0f;
             }
 
-            // If mouse already has this candy, immediately cut the rope
-            if (miceManager?.ActiveMouseHasCandy() ?? false)
+            // If the mouse already has THIS candy, immediately cut the rope. Per-candy: a mouse
+            // holding another candy must not cut a rope just auto-attached to this one.
+            if (ctx.carriedByMouse)
             {
                 bungee.SetCut(bungee.parts.Count - 2);
             }

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1788,6 +1788,12 @@ namespace CutTheRopeDX.GameMain
                             }
                             ExhaustRocketForCandy(ctx);
                             ReleaseRopesForPoint(ctx.point);
+                            // Drop this candy's riders here, not at GameWon(). With one candy the
+                            // reference engine went straight from "eaten" to gameWon(), which tore
+                            // them down; now the other candies keep the level running, so a snail
+                            // would stay riding an eaten candy's invisible point until the last one
+                            // is eaten.
+                            DetachSnailsForPoint(ctx.point);
                             ctx.candy.visible = false;
                             t.asleep = true;
                             t.mouthOpen = false;

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1596,7 +1596,7 @@ namespace CutTheRopeDX.GameMain
                         {
                             CandyContext ctx = candies[ci];
                             bool gone = CandyGone(ci, ctx);
-                            if (gone || !ctx.Capabilities.CanBeDraggedBySnail || !GameObject.ObjectsIntersect(ctx.candy, snail))
+                            if (!SnailAttach.ShouldAttach(gone, ctx.Capabilities.CanBeDraggedBySnail, GameObject.ObjectsIntersect(ctx.candy, snail)))
                             {
                                 continue;
                             }

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -2007,7 +2007,7 @@ namespace CutTheRopeDX.GameMain
         /// Shared by the whole-candy path and the split-candy path (for the whole candies, e.g. light
         /// emitters, that sit alongside the split halves at <c>candies[1+]</c>).
         /// </remarks>
-        private bool TryAutoAttachGrabToCandy(Grab grab, CandyContext ctx)
+        private static bool TryAutoAttachGrabToCandy(Grab grab, CandyContext ctx)
         {
             bool inRange = !ctx.noCandy
                 && VectDistance(Vect(grab.x, grab.y), ctx.point.pos) <= grab.radius + ActivePhysicsConstants.CandyGrabPadding;

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -2145,9 +2145,10 @@ namespace CutTheRopeDX.GameMain
                     {
                         foreach (MechanicalHand otherHand in hands)
                         {
-                            if (otherHand != null && otherHand != hand
-                                && otherHand.state == MechanicalHand.STATE_HAND_CANDY
-                                && ctx.capturingHand == otherHand)
+                            if (otherHand != null && HandSteal.ShouldReleaseOtherHand(
+                                    otherHand != hand,
+                                    otherHand.state == MechanicalHand.STATE_HAND_CANDY,
+                                    ctx.capturingHand == otherHand))
                             {
                                 otherHand.cPoint.RemoveConstraint(ctx.point);
                                 otherHand.state = MechanicalHand.STATE_HAND_RELEASE;

--- a/CutTheRopeDX/GameMain/HandSteal.cs
+++ b/CutTheRopeDX/GameMain/HandSteal.cs
@@ -1,0 +1,25 @@
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// Decides whether a rival mechanical hand must release a candy that another hand is now grabbing.
+    /// Keyed to the specific candy so that, with several hands and candies in play, only the hand holding
+    /// the contested candy lets go.
+    /// </summary>
+    internal static class HandSteal
+    {
+        /// <summary>
+        /// True when <paramref name="otherHandHoldsThisCandy"/> should be forced to release: it is a
+        /// different hand, it is currently holding a candy, and that candy is the one being grabbed.
+        /// </summary>
+        /// <param name="isDifferentHand">True when the candidate is not the grabbing hand.</param>
+        /// <param name="otherHandHoldingCandy">True when the candidate hand is in its holding state.</param>
+        /// <param name="otherHandHoldsThisCandy">True when the candidate hand holds the candy being grabbed.</param>
+        public static bool ShouldReleaseOtherHand(
+            bool isDifferentHand,
+            bool otherHandHoldingCandy,
+            bool otherHandHoldsThisCandy)
+        {
+            return isDifferentHand && otherHandHoldingCandy && otherHandHoldsThisCandy;
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/MouseOwnership.cs
+++ b/CutTheRopeDX/GameMain/MouseOwnership.cs
@@ -1,0 +1,22 @@
+using CutTheRopeDX.Framework.Physics;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// Per-candy mouse ownership. Answers "is the active mouse carrying THIS candy" by physics-point
+    /// identity, so multi-candy interactions gate on the candy the mouse actually holds rather than a
+    /// global "mouse holds any candy" flag that would couple unrelated candies together.
+    /// </summary>
+    internal static class MouseOwnership
+    {
+        /// <summary>
+        /// True when the point the active mouse is carrying is exactly <paramref name="candyPoint"/>.
+        /// </summary>
+        /// <param name="carriedByActiveMouse">The point the active mouse currently carries, or null.</param>
+        /// <param name="candyPoint">The candy physics point being tested.</param>
+        public static bool CarriesCandy(ConstraintedPoint carriedByActiveMouse, ConstraintedPoint candyPoint)
+        {
+            return carriedByActiveMouse != null && ReferenceEquals(carriedByActiveMouse, candyPoint);
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/SnailAttach.cs
+++ b/CutTheRopeDX/GameMain/SnailAttach.cs
@@ -1,0 +1,21 @@
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// Gate for an inactive snail attaching to a candy. Judged per candy so a multi-candy level skips
+    /// a gone or non-draggable body and lets the snail ride the next candy it overlaps.
+    /// </summary>
+    internal static class SnailAttach
+    {
+        /// <summary>
+        /// True when the snail should attach: the candy is still in play, opts into snail dragging,
+        /// and the snail overlaps it.
+        /// </summary>
+        /// <param name="candyGone">True when the candy has been consumed or otherwise removed.</param>
+        /// <param name="canBeDraggedBySnail">True when the body opts into snail dragging.</param>
+        /// <param name="snailIntersectsCandy">True when the snail overlaps the candy.</param>
+        public static bool ShouldAttach(bool candyGone, bool canBeDraggedBySnail, bool snailIntersectsCandy)
+        {
+            return !candyGone && canBeDraggedBySnail && snailIntersectsCandy;
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/SnailDetachSelection.cs
+++ b/CutTheRopeDX/GameMain/SnailDetachSelection.cs
@@ -1,0 +1,29 @@
+using CutTheRopeDX.Framework.Physics;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// Selects which snails detach when a candy leaves play. A snail detaches only while it is actively
+    /// riding and its attached physics point is the candy being removed, so per-candy removals stay
+    /// isolated — eating one candy does not drop a snail riding another.
+    /// </summary>
+    internal static class SnailDetachSelection
+    {
+        /// <summary>
+        /// True when a snail should detach from <paramref name="targetPoint"/>: it is active and its
+        /// attached point is exactly that candy point.
+        /// </summary>
+        /// <param name="snailActive">True when the snail is in its active (riding) state.</param>
+        /// <param name="snailAttachedPoint">The point the snail currently rides, or null.</param>
+        /// <param name="targetPoint">The candy point being removed.</param>
+        public static bool ShouldDetach(
+            bool snailActive,
+            ConstraintedPoint snailAttachedPoint,
+            ConstraintedPoint targetPoint)
+        {
+            return snailActive
+                && snailAttachedPoint != null
+                && ReferenceEquals(snailAttachedPoint, targetPoint);
+        }
+    }
+}


### PR DESCRIPTION
## Description

There are some edge cases that I have overlooked when I worked on #233. This PR amends that, plus one older rendering bug unrelated to it.

## Changes

- Fix snails not detaching from a candy when it is eaten. With a single candy this was masked: eating went straight to the win transition, which detaches them anyway.
- On conveyor wrap, the ropes to cut are now identified by the rope's tail point instead of `Grab.candyNumber`. #233 gives every candy-bound grab `candyNumber = 0`, so wrapping one hook also cut the other candies' ropes.
- On level finish (win or lose), conveyor drags are now released. The win/loss input gate added in #233 swallows the pointer-up, so the belt kept its last drag delta and re-triggered its move sound every frame.
- All grab backing layers are now drawn before any rope, instead of interleaving per grab, so a moveable hook's rail can no longer paint over a rope drawn earlier. This one predates #233.