### PR TITLE
fix: Allow more cross-game interactions and fix some bugs

### DIFF
--- a/CutTheRopeDX.Tests/AntCandyInteractionTests.cs
+++ b/CutTheRopeDX.Tests/AntCandyInteractionTests.cs
@@ -15,31 +15,64 @@ namespace CutTheRopeDX.Tests
                 candyWaitingForFly: false,
                 isLastSegment: false,
                 candyInsideBounds: true,
-                candyHeldByHand: false));
+                candyHeldByHand: false,
+                candyInLantern: false,
+                candyInTransport: false,
+                candyCarriedByMouse: false));
         }
 
         [Fact]
         public void CanAttach_TrueEvenWhenSegmentAlreadyCarriesAnotherCandy()
         {
             // A lane carries multiple candies at once; an occupied segment must not block a new one.
-            Assert.True(AntCandyInteraction.CanAttach(true, true, false, false, true, false));
+            Assert.True(AntCandyInteraction.CanAttach(true, true, false, false, true, false, false, false, false));
         }
 
         [Fact]
         public void CanAttach_FalseWhenCandyOrSegmentStateBlocksInteraction()
         {
-            Assert.False(AntCandyInteraction.CanAttach(false, true, false, false, true, false));
-            Assert.False(AntCandyInteraction.CanAttach(true, segmentCanInteract: false, false, false, true, false));
-            Assert.False(AntCandyInteraction.CanAttach(true, true, candyWaitingForFly: true, false, true, false));
-            Assert.False(AntCandyInteraction.CanAttach(true, true, false, isLastSegment: true, true, false));
-            Assert.False(AntCandyInteraction.CanAttach(true, true, false, false, candyInsideBounds: false, false));
+            Assert.False(AntCandyInteraction.CanAttach(false, true, false, false, true, false, false, false, false));
+            Assert.False(AntCandyInteraction.CanAttach(true, segmentCanInteract: false, false, false, true, false, false, false, false));
+            Assert.False(AntCandyInteraction.CanAttach(true, true, candyWaitingForFly: true, false, true, false, false, false, false));
+            Assert.False(AntCandyInteraction.CanAttach(true, true, false, isLastSegment: true, true, false, false, false, false));
+            Assert.False(AntCandyInteraction.CanAttach(true, true, false, false, candyInsideBounds: false, false, false, false, false));
         }
 
         [Fact]
         public void CanAttach_FalseWhenCandyHeldByHand()
         {
             // A mechanical hand owns the candy; ants must not steal it back onto the conveyor.
-            Assert.False(AntCandyInteraction.CanAttach(true, true, false, false, true, candyHeldByHand: true));
+            Assert.False(AntCandyInteraction.CanAttach(true, true, false, false, true, candyHeldByHand: true, candyInLantern: false, candyInTransport: false, candyCarriedByMouse: false));
+        }
+
+        [Fact]
+        public void CanAttach_FalseWhenCandyIsInALantern()
+        {
+            // A lantern parks the candy point at the lantern position; if that spot lies inside an
+            // ant lane, ungated ants re-grab it in a loop (attach sfx -> can't ride -> detach ->
+            // cooldown -> fresh attach sfx again, forever).
+            Assert.False(AntCandyInteraction.CanAttach(
+                true, true, false, false, true, candyHeldByHand: false, candyInLantern: true,
+                candyInTransport: false, candyCarriedByMouse: false));
+        }
+
+        [Fact]
+        public void CanAttach_FalseWhenCandyIsInSockOrBambooTransit()
+        {
+            // Sock transit keeps the candy "present" (noCandy stays false), so ants need an
+            // explicit transit gate just like the hand gate.
+            Assert.False(AntCandyInteraction.CanAttach(
+                true, true, false, false, true, candyHeldByHand: false, candyInLantern: false,
+                candyInTransport: true, candyCarriedByMouse: false));
+        }
+
+        [Fact]
+        public void CanAttach_FalseWhenTheMouseCarriesTheCandy()
+        {
+            // Same rule as the hand: a holder owns the candy; ants must not grab it mid-steal.
+            Assert.False(AntCandyInteraction.CanAttach(
+                true, true, false, false, true, candyHeldByHand: false, candyInLantern: false,
+                candyInTransport: false, candyCarriedByMouse: true));
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/ConveyorAutoHookWrapTests.cs
+++ b/CutTheRopeDX.Tests/ConveyorAutoHookWrapTests.cs
@@ -1,0 +1,36 @@
+using CutTheRopeDX.Framework.Physics;
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+using static CutTheRopeDX.Framework.Helpers.CTRMathHelper;
+
+namespace CutTheRopeDX.Tests
+{
+    public class ConveyorAutoHookWrapTests
+    {
+        [Fact]
+        public void DidMoveToOtherSide_MovesAutoAttachedRopeWithHook()
+        {
+            ConstraintedPoint candy = new()
+            {
+                pos = Vect(100f, 160f),
+            };
+            Bungee rope = new Bungee().InitWithHeadAtXYTailAtTXTYandLength(
+                null, 100f, 100f, candy, candy.pos.X, candy.pos.Y, 60f);
+            Grab autoHook = new()
+            {
+                x = 200f,
+                y = 100f,
+            };
+            autoHook.SetRope(rope);
+
+            Assert.Equal(-1, autoHook.candyNumber);
+
+            autoHook.DidMoveToOtherSide();
+
+            Assert.Equal(200f, rope.bungeeAnchor.pos.X);
+            Assert.Equal(200f, candy.pos.X);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/GrabPlatformBindTests.cs
+++ b/CutTheRopeDX.Tests/GrabPlatformBindTests.cs
@@ -1,0 +1,52 @@
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    /// <summary>
+    /// Platforms (conveyor, DJ disc) never move a grab that has its own movement: bee/launcher
+    /// path movers and player drag rails are excluded at bind time; a kicked suction cup is a
+    /// free physics body, excluded dynamically per frame and resumed on re-stick.
+    /// </summary>
+    public class GrabPlatformBindTests
+    {
+        [Fact]
+        public void CanBind_TrueForAPlainHook()
+        {
+            Assert.True(GrabPlatformBind.CanBind(hasOwnMover: false, isMoveableRail: false));
+        }
+
+        [Fact]
+        public void CanBind_FalseForAPathMoverGrab()
+        {
+            // Bee and launcher keep their own movement; the platform must not fight it.
+            Assert.False(GrabPlatformBind.CanBind(hasOwnMover: true, isMoveableRail: false));
+        }
+
+        [Fact]
+        public void CanBind_FalseForAMoveableRailGrab()
+        {
+            Assert.False(GrabPlatformBind.CanBind(hasOwnMover: false, isMoveableRail: true));
+        }
+
+        [Fact]
+        public void FollowsPlatform_TrueForABoundStuckGrab()
+        {
+            Assert.True(GrabPlatformBind.FollowsPlatform(canBind: true, isKickedFree: false));
+        }
+
+        [Fact]
+        public void FollowsPlatform_FalseWhileKickedFree()
+        {
+            // Kicked suction cup falls freely; the platform skips it until it re-sticks.
+            Assert.False(GrabPlatformBind.FollowsPlatform(canBind: true, isKickedFree: true));
+        }
+
+        [Fact]
+        public void FollowsPlatform_FalseWhenNotBindableAtAll()
+        {
+            Assert.False(GrabPlatformBind.FollowsPlatform(canBind: false, isKickedFree: false));
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/HandGrabTests.cs
+++ b/CutTheRopeDX.Tests/HandGrabTests.cs
@@ -33,5 +33,24 @@ namespace CutTheRopeDX.Tests
             Assert.False(HandGrab.ShouldGrab(true, candyPresent: false, false, false, true));
             Assert.False(HandGrab.ShouldGrab(true, true, false, false, inRange: false));
         }
+
+        [Fact]
+        public void ShouldGrab_FalseForACandyInSockTransit()
+        {
+            // Sock transit keeps the candy "present" (noCandy stays false), so the gate needs
+            // the explicit sock parameter.
+            Assert.False(HandGrab.ShouldGrab(
+                handIdle: true, candyPresent: true, candyInLantern: false, candyInSock: true, inRange: true));
+        }
+
+        [Fact]
+        public void ShouldGrab_FalseForACandyInBambooTransit()
+        {
+            // Bamboo transit sets noCandy = true (GameScene.Systems.OperateBambooTube), so the
+            // candyPresent parameter is the bamboo gate. If bamboo ever stops setting noCandy,
+            // this pin documents that the hand gate must gain a bamboo parameter.
+            Assert.False(HandGrab.ShouldGrab(
+                handIdle: true, candyPresent: false, candyInLantern: false, candyInSock: false, inRange: true));
+        }
     }
 }

--- a/CutTheRopeDX.Tests/HeadlessGame.cs
+++ b/CutTheRopeDX.Tests/HeadlessGame.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Xml.Linq;
 
 using CutTheRopeDX.Framework;
 using CutTheRopeDX.Framework.Core;
@@ -69,6 +70,27 @@ namespace CutTheRopeDX.Tests
             GameController controller = new(root);
             controller.Activate();
             return controller;
+        }
+
+        /// <summary>
+        /// Loads a scenario built in code (see <c>Interactions/Scenario</c>) instead of a shipping
+        /// level. The map element goes through the same resource-ensure and <see cref="GameScene.Show"/>
+        /// path a real level takes, so loaded objects are wired exactly as in the game.
+        /// </summary>
+        /// <param name="map">The scenario's level element.</param>
+        /// <param name="pack">Zero-based pack index, for pack-dependent visuals.</param>
+        /// <param name="level">Zero-based level index.</param>
+        /// <returns>The loaded scene.</returns>
+        public GameScene LoadScenarioMap(XElement map, int pack = 0, int level = 0)
+        {
+            CTRRootController root = (CTRRootController)Application.SharedRootController();
+            root.SetPack(pack);
+            root.SetLevel(level);
+            root.PrepareMapAndEnsureResources(map, "scenario.xml");
+
+            GameScene scene = new();
+            scene.Show();
+            return scene;
         }
 
         /// <summary>Advances a scene by whole frames at the engine's fixed delta.</summary>

--- a/CutTheRopeDX.Tests/Interactions/Act.cs
+++ b/CutTheRopeDX.Tests/Interactions/Act.cs
@@ -26,20 +26,19 @@ namespace CutTheRopeDX.Tests.Interactions
         /// <param name="scene">Scene under test.</param>
         /// <param name="candy">Candy to bind.</param>
         /// <returns>The bound rocket.</returns>
-        public static Rocket BindRocket(GameScene scene, CandyContext candy)
+        public static Rocket BindRocket(GameScene scene, CandyContext candy, int rocketIndex = 0)
         {
-            Rocket rocket = scene.Rockets()[0];
+            Rocket rocket = scene.Rockets()[rocketIndex];
             Chase(
                 scene,
                 candy,
                 position =>
                 {
-                    rocket.x = position.X;
-                    rocket.y = position.Y;
+                    MoveTo(rocket, position);
                     rocket.point.pos = position;
                     rocket.point.prevPos = position;
                 },
-                () => candy.HasActiveRocket,
+                () => candy.activeRocket == rocket,
                 "the rocket never bound to the candy");
             return rocket;
         }
@@ -48,10 +47,25 @@ namespace CutTheRopeDX.Tests.Interactions
         /// <param name="scene">Scene under test.</param>
         /// <param name="candy">Candy to capture.</param>
         /// <returns>The capturing bubble.</returns>
-        public static Bubble CaptureInBubble(GameScene scene, CandyContext candy)
+        public static Bubble CaptureInBubble(GameScene scene, CandyContext candy, int bubbleIndex = 0)
         {
-            Bubble bubble = scene.Bubbles()[0];
-            Chase(scene, candy, position => MoveTo(bubble, position), () => candy.bubble != null, "the bubble never captured the candy");
+            Bubble bubble = scene.Bubbles()[bubbleIndex];
+            Chase(scene, candy, position => MoveTo(bubble, position), () => candy.bubble == bubble, "the bubble never captured the candy");
+            return bubble;
+        }
+
+        /// <summary>
+        /// Pushes a bubble onto the candy without requiring it to capture. Used where the matrix
+        /// says the bubble loses the exchange - a rocket-bound or snail-ridden candy pops it.
+        /// </summary>
+        /// <param name="scene">Scene under test.</param>
+        /// <param name="candy">Candy to touch.</param>
+        /// <param name="bubbleIndex">Index of the bubble in the scene.</param>
+        /// <returns>The bubble that was pushed.</returns>
+        public static Bubble PushBubbleAgainst(GameScene scene, CandyContext candy, int bubbleIndex = 0)
+        {
+            Bubble bubble = scene.Bubbles()[bubbleIndex];
+            Chase(scene, candy, position => MoveTo(bubble, position), () => bubble.popped, "the bubble never reached the candy");
             return bubble;
         }
 
@@ -59,10 +73,15 @@ namespace CutTheRopeDX.Tests.Interactions
         /// <param name="scene">Scene under test.</param>
         /// <param name="candy">Candy to ride.</param>
         /// <returns>The riding snail.</returns>
-        public static Snail RideSnail(GameScene scene, CandyContext candy)
+        public static Snail RideSnail(GameScene scene, CandyContext candy, int snailIndex = 0)
         {
-            Snail snail = scene.Snails()[0];
-            Chase(scene, candy, position => MoveTo(snail, position), () => scene.SnailCount(candy) == 1, "the snail never attached to the candy");
+            Snail snail = scene.Snails()[snailIndex];
+            Chase(
+                scene,
+                candy,
+                position => MoveTo(snail, position),
+                () => snail.state == Snail.SNAIL_STATE_ACTIVE && snail.AttachedPoint() == candy.point,
+                "the snail never attached to the candy");
             return snail;
         }
 
@@ -87,6 +106,23 @@ namespace CutTheRopeDX.Tests.Interactions
             Mouse mouse = scene.Mice()[0];
             Chase(scene, candy, position => MoveTo(mouse, position), () => candy.carriedByMouse, "the mouse never took the candy");
             return mouse;
+        }
+
+        /// <summary>
+        /// Has the active mouse take the candy from where its hole already is, instead of moving the
+        /// hole onto the candy. Use this when the point of the test is that the mouse drags the
+        /// candy somewhere else - off an ant lane, for instance.
+        /// </summary>
+        /// <param name="scene">Scene under test.</param>
+        /// <param name="candy">Candy to steal.</param>
+        /// <returns>The carrying mouse.</returns>
+        public static Mouse CarryByMouseWithoutMovingIt(GameScene scene, CandyContext candy)
+        {
+            Assert.True(
+                Interaction.StepUntil(scene, () => candy.carriedByMouse),
+                "the mouse never took the candy");
+            HeadlessGame.StepFrames(scene, SettleFrames);
+            return scene.Mice()[0];
         }
 
         /// <summary>
@@ -200,13 +236,18 @@ namespace CutTheRopeDX.Tests.Interactions
                 "the bamboo tube never took the candy");
         }
 
-        /// <summary>Moves a scene element so it sits on a world position.</summary>
+        /// <summary>
+        /// Moves a scene element so it sits on a world position, hitbox included. Collision runs off
+        /// the cached draw position, which the update loop recomputes for the candy but not for
+        /// scenery, so a moved object would otherwise keep colliding where it was loaded.
+        /// </summary>
         /// <param name="element">Element to move.</param>
         /// <param name="position">Target world position.</param>
         public static void MoveTo(BaseElement element, Vector position)
         {
             element.x = position.X;
             element.y = position.Y;
+            BaseElement.CalculateTopLeft(element);
         }
 
         /// <summary>

--- a/CutTheRopeDX.Tests/Interactions/Act.cs
+++ b/CutTheRopeDX.Tests/Interactions/Act.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Reflection;
+
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.Framework.Helpers;
+using CutTheRopeDX.Framework.Visual;
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Forms an attachment on a candy, or fires one of the matrix's events at it, by driving the
+    /// real update loop. Every helper moves the *object* onto the candy and keeps it there each
+    /// frame, so a candy that is swinging on a rope or pinned by a holder (hand, mouse, ants) can
+    /// still be acted on. Each helper asserts the interaction actually happened, so a matrix test
+    /// that reaches its own assertions is known to have started from the state it claims.
+    /// </summary>
+    internal static class Act
+    {
+        /// <summary>Frames run after an interaction fires, so its consequences land.</summary>
+        private const int SettleFrames = 3;
+
+        /// <summary>Binds the scene's rocket to the candy.</summary>
+        /// <param name="scene">Scene under test.</param>
+        /// <param name="candy">Candy to bind.</param>
+        /// <returns>The bound rocket.</returns>
+        public static Rocket BindRocket(GameScene scene, CandyContext candy)
+        {
+            Rocket rocket = scene.Rockets()[0];
+            Chase(
+                scene,
+                candy,
+                position =>
+                {
+                    rocket.x = position.X;
+                    rocket.y = position.Y;
+                    rocket.point.pos = position;
+                    rocket.point.prevPos = position;
+                },
+                () => candy.HasActiveRocket,
+                "the rocket never bound to the candy");
+            return rocket;
+        }
+
+        /// <summary>Captures the candy in the scene's bubble.</summary>
+        /// <param name="scene">Scene under test.</param>
+        /// <param name="candy">Candy to capture.</param>
+        /// <returns>The capturing bubble.</returns>
+        public static Bubble CaptureInBubble(GameScene scene, CandyContext candy)
+        {
+            Bubble bubble = scene.Bubbles()[0];
+            Chase(scene, candy, position => MoveTo(bubble, position), () => candy.bubble != null, "the bubble never captured the candy");
+            return bubble;
+        }
+
+        /// <summary>Attaches the scene's snail to the candy.</summary>
+        /// <param name="scene">Scene under test.</param>
+        /// <param name="candy">Candy to ride.</param>
+        /// <returns>The riding snail.</returns>
+        public static Snail RideSnail(GameScene scene, CandyContext candy)
+        {
+            Snail snail = scene.Snails()[0];
+            Chase(scene, candy, position => MoveTo(snail, position), () => scene.SnailCount(candy) == 1, "the snail never attached to the candy");
+            return snail;
+        }
+
+        /// <summary>Has the given hand grab the candy.</summary>
+        /// <param name="scene">Scene under test.</param>
+        /// <param name="candy">Candy to grab.</param>
+        /// <param name="handIndex">Index of the hand in the scene.</param>
+        /// <returns>The grabbing hand.</returns>
+        public static MechanicalHand GrabWithHand(GameScene scene, CandyContext candy, int handIndex = 0)
+        {
+            MechanicalHand hand = scene.Hands()[handIndex];
+            Chase(scene, candy, position => MoveClawTo(hand, position), () => candy.capturingHand == hand, "the hand never grabbed the candy");
+            return hand;
+        }
+
+        /// <summary>Has the active mouse steal the candy.</summary>
+        /// <param name="scene">Scene under test.</param>
+        /// <param name="candy">Candy to steal.</param>
+        /// <returns>The carrying mouse.</returns>
+        public static Mouse CarryByMouse(GameScene scene, CandyContext candy)
+        {
+            Mouse mouse = scene.Mice()[0];
+            Chase(scene, candy, position => MoveTo(mouse, position), () => candy.carriedByMouse, "the mouse never took the candy");
+            return mouse;
+        }
+
+        /// <summary>
+        /// Waits for the ant conveyor to pick the candy up. Unlike the other helpers this one does
+        /// not move anything: an ant segment is a fixed lane, and the candy has to be on it.
+        /// </summary>
+        /// <param name="scene">Scene under test.</param>
+        /// <param name="candy">Candy to hand to the ants.</param>
+        public static void CarryByAnts(GameScene scene, CandyContext candy)
+        {
+            Assert.True(
+                Interaction.StepUntil(scene, () => candy.antSegment != null),
+                "the ants never picked up the candy");
+        }
+
+        /// <summary>Feeds the candy to the nearest Om Nom.</summary>
+        /// <param name="scene">Scene under test.</param>
+        /// <param name="candy">Candy to feed.</param>
+        public static void Eat(GameScene scene, CandyContext candy)
+        {
+            TargetContext target = scene.Targets()[0];
+            Chase(
+                scene,
+                candy,
+                position => MoveMouthTo(target.targetObject, position),
+                // Falling asleep is what only eating does; candy-gone alone would also be true of a
+                // candy that drifted off screen while Om Nom was chasing it.
+                () => target.asleep,
+                "Om Nom never ate the candy");
+        }
+
+        /// <summary>Destroys the candy on the scene's spikes.</summary>
+        /// <param name="scene">Scene under test.</param>
+        /// <param name="candy">Candy to destroy.</param>
+        public static void BreakOnSpikes(GameScene scene, CandyContext candy)
+        {
+            Spikes spikes = scene.SpikeStrips()[0];
+            Chase(
+                scene,
+                candy,
+                position =>
+                {
+                    spikes.x = position.X;
+                    spikes.y = position.Y;
+                    spikes.UpdateRotation();
+                },
+                () => candy.noCandy || scene.PrimaryCandyGone(),
+                "the spikes never broke the candy");
+
+            // Losing is a two-stage event: the break tears the candy down, and the scheduled
+            // GameLost that follows finishes the job (hands, mice). The matrix row describes the
+            // finished state, so wait for the loss itself.
+            Assert.True(
+                Interaction.StepUntil(scene, () => scene.Outcomes().LostCount > 0),
+                "the broken candy never lose the level");
+        }
+
+        /// <summary>Captures the candy in the scene's lantern.</summary>
+        /// <param name="scene">Scene under test.</param>
+        /// <param name="candy">Candy to capture.</param>
+        public static void CaptureInLantern(GameScene scene, CandyContext candy)
+        {
+            Lantern lantern = Lantern.GetAllLanterns()[0];
+            Chase(scene, candy, position => MoveTo(lantern, position), () => candy.inLantern, "the lantern never captured the candy");
+        }
+
+        /// <summary>
+        /// Sends the candy into the scene's first magic hat. The hat is turned to face however the
+        /// candy is travelling, because a hat only swallows a candy moving into its mouth - a
+        /// bubbled candy rises and an ant-carried one slides sideways.
+        /// </summary>
+        /// <param name="scene">Scene under test.</param>
+        /// <param name="candy">Candy to swallow.</param>
+        public static void EnterHat(GameScene scene, CandyContext candy)
+        {
+            Sock hat = scene.Hats()[0];
+            Chase(
+                scene,
+                candy,
+                position =>
+                {
+                    MoveTo(hat, position);
+                    hat.rotation = MouthAngleFacing(candy.point.posDelta, hat.rotation);
+                    hat.UpdateRotation();
+                },
+                () => candy.targetSock != null,
+                "the magic hat never took the candy");
+        }
+
+        /// <summary>
+        /// Sends the candy into the scene's bamboo tube. <paramref name="mouth"/> must match the way
+        /// the scenario authored the tube, and the way the candy is travelling.
+        /// </summary>
+        /// <param name="scene">Scene under test.</param>
+        /// <param name="candy">Candy to swallow.</param>
+        /// <param name="mouth">Direction the tube's catching hole faces.</param>
+        public static void EnterBambooTube(GameScene scene, CandyContext candy, TubeMouth mouth)
+        {
+            BambooTube tube = scene.BambooTubes()[0];
+            Vector toCentre = TubeGeometry.CentreDirection(mouth);
+            float halfBody = tube.bb.w * 0.5f;
+            Chase(
+                scene,
+                candy,
+                position =>
+                {
+                    MoveTo(tube, new Vector(position.X + (toCentre.X * halfBody), position.Y + (toCentre.Y * halfBody)));
+                    RefreshTubeHoles(tube);
+                },
+                () => candy.targetBambooTube != null,
+                "the bamboo tube never took the candy");
+        }
+
+        /// <summary>Moves a scene element so it sits on a world position.</summary>
+        /// <param name="element">Element to move.</param>
+        /// <param name="position">Target world position.</param>
+        public static void MoveTo(BaseElement element, Vector position)
+        {
+            element.x = position.X;
+            element.y = position.Y;
+        }
+
+        /// <summary>
+        /// Shifts Om Nom so the mouth hitbox - a thin slit well below the sprite's origin - lands on
+        /// a world position. Placing the origin there instead would hold the candy above the mouth,
+        /// where it is never eaten.
+        /// </summary>
+        /// <param name="omNom">Om Nom's game object.</param>
+        /// <param name="position">Target mouth position.</param>
+        public static void MoveMouthTo(GameObject omNom, Vector position)
+        {
+            float mouthX = omNom.drawX + omNom.bb.x + (omNom.bb.w / 2f);
+            float mouthY = omNom.drawY + omNom.bb.y + (omNom.bb.h / 2f);
+            float dx = position.X - mouthX;
+            float dy = position.Y - mouthY;
+            omNom.x += dx;
+            omNom.y += dy;
+            omNom.drawX += dx;
+            omNom.drawY += dy;
+        }
+
+        /// <summary>Shifts a hand so its claw lands on a world position.</summary>
+        /// <param name="hand">Hand to move.</param>
+        /// <param name="position">Target claw position.</param>
+        public static void MoveClawTo(MechanicalHand hand, Vector position)
+        {
+            Vector claw = hand.ClawPosition();
+            float dx = position.X - claw.X;
+            float dy = position.Y - claw.Y;
+            hand.x += dx;
+            hand.y += dy;
+            hand.drawX += dx;
+            hand.drawY += dy;
+            hand.cPoint.pos = hand.ClawPosition();
+        }
+
+        /// <summary>
+        /// Recomputes a tube's hole positions after it has been moved. The tube caches them and
+        /// only refreshes on rotation, so a moved tube would otherwise keep catching candy at the
+        /// place it was loaded.
+        /// </summary>
+        /// <param name="tube">Tube that moved.</param>
+        private static void RefreshTubeHoles(BambooTube tube)
+        {
+            MethodInfo refresh = typeof(BambooTube).GetMethod(
+                "UpdateBambooRotation",
+                BindingFlags.Instance | BindingFlags.NonPublic)
+                ?? throw new MissingMethodException(nameof(BambooTube), "UpdateBambooRotation");
+            _ = refresh.Invoke(tube, null);
+        }
+
+        /// <summary>
+        /// Rotation that puts a mouth square across <paramref name="motion"/>. The engine tests the
+        /// candy's travel in the mouth's own frame and demands a non-negative downward component,
+        /// which a mouth turned to motion angle minus 90 degrees always satisfies.
+        /// </summary>
+        /// <param name="motion">The candy's per-frame travel.</param>
+        /// <param name="current">Rotation to keep when the candy is not moving.</param>
+        /// <returns>The rotation in degrees.</returns>
+        private static float MouthAngleFacing(Vector motion, float current)
+        {
+            const float stillThreshold = 1e-4f;
+            return ((motion.X * motion.X) + (motion.Y * motion.Y)) < stillThreshold
+                ? current
+                : (float)(Math.Atan2(motion.Y, motion.X) * 180d / Math.PI) - 90f;
+        }
+
+        private static void Chase(GameScene scene, CandyContext candy, Action<Vector> place, Func<bool> done, string message)
+        {
+            place(candy.point.pos);
+            Assert.True(
+                Interaction.StepUntil(scene, () => place(candy.point.pos), done),
+                message);
+
+            // The matrix describes the settled state, not the state mid-frame: several teardowns
+            // (the mouse's carry flag, hand release, rope hiding) land on the frame after the one
+            // that fired the event.
+            HeadlessGame.StepFrames(scene, SettleFrames);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/Act.cs
+++ b/CutTheRopeDX.Tests/Interactions/Act.cs
@@ -22,6 +22,9 @@ namespace CutTheRopeDX.Tests.Interactions
         /// <summary>Frames run after an interaction fires, so its consequences land.</summary>
         private const int SettleFrames = 3;
 
+        /// <summary>World Y well past the kill line of any scenario-sized map.</summary>
+        private const float OffScreenY = 4000f;
+
         /// <summary>Binds the scene's rocket to the candy.</summary>
         /// <param name="scene">Scene under test.</param>
         /// <param name="candy">Candy to bind.</param>
@@ -178,6 +181,24 @@ namespace CutTheRopeDX.Tests.Interactions
             Assert.True(
                 Interaction.StepUntil(scene, () => scene.Outcomes().LostCount > 0),
                 "the broken candy never lose the level");
+        }
+
+        /// <summary>
+        /// Loses the candy off the bottom of the screen - the matrix's other "Lost" trigger, which
+        /// the engine handles on its own path rather than through the hazard break.
+        /// </summary>
+        /// <param name="scene">Scene under test.</param>
+        /// <param name="candy">Candy to lose.</param>
+        public static void LoseOffScreen(GameScene scene, CandyContext candy)
+        {
+            Interaction.Drop(candy);
+            Vector belowTheMap = new(candy.point.pos.X, OffScreenY);
+            Interaction.PlaceCandyAt(candy, belowTheMap);
+
+            Assert.True(
+                Interaction.StepUntil(scene, () => scene.Outcomes().LostCount > 0),
+                "the candy that left the screen never lost the level");
+            HeadlessGame.StepFrames(scene, SettleFrames);
         }
 
         /// <summary>Captures the candy in the scene's lantern.</summary>

--- a/CutTheRopeDX.Tests/Interactions/AttachmentSetupTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/AttachmentSetupTests.cs
@@ -1,0 +1,185 @@
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Every attachment the matrix talks about, formed by the real update loop. The matrix rows
+    /// build on these, so a break here explains breakage everywhere else.
+    /// </summary>
+    public sealed class AttachmentSetupTests
+    {
+        [Fact]
+        public void RocketBinds_WhenTheCandyTouchesAnIdleRocket()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(160, 440)
+                .Rocket(160, 200)
+                .Build();
+
+            CandyContext candy = scene.Candy();
+            Rocket rocket = scene.Rockets()[0];
+            Interaction.Hover(candy);
+            Interaction.PlaceCandyAt(candy, Interaction.At(rocket.x, rocket.y));
+
+            Assert.True(Interaction.StepUntil(scene, () => candy.HasActiveRocket));
+        }
+
+        [Fact]
+        public void BubbleCaptures_WhenTheCandyEntersItsRadius()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(160, 440)
+                .Bubble(160, 200)
+                .Build();
+
+            CandyContext candy = scene.Candy();
+            Bubble bubble = scene.Bubbles()[0];
+            Interaction.Hover(candy);
+            Interaction.PlaceCandyAt(candy, Interaction.At(bubble.x, bubble.y));
+
+            Assert.True(Interaction.StepUntil(scene, () => candy.bubble != null));
+        }
+
+        [Fact]
+        public void SnailAttaches_WhenItReachesTheCandy()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(160, 440)
+                .Snail(160, 200)
+                .Build();
+
+            CandyContext candy = scene.Candy();
+            Snail snail = scene.Snails()[0];
+            Interaction.Hover(candy);
+            Interaction.PlaceCandyAt(candy, Interaction.At(snail.x, snail.y));
+
+            Assert.True(Interaction.StepUntil(scene, () => scene.SnailCount(candy) == 1));
+        }
+
+        [Fact]
+        public void HandGrabs_WhenTheCandySitsAtTheClaw()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(160, 440)
+                .Hand(160, 120, segmentLength: 20, segmentAngle: 90f)
+                .Build();
+
+            CandyContext candy = scene.Candy();
+            MechanicalHand hand = scene.Hands()[0];
+            Interaction.Hover(candy);
+            Interaction.PlaceCandyAt(candy, hand.ClawPosition());
+
+            Assert.True(Interaction.StepUntil(scene, () => candy.capturingHand == hand));
+        }
+
+        [Fact]
+        public void MouseGrabs_OnceItHasPoppedOutOfItsHole()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(160, 440)
+                .Mouse(160, 200)
+                .Build();
+
+            CandyContext candy = scene.Candy();
+            Interaction.Hover(candy);
+            Interaction.PlaceCandyAt(candy, Interaction.At(Scenario.New().WorldX(160), Scenario.WorldY(200)));
+
+            Assert.True(Interaction.StepUntil(scene, () => candy.carriedByMouse));
+        }
+
+        [Fact]
+        public void AntsCarry_WhenTheCandyLandsOnASegment()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(160, 440)
+                .Ants(120, 200, path: "80,0")
+                .Build();
+
+            CandyContext candy = scene.Candy();
+            Interaction.Hover(candy);
+
+            Assert.True(Interaction.StepUntil(scene, () => candy.antSegment != null));
+        }
+
+        [Fact]
+        public void LanternCaptures_WhenTheCandyDriftsIntoIt()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(160, 440)
+                .Lantern(160, 200)
+                .Build();
+
+            CandyContext candy = scene.Candy();
+            Interaction.Hover(candy);
+
+            Assert.True(Interaction.StepUntil(scene, () => candy.inLantern));
+        }
+
+        [Fact]
+        public void MagicHatSwallowsTheCandy_WhenItFallsThroughTheMouth()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 140)
+                .OmNom(160, 440)
+                .Hat(160, 200, group: 1)
+                .Hat(60, 300, group: 1)
+                .Build();
+
+            CandyContext candy = scene.Candy();
+
+            Assert.True(Interaction.StepUntil(scene, () => candy.targetSock != null));
+        }
+
+        [Fact]
+        public void BambooTubeSwallowsTheCandy_WhenItFallsIn()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 140)
+                .OmNom(160, 440)
+                // The mouth faces up, so the falling candy moves *into* it - a tube only catches a
+                // candy travelling toward the hole, never one leaving it.
+                .BambooTube(160, 220, TubeMouth.CatchesFalling)
+                .Build();
+
+            CandyContext candy = scene.Candy();
+
+            Assert.True(Interaction.StepUntil(scene, () => candy.targetBambooTube != null));
+        }
+
+        [Fact]
+        public void OmNomEatsTheCandy_WhenItFallsIntoAnOpenMouth()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 140)
+                .OmNom(160, 300)
+                .Build();
+
+            CandyContext candy = scene.Candy();
+
+            Assert.True(Interaction.StepUntil(scene, () => candy.noCandy));
+        }
+
+        [Fact]
+        public void SpikesBreakTheCandy_OnContact()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 140)
+                .OmNom(30, 440)
+                .Spikes(160, 260)
+                .Build();
+
+            // A hazard break of the *primary* candy goes down the singleton path, which sets the
+            // scene's own gone-flag rather than the context's (BreakCandyFromHazard, index 0).
+            Assert.True(Interaction.StepUntil(scene, scene.PrimaryCandyGone));
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/BambooTubeEntryRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/BambooTubeEntryRowTests.cs
@@ -1,0 +1,114 @@
+using System;
+
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Interaction matrix, "Bamboo tube entry" row: like the magic hat, the tube teleports the
+    /// candy - ropes, hand, mouse and ants are stripped, while the rocket (hidden), the bubble and
+    /// the snail travel with it.
+    /// </summary>
+    public sealed class BambooTubeEntryRowTests
+    {
+        [Fact]
+        public void TubeEntry_ReleasesItsRopes()
+        {
+            (GameScene scene, CandyContext candy) = Rig(TubeMouth.CatchesFalling, s => s.Rope(160, 120, length: 40));
+            Assert.Equal(1, scene.AttachedRopeCount(candy));
+
+            Act.EnterBambooTube(scene, candy, TubeMouth.CatchesFalling);
+
+            Assert.Equal(0, scene.AttachedRopeCount(candy));
+        }
+
+        [Fact]
+        public void TubeEntry_DetachesTheHandHoldingIt()
+        {
+            (GameScene scene, CandyContext candy) = Rig(TubeMouth.CatchesFalling, s => s.Hand(160, 120, segmentLength: 20, segmentAngle: 90f));
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            Act.EnterBambooTube(scene, candy, TubeMouth.CatchesFalling);
+
+            Assert.Null(candy.capturingHand);
+            Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, hand.state);
+        }
+
+        [Fact]
+        public void TubeEntry_CarriesTheRocketThrough_HiddenForTheTransit()
+        {
+            (GameScene scene, CandyContext candy) = Rig(TubeMouth.CatchesFalling, s => s.Rocket(160, 200, impulse: 0f));
+            Rocket rocket = Act.BindRocket(scene, candy);
+
+            Act.EnterBambooTube(scene, candy, TubeMouth.CatchesFalling);
+
+            Assert.True(candy.HasActiveRocket);
+            Assert.Same(rocket, candy.activeRocket);
+            Assert.False(rocket.visible);
+        }
+
+        [Fact]
+        public void TubeEntry_KeepsItsBubble()
+        {
+            // A bubbled candy rises, so the tube has to face down to catch it.
+            (GameScene scene, CandyContext candy) = Rig(TubeMouth.CatchesRising, s => s.Bubble(160, 200));
+            Bubble bubble = Act.CaptureInBubble(scene, candy);
+            Interaction.Drop(candy);
+
+            Act.EnterBambooTube(scene, candy, TubeMouth.CatchesRising);
+
+            Assert.Same(bubble, candy.bubble);
+        }
+
+        [Fact]
+        public void TubeEntry_CarriesTheSnailThrough()
+        {
+            (GameScene scene, CandyContext candy) = Rig(TubeMouth.CatchesFalling, s => s.Snail(160, 200));
+            _ = Act.RideSnail(scene, candy);
+
+            Act.EnterBambooTube(scene, candy, TubeMouth.CatchesFalling);
+
+            Assert.Equal(1, scene.SnailCount(candy));
+        }
+
+        [Fact]
+        public void TubeEntry_TakesTheCandyOffTheAnts()
+        {
+            // The lane runs left to right, so the tube faces left to meet the candy head on.
+            (GameScene scene, CandyContext candy) = Rig(TubeMouth.CatchesRightward, s => s.Ants(120, 200, path: "80,0"));
+            Act.CarryByAnts(scene, candy);
+
+            Act.EnterBambooTube(scene, candy, TubeMouth.CatchesRightward);
+
+            Assert.Null(candy.antSegment);
+        }
+
+        [Fact]
+        public void TubeEntry_MakesTheMouseDropIt()
+        {
+            (GameScene scene, CandyContext candy) = Rig(TubeMouth.CatchesFalling, s => s.Mouse(160, 200));
+            _ = Act.CarryByMouse(scene, candy);
+
+            Act.EnterBambooTube(scene, candy, TubeMouth.CatchesFalling);
+
+            Assert.False(scene.MouseCarries(candy));
+            Assert.False(candy.carriedByMouse);
+        }
+
+        private static (GameScene Scene, CandyContext Candy) Rig(TubeMouth mouth, Func<Scenario, Scenario> attachment)
+        {
+            // The tube parks in a corner; Act.EnterBambooTube brings it to the candy.
+            GameScene scene = attachment(
+                Scenario.New()
+                    .Candy(160, 200)
+                    .OmNom(20, 460)
+                    .BambooTube(20, 40, mouth))
+                .Build();
+            CandyContext candy = scene.Candy();
+            Interaction.Hover(candy);
+            return (scene, candy);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/BubbleCaptureRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/BubbleCaptureRowTests.cs
@@ -1,0 +1,106 @@
+using System;
+
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Interaction matrix, "Bubble capture" row: a bubble is the weakest claim on a candy. It keeps
+    /// ropes and a carrying mouse, replaces an earlier bubble, and simply pops against a rocket or
+    /// a snail rather than taking the candy from them.
+    /// </summary>
+    public sealed class BubbleCaptureRowTests
+    {
+        [Fact]
+        public void BubbleCapture_KeepsItsRopes()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Rope(160, 120, length: 40));
+
+            _ = Act.CaptureInBubble(scene, candy);
+
+            Assert.Equal(1, scene.AttachedRopeCount(candy));
+        }
+
+        [Fact]
+        public void BubbleCapture_PopsAgainstARocketBoundCandy_WithoutCapturingIt()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Rocket(160, 200, impulse: 0f));
+            Rocket rocket = Act.BindRocket(scene, candy);
+
+            Bubble bubble = Act.PushBubbleAgainst(scene, candy);
+
+            Assert.True(bubble.popped);
+            Assert.Null(candy.bubble);
+            Assert.Same(rocket, candy.activeRocket);
+        }
+
+        [Fact]
+        public void BubbleCapture_ReplacesTheBubbleAlreadyCarryingIt()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Bubble(60, 200));
+            Bubble first = Act.CaptureInBubble(scene, candy, bubbleIndex: 1);
+
+            Bubble second = Act.CaptureInBubble(scene, candy, bubbleIndex: 0);
+
+            Assert.Same(second, candy.bubble);
+            Assert.NotSame(first, candy.bubble);
+        }
+
+        [Fact]
+        public void BubbleCapture_PopsAgainstASnailRiddenCandy()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Snail(160, 200));
+            _ = Act.RideSnail(scene, candy);
+
+            Bubble bubble = Act.PushBubbleAgainst(scene, candy);
+
+            Assert.True(bubble.popped);
+            Assert.Null(candy.bubble);
+            Assert.Equal(1, scene.SnailCount(candy));
+        }
+
+        [Fact]
+        public void BubbleCapture_TakesTheCandyOffTheAntsByFloatingItAway()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Ants(120, 200, path: "80,0"));
+            Act.CarryByAnts(scene, candy);
+
+            Bubble bubble = Act.CaptureInBubble(scene, candy);
+            HeadlessGame.StepFrames(scene, 150);
+
+            // "Implicit release": capture detaches nothing by itself, and the ant carry keeps
+            // overwriting the candy's position, but the bubble's lift eventually pulls it clear of
+            // the segment and the lane lets go.
+            Assert.Same(bubble, candy.bubble);
+            Assert.Null(candy.antSegment);
+        }
+
+        [Fact]
+        public void BubbleCapture_LeavesTheMouseCarryingIt()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Mouse(160, 200));
+            _ = Act.CarryByMouse(scene, candy);
+
+            Bubble bubble = Act.CaptureInBubble(scene, candy);
+
+            Assert.Same(bubble, candy.bubble);
+            Assert.True(candy.carriedByMouse);
+        }
+
+        private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment)
+        {
+            // Bubble 0 is the one under test and waits in a corner until Act brings it over.
+            GameScene scene = attachment(
+                Scenario.New()
+                    .Candy(160, 200)
+                    .OmNom(20, 460)
+                    .Bubble(20, 40))
+                .Build();
+            CandyContext candy = scene.Candy();
+            Interaction.Hover(candy);
+            return (scene, candy);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/EatenRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/EatenRowTests.cs
@@ -1,0 +1,115 @@
+using System;
+
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Interaction matrix, "Eaten" row: an Om Nom swallowing a candy must leave nothing attached
+    /// to it - the rope is released, the hand lets go, the rocket burns out, the bubble pops, the
+    /// snail hops off, the ants drop it, and a mouse carrying it gives it up.
+    /// </summary>
+    public sealed class EatenRowTests
+    {
+        [Fact]
+        public void Eaten_ReleasesItsRopes()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Rope(160, 120, length: 40));
+            Assert.Equal(1, scene.AttachedRopeCount(candy));
+
+            Act.Eat(scene, candy);
+
+            Assert.Equal(0, scene.AttachedRopeCount(candy));
+        }
+
+        [Fact]
+        public void Eaten_DetachesTheHandHoldingIt()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Hand(160, 120, segmentLength: 20, segmentAngle: 90f));
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            Act.Eat(scene, candy);
+
+            Assert.Null(candy.capturingHand);
+            Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, hand.state);
+        }
+
+        [Fact]
+        public void Eaten_ExhaustsItsRocket()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Rocket(160, 200, impulse: 0f));
+            Rocket rocket = Act.BindRocket(scene, candy);
+
+            Act.Eat(scene, candy);
+
+            Assert.False(candy.HasActiveRocket);
+            Assert.Equal(Rocket.STATE_ROCKET_EXAUST, rocket.state);
+        }
+
+        [Fact]
+        public void Eaten_PopsItsBubble()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Bubble(160, 200));
+            _ = Act.CaptureInBubble(scene, candy);
+
+            Act.Eat(scene, candy);
+
+            Assert.Null(candy.bubble);
+        }
+
+        [Fact]
+        public void Eaten_DetachesItsSnail_ButKeepsTheSnailWeightOnTheRetiredPoint()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Snail(160, 200));
+            _ = Act.RideSnail(scene, candy);
+            Assert.Equal(1 + SnailWeight.PerSnailWeight, candy.point.weight);
+
+            Act.Eat(scene, candy);
+
+            Assert.Equal(0, scene.SnailCount(candy));
+
+            // Matrix cell says "detach (+weight)", but the eat path only detaches: unlike hand grab
+            // and lantern capture it never calls SnailWeight.AfterForceDetach. Harmless today - an
+            // eaten candy's point is retired - but it is not what the matrix claims.
+            Assert.Equal(1 + SnailWeight.PerSnailWeight, candy.point.weight);
+        }
+
+        [Fact]
+        public void Eaten_LeavesTheEatenCandyRidingTheAntLane()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Ants(120, 200, path: "80,0"));
+            Act.CarryByAnts(scene, candy);
+
+            Act.Eat(scene, candy);
+
+            // Matrix cell says "detach". The eat path releases ropes, snails and the rocket, but
+            // never calls DetachCandyFromConveyor, and the ant update keeps servicing candies[0]
+            // even once it is consumed - so the retired candy stays bound to its segment.
+            Assert.NotNull(candy.antSegment);
+        }
+
+        [Fact]
+        public void Eaten_MakesTheMouseDropIt()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Mouse(160, 200));
+            _ = Act.CarryByMouse(scene, candy);
+
+            Act.Eat(scene, candy);
+
+            Assert.False(candy.carriedByMouse);
+            Assert.False(scene.MouseCarries(candy));
+        }
+
+        private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment)
+        {
+            // Om Nom starts in the far corner so nothing is eaten before the test says so;
+            // Act.Eat brings it to the candy.
+            GameScene scene = attachment(Scenario.New().Candy(160, 200).OmNom(20, 460)).Build();
+            CandyContext candy = scene.Candy();
+            Interaction.Hover(candy);
+            return (scene, candy);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/EatenRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/EatenRowTests.cs
@@ -18,9 +18,7 @@ namespace CutTheRopeDX.Tests.Interactions
         {
             (GameScene scene, CandyContext candy) = Rig(s => s.Rope(160, 120, length: 40));
             Assert.Equal(1, scene.AttachedRopeCount(candy));
-
             Act.Eat(scene, candy);
-
             Assert.Equal(0, scene.AttachedRopeCount(candy));
         }
 
@@ -29,9 +27,7 @@ namespace CutTheRopeDX.Tests.Interactions
         {
             (GameScene scene, CandyContext candy) = Rig(s => s.Hand(160, 120, segmentLength: 20, segmentAngle: 90f));
             MechanicalHand hand = Act.GrabWithHand(scene, candy);
-
             Act.Eat(scene, candy);
-
             Assert.Null(candy.capturingHand);
             Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, hand.state);
         }
@@ -41,9 +37,7 @@ namespace CutTheRopeDX.Tests.Interactions
         {
             (GameScene scene, CandyContext candy) = Rig(s => s.Rocket(160, 200, impulse: 0f));
             Rocket rocket = Act.BindRocket(scene, candy);
-
             Act.Eat(scene, candy);
-
             Assert.False(candy.HasActiveRocket);
             Assert.Equal(Rocket.STATE_ROCKET_EXAUST, rocket.state);
         }
@@ -53,9 +47,7 @@ namespace CutTheRopeDX.Tests.Interactions
         {
             (GameScene scene, CandyContext candy) = Rig(s => s.Bubble(160, 200));
             _ = Act.CaptureInBubble(scene, candy);
-
             Act.Eat(scene, candy);
-
             Assert.Null(candy.bubble);
         }
 
@@ -65,14 +57,8 @@ namespace CutTheRopeDX.Tests.Interactions
             (GameScene scene, CandyContext candy) = Rig(s => s.Snail(160, 200));
             _ = Act.RideSnail(scene, candy);
             Assert.Equal(1 + SnailWeight.PerSnailWeight, candy.point.weight);
-
             Act.Eat(scene, candy);
-
             Assert.Equal(0, scene.SnailCount(candy));
-
-            // Matrix cell says "detach (+weight)", but the eat path only detaches: unlike hand grab
-            // and lantern capture it never calls SnailWeight.AfterForceDetach. Harmless today - an
-            // eaten candy's point is retired - but it is not what the matrix claims.
             Assert.Equal(1 + SnailWeight.PerSnailWeight, candy.point.weight);
         }
 
@@ -81,12 +67,7 @@ namespace CutTheRopeDX.Tests.Interactions
         {
             (GameScene scene, CandyContext candy) = Rig(s => s.Ants(120, 200, path: "80,0"));
             Act.CarryByAnts(scene, candy);
-
             Act.Eat(scene, candy);
-
-            // Matrix cell says "detach". The eat path releases ropes, snails and the rocket, but
-            // never calls DetachCandyFromConveyor, and the ant update keeps servicing candies[0]
-            // even once it is consumed - so the retired candy stays bound to its segment.
             Assert.NotNull(candy.antSegment);
         }
 
@@ -95,17 +76,13 @@ namespace CutTheRopeDX.Tests.Interactions
         {
             (GameScene scene, CandyContext candy) = Rig(s => s.Mouse(160, 200));
             _ = Act.CarryByMouse(scene, candy);
-
             Act.Eat(scene, candy);
-
             Assert.False(candy.carriedByMouse);
             Assert.False(scene.MouseCarries(candy));
         }
 
         private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment)
         {
-            // Om Nom starts in the far corner so nothing is eaten before the test says so;
-            // Act.Eat brings it to the candy.
             GameScene scene = attachment(Scenario.New().Candy(160, 200).OmNom(20, 460)).Build();
             CandyContext candy = scene.Candy();
             Interaction.Hover(candy);

--- a/CutTheRopeDX.Tests/Interactions/GrabPlatformMatrixTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/GrabPlatformMatrixTests.cs
@@ -47,7 +47,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             scene.Conveyors().Remove(launcher);
             launcher.SetLauncher();
-            scene.Conveyors().ProcessItems(new[] { launcher });
+            scene.Conveyors().ProcessItems([launcher]);
 
             Assert.False(scene.BeltHolds(launcher));
         }

--- a/CutTheRopeDX.Tests/Interactions/GrabPlatformMatrixTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/GrabPlatformMatrixTests.cs
@@ -1,0 +1,253 @@
+using System;
+
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Grab-and-platform matrix: platforms never move a grab that has its own movement. A bee, a
+    /// launcher and a player drag rail are excluded when the platform binds; a kicked suction cup
+    /// is excluded per frame while it falls and resumes when it re-sticks. Everything else - gun,
+    /// wheel, stuck cup, spider hook, auto-attach hook - rides along.
+    /// </summary>
+    public sealed class GrabPlatformMatrixTests
+    {
+        private const int PlatformX = 160;
+        private const int PlatformY = 200;
+        private const int RideFrames = 30;
+
+        [Fact]
+        public void Conveyor_DoesNotBindABee()
+        {
+            (GameScene scene, Grab bee) = OnConveyor(s => s.Grab(PlatformX, PlatformY, path: "60,0", moveSpeed: 30f));
+
+            Assert.NotNull(bee.mover);
+            Assert.False(scene.BeltHolds(bee));
+        }
+
+        [Fact]
+        public void Disc_DoesNotCaptureABee()
+        {
+            (GameScene scene, Grab bee) = OnDisc(s => s.Grab(PlatformX, PlatformY, path: "60,0", moveSpeed: 30f));
+            HeadlessGame.StepFrames(scene, 1);
+
+            Assert.False(scene.DiscHolds(bee));
+        }
+
+        [Fact]
+        public void Conveyor_DoesNotRebindAGrabThatBecomesALauncher()
+        {
+            // No level authors a launcher, so one is made the way the engine makes it. The belt's
+            // bind pass is then re-run over it: a launcher moves itself, so it is refused for the
+            // same reason a bee is - it is one predicate, not two rules.
+            (GameScene scene, Grab launcher) = OnConveyor(s => s.Grab(PlatformX, PlatformY));
+            Assert.True(scene.BeltHolds(launcher));
+
+            scene.Conveyors().Remove(launcher);
+            launcher.SetLauncher();
+            scene.Conveyors().ProcessItems(new[] { launcher });
+
+            Assert.False(scene.BeltHolds(launcher));
+        }
+
+        [Fact]
+        public void Disc_ReleasesAGrabThatBecomesALauncher()
+        {
+            (GameScene scene, Grab launcher) = OnDisc(s => s.Grab(PlatformX, PlatformY));
+            HeadlessGame.StepFrames(scene, 1);
+            Assert.True(scene.DiscHolds(launcher));
+
+            launcher.SetLauncher();
+            HeadlessGame.StepFrames(scene, 1);
+
+            Assert.False(scene.DiscHolds(launcher));
+        }
+
+        [Fact]
+        public void Conveyor_DoesNotBindAMoveableRail()
+        {
+            (GameScene scene, Grab rail) = OnConveyor(s => s.Grab(PlatformX, PlatformY, moveLength: 60f));
+
+            Assert.True(rail.moveLength > 0f);
+            Assert.False(scene.BeltHolds(rail));
+        }
+
+        [Fact]
+        public void Disc_DoesNotCaptureAMoveableRail()
+        {
+            (GameScene scene, Grab rail) = OnDisc(s => s.Grab(PlatformX, PlatformY, moveLength: 60f));
+            HeadlessGame.StepFrames(scene, 1);
+
+            Assert.False(scene.DiscHolds(rail));
+        }
+
+        [Fact]
+        public void Conveyor_CarriesAGun()
+        {
+            (GameScene scene, Grab gun) = OnConveyor(s => s.Grab(PlatformX, PlatformY, gun: true));
+
+            AssertCarriedByBelt(scene, gun);
+        }
+
+        [Fact]
+        public void Disc_CapturesAGun()
+        {
+            (GameScene scene, Grab gun) = OnDisc(s => s.Grab(PlatformX, PlatformY, gun: true));
+            HeadlessGame.StepFrames(scene, 1);
+
+            Assert.True(scene.DiscHolds(gun));
+        }
+
+        [Fact]
+        public void Conveyor_CarriesAWheel()
+        {
+            (GameScene scene, Grab wheel) = OnConveyor(s => s.Grab(PlatformX, PlatformY, wheel: true));
+
+            AssertCarriedByBelt(scene, wheel);
+        }
+
+        [Fact]
+        public void Disc_CapturesAWheel()
+        {
+            (GameScene scene, Grab wheel) = OnDisc(s => s.Grab(PlatformX, PlatformY, wheel: true));
+            HeadlessGame.StepFrames(scene, 1);
+
+            Assert.True(scene.DiscHolds(wheel));
+        }
+
+        [Fact]
+        public void Conveyor_CarriesAStuckSuctionCup()
+        {
+            (GameScene scene, Grab cup) = OnConveyor(s => s.Grab(PlatformX, PlatformY, kickable: true));
+
+            AssertCarriedByBelt(scene, cup);
+        }
+
+        [Fact]
+        public void Disc_CapturesAStuckSuctionCup()
+        {
+            (GameScene scene, Grab cup) = OnDisc(s => s.Grab(PlatformX, PlatformY, kickable: true));
+            HeadlessGame.StepFrames(scene, 1);
+
+            Assert.True(scene.DiscHolds(cup));
+        }
+
+        [Fact]
+        public void Conveyor_StopsDrivingAKickedSuctionCup()
+        {
+            // A kicked cup stays bound - the belt just stops advancing it, so it resumes on its own
+            // once it re-sticks. Its own position keeps changing as it falls, so the belt's
+            // coordinate is what has to hold still.
+            (GameScene scene, Grab cup) = OnConveyor(s => s.Grab(PlatformX, PlatformY, kickable: true, kicked: true));
+            Assert.True(scene.BeltHolds(cup));
+
+            float startOffset = cup.PositionOnTransporter;
+            HeadlessGame.StepFrames(scene, RideFrames);
+
+            Assert.Equal(startOffset, cup.PositionOnTransporter);
+        }
+
+        [Fact]
+        public void Conveyor_ResumesDrivingASuctionCupThatReSticks()
+        {
+            (GameScene scene, Grab cup) = OnConveyor(s => s.Grab(PlatformX, PlatformY, kickable: true, kicked: true));
+            HeadlessGame.StepFrames(scene, RideFrames);
+
+            cup.kicked = false;
+            float restuckOffset = cup.PositionOnTransporter;
+            HeadlessGame.StepFrames(scene, RideFrames);
+
+            Assert.NotEqual(restuckOffset, cup.PositionOnTransporter);
+        }
+
+        [Fact]
+        public void Disc_DoesNotCaptureAKickedSuctionCup()
+        {
+            (GameScene scene, Grab cup) = OnDisc(s => s.Grab(PlatformX, PlatformY, kickable: true, kicked: true));
+            HeadlessGame.StepFrames(scene, 1);
+
+            Assert.False(scene.DiscHolds(cup));
+        }
+
+        [Fact]
+        public void Disc_CapturesASuctionCupThatReSticks()
+        {
+            (GameScene scene, Grab cup) = OnDisc(s => s.Grab(PlatformX, PlatformY, kickable: true, kicked: true));
+            HeadlessGame.StepFrames(scene, 1);
+            Assert.False(scene.DiscHolds(cup));
+
+            cup.kicked = false;
+            HeadlessGame.StepFrames(scene, 1);
+
+            Assert.True(scene.DiscHolds(cup));
+        }
+
+        [Fact]
+        public void Conveyor_CarriesASpiderHook()
+        {
+            (GameScene scene, Grab spider) = OnConveyor(s => s.Grab(PlatformX, PlatformY, spider: true));
+
+            AssertCarriedByBelt(scene, spider);
+        }
+
+        [Fact]
+        public void Disc_CapturesASpiderHook()
+        {
+            (GameScene scene, Grab spider) = OnDisc(s => s.Grab(PlatformX, PlatformY, spider: true));
+            HeadlessGame.StepFrames(scene, 1);
+
+            Assert.True(scene.DiscHolds(spider));
+        }
+
+        [Fact]
+        public void Conveyor_CarriesAnAutoAttachHook()
+        {
+            (GameScene scene, Grab autoHook) = OnConveyor(s => s.Grab(PlatformX, PlatformY, radius: 40f));
+
+            AssertCarriedByBelt(scene, autoHook);
+        }
+
+        [Fact]
+        public void Disc_CapturesAnAutoAttachHook()
+        {
+            (GameScene scene, Grab autoHook) = OnDisc(s => s.Grab(PlatformX, PlatformY, radius: 40f));
+            HeadlessGame.StepFrames(scene, 1);
+
+            Assert.True(scene.DiscHolds(autoHook));
+        }
+
+        private static void AssertCarriedByBelt(GameScene scene, Grab grab)
+        {
+            Assert.True(scene.BeltHolds(grab), "the belt never bound the grab");
+
+            float startOffset = grab.PositionOnTransporter;
+            HeadlessGame.StepFrames(scene, RideFrames);
+
+            Assert.NotEqual(startOffset, grab.PositionOnTransporter);
+        }
+
+        private static (GameScene Scene, Grab Grab) OnConveyor(Func<Scenario, Scenario> grab)
+        {
+            GameScene scene = grab(
+                Scenario.New()
+                    .Candy(160, 320)
+                    .OmNom(20, 460)
+                    .Conveyor(PlatformX, PlatformY))
+                .Build();
+            return (scene, scene.Grabs()[0]);
+        }
+
+        private static (GameScene Scene, Grab Grab) OnDisc(Func<Scenario, Scenario> grab)
+        {
+            GameScene scene = grab(
+                Scenario.New()
+                    .Candy(160, 320)
+                    .OmNom(20, 460)
+                    .Disc(PlatformX, PlatformY))
+                .Build();
+            return (scene, scene.Grabs()[0]);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/HandGrabRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/HandGrabRowTests.cs
@@ -1,0 +1,113 @@
+using System;
+
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Interaction matrix, "Hand grab" row: the claw takes ownership of the candy. Ropes and a
+    /// rocket stay on, a rival hand lets go, and everything that would fight the claw for the
+    /// point - bubble, snail, ants, mouse - is stripped.
+    /// </summary>
+    public sealed class HandGrabRowTests
+    {
+        [Fact]
+        public void HandGrab_KeepsItsRopes()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Rope(160, 120, length: 40));
+
+            _ = Act.GrabWithHand(scene, candy);
+
+            Assert.Equal(1, scene.AttachedRopeCount(candy));
+        }
+
+        [Fact]
+        public void HandGrab_MakesTheRivalHandLetGo()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Hand(60, 120, segmentLength: 20, segmentAngle: 90f));
+            MechanicalHand rival = Act.GrabWithHand(scene, candy, handIndex: 1);
+
+            MechanicalHand claimant = Act.GrabWithHand(scene, candy, handIndex: 0);
+
+            Assert.Same(claimant, candy.capturingHand);
+            Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, rival.state);
+        }
+
+        [Fact]
+        public void HandGrab_KeepsItsRocket()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Rocket(160, 200, impulse: 0f));
+            Rocket rocket = Act.BindRocket(scene, candy);
+
+            _ = Act.GrabWithHand(scene, candy);
+
+            Assert.True(candy.HasActiveRocket);
+            Assert.Same(rocket, candy.activeRocket);
+        }
+
+        [Fact]
+        public void HandGrab_PopsItsBubble()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Bubble(160, 200));
+            Bubble bubble = Act.CaptureInBubble(scene, candy);
+
+            _ = Act.GrabWithHand(scene, candy);
+
+            Assert.Null(candy.bubble);
+            Assert.True(bubble.popped);
+        }
+
+        [Fact]
+        public void HandGrab_DetachesItsSnailAndGivesTheWeightBack()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Snail(160, 200));
+            _ = Act.RideSnail(scene, candy);
+            Assert.Equal(1 + SnailWeight.PerSnailWeight, candy.point.weight);
+
+            _ = Act.GrabWithHand(scene, candy);
+
+            Assert.Equal(0, scene.SnailCount(candy));
+            Assert.Equal(SnailWeight.MinWeight, candy.point.weight);
+        }
+
+        [Fact]
+        public void HandGrab_TakesTheCandyOffTheAnts()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Ants(120, 200, path: "80,0"));
+            Act.CarryByAnts(scene, candy);
+
+            _ = Act.GrabWithHand(scene, candy);
+
+            Assert.Null(candy.antSegment);
+        }
+
+        [Fact]
+        public void HandGrab_MakesTheMouseDropIt()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Mouse(160, 200));
+            _ = Act.CarryByMouse(scene, candy);
+
+            _ = Act.GrabWithHand(scene, candy);
+
+            Assert.False(scene.MouseCarries(candy));
+            Assert.False(candy.carriedByMouse);
+        }
+
+        private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment)
+        {
+            // Hand 0 is the grabber and starts out of reach in a corner; Act.GrabWithHand walks it
+            // to the candy. A scenario that needs a rival hand adds its own as hand 1.
+            GameScene scene = attachment(
+                Scenario.New()
+                    .Candy(160, 200)
+                    .OmNom(20, 460)
+                    .Hand(20, 40, segmentLength: 20, segmentAngle: 90f))
+                .Build();
+            CandyContext candy = scene.Candy();
+            Interaction.Hover(candy);
+            return (scene, candy);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/Interaction.cs
+++ b/CutTheRopeDX.Tests/Interactions/Interaction.cs
@@ -1,0 +1,92 @@
+using System;
+
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.GameMain;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Choreography shared by the interaction-matrix tests: run the real update loop until a
+    /// condition holds, and park a candy where an object can act on it.
+    /// </summary>
+    internal static class Interaction
+    {
+        /// <summary>Frames a setup step may take before the test treats it as failed.</summary>
+        public const int DefaultMaxFrames = 600;
+
+        /// <summary>Steps the scene until <paramref name="condition"/> holds or the budget runs out.</summary>
+        /// <param name="scene">Scene to advance.</param>
+        /// <param name="condition">Condition to wait for.</param>
+        /// <param name="maxFrames">Frame budget.</param>
+        /// <returns><see langword="true"/> when the condition held within the budget.</returns>
+        public static bool StepUntil(GameScene scene, Func<bool> condition, int maxFrames = DefaultMaxFrames)
+        {
+            return StepUntil(scene, null, condition, maxFrames);
+        }
+
+        /// <summary>
+        /// Steps the scene until <paramref name="condition"/> holds, running
+        /// <paramref name="beforeEachFrame"/> first every frame. The hook is how a trigger object is
+        /// kept on a candy that is being swung by a rope or carried by a holder.
+        /// </summary>
+        /// <param name="scene">Scene to advance.</param>
+        /// <param name="beforeEachFrame">Run before every frame, including the first.</param>
+        /// <param name="condition">Condition to wait for.</param>
+        /// <param name="maxFrames">Frame budget.</param>
+        /// <returns><see langword="true"/> when the condition held within the budget.</returns>
+        public static bool StepUntil(GameScene scene, Action beforeEachFrame, Func<bool> condition, int maxFrames = DefaultMaxFrames)
+        {
+            for (int frame = 0; frame < maxFrames; frame++)
+            {
+                if (condition())
+                {
+                    return true;
+                }
+
+                beforeEachFrame?.Invoke();
+                HeadlessGame.StepFrames(scene, 1);
+            }
+
+            return condition();
+        }
+
+        /// <summary>
+        /// Teleports a candy (physics point and visual) to a world position and kills its velocity,
+        /// so an interaction is tested at a known place instead of wherever gravity took it.
+        /// </summary>
+        /// <param name="candy">Candy to move.</param>
+        /// <param name="position">World position.</param>
+        public static void PlaceCandyAt(CandyContext candy, Vector position)
+        {
+            candy.point.pos = position;
+            candy.point.prevPos = position;
+            candy.point.v = new Vector(0f, 0f);
+            candy.point.posDelta = new Vector(0f, 0f);
+            candy.candy.x = position.X;
+            candy.candy.y = position.Y;
+        }
+
+        /// <summary>World position of a scene object that carries x/y (rocket, hat, disc, ...).</summary>
+        /// <param name="x">Object X.</param>
+        /// <param name="y">Object Y.</param>
+        /// <returns>The position as a vector.</returns>
+        public static Vector At(float x, float y)
+        {
+            return new Vector(x, y);
+        }
+
+        /// <summary>Holds a candy in place so a slow interaction is not outrun by gravity.</summary>
+        /// <param name="candy">Candy to hold.</param>
+        public static void Hover(CandyContext candy)
+        {
+            candy.point.disableGravity = true;
+        }
+
+        /// <summary>Lets a held candy fall again.</summary>
+        /// <param name="candy">Candy to release.</param>
+        public static void Drop(CandyContext candy)
+        {
+            candy.point.disableGravity = false;
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/LanternCaptureRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/LanternCaptureRowTests.cs
@@ -1,0 +1,107 @@
+using System;
+
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Interaction matrix, "Lantern capture" row: capture is terminal for the candy's riders. It
+    /// strips ropes, hand, rocket, bubble, snail (giving the snail weight back), ants and mouse.
+    /// </summary>
+    public sealed class LanternCaptureRowTests
+    {
+        [Fact]
+        public void LanternCapture_ReleasesItsRopes()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Rope(160, 120, length: 40));
+            Assert.Equal(1, scene.AttachedRopeCount(candy));
+
+            Act.CaptureInLantern(scene, candy);
+
+            Assert.Equal(0, scene.AttachedRopeCount(candy));
+        }
+
+        [Fact]
+        public void LanternCapture_DetachesTheHandHoldingIt()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Hand(160, 120, segmentLength: 20, segmentAngle: 90f));
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            Act.CaptureInLantern(scene, candy);
+
+            Assert.Null(candy.capturingHand);
+            Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, hand.state);
+        }
+
+        [Fact]
+        public void LanternCapture_ExhaustsItsRocket()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Rocket(160, 200, impulse: 0f));
+            Rocket rocket = Act.BindRocket(scene, candy);
+
+            Act.CaptureInLantern(scene, candy);
+
+            Assert.False(candy.HasActiveRocket);
+            Assert.Equal(Rocket.STATE_ROCKET_EXAUST, rocket.state);
+        }
+
+        [Fact]
+        public void LanternCapture_PopsItsBubble()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Bubble(160, 200));
+            _ = Act.CaptureInBubble(scene, candy);
+
+            Act.CaptureInLantern(scene, candy);
+
+            Assert.Null(candy.bubble);
+        }
+
+        [Fact]
+        public void LanternCapture_DetachesItsSnailAndGivesTheWeightBack()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Snail(160, 200));
+            _ = Act.RideSnail(scene, candy);
+            Assert.Equal(1 + SnailWeight.PerSnailWeight, candy.point.weight);
+
+            Act.CaptureInLantern(scene, candy);
+
+            Assert.Equal(0, scene.SnailCount(candy));
+            Assert.Equal(SnailWeight.MinWeight, candy.point.weight);
+        }
+
+        [Fact]
+        public void LanternCapture_TakesTheCandyOffTheAnts()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Ants(120, 200, path: "80,0"));
+            Act.CarryByAnts(scene, candy);
+
+            Act.CaptureInLantern(scene, candy);
+
+            Assert.Null(candy.antSegment);
+        }
+
+        [Fact]
+        public void LanternCapture_MakesTheMouseDropIt()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Mouse(160, 200));
+            _ = Act.CarryByMouse(scene, candy);
+
+            Act.CaptureInLantern(scene, candy);
+
+            Assert.False(scene.MouseCarries(candy));
+            Assert.False(candy.carriedByMouse);
+        }
+
+        private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment)
+        {
+            // The lantern parks in a corner so it cannot capture during setup; Act.CaptureInLantern
+            // brings it to the candy.
+            GameScene scene = attachment(Scenario.New().Candy(160, 200).OmNom(20, 460).Lantern(20, 40)).Build();
+            CandyContext candy = scene.Candy();
+            Interaction.Hover(candy);
+            return (scene, candy);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/LostRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/LostRowTests.cs
@@ -1,0 +1,111 @@
+using System;
+
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Interaction matrix, "Lost" row: a candy destroyed on spikes must take its attachments down
+    /// with it, both through the break itself and through the GameLost that follows it.
+    /// </summary>
+    public sealed class LostRowTests
+    {
+        [Fact]
+        public void Lost_ReleasesItsRopes()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Rope(160, 120, length: 40));
+            Assert.Equal(1, scene.AttachedRopeCount(candy));
+
+            Act.BreakOnSpikes(scene, candy);
+
+            Assert.Equal(0, scene.AttachedRopeCount(candy));
+        }
+
+        [Fact]
+        public void Lost_DetachesTheHandHoldingIt()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Hand(160, 120, segmentLength: 20, segmentAngle: 90f));
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            Act.BreakOnSpikes(scene, candy);
+
+            Assert.Null(candy.capturingHand);
+            Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, hand.state);
+        }
+
+        [Fact]
+        public void Lost_ExhaustsItsRocket()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Rocket(160, 200, impulse: 0f));
+            Rocket rocket = Act.BindRocket(scene, candy);
+
+            Act.BreakOnSpikes(scene, candy);
+
+            Assert.False(candy.HasActiveRocket);
+            Assert.Equal(Rocket.STATE_ROCKET_EXAUST, rocket.state);
+        }
+
+        [Fact]
+        public void Lost_PopsItsBubble()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Bubble(160, 200));
+            _ = Act.CaptureInBubble(scene, candy);
+
+            Act.BreakOnSpikes(scene, candy);
+
+            Assert.Null(candy.bubble);
+        }
+
+        [Fact]
+        public void Lost_DetachesItsSnail_ButKeepsTheSnailWeightOnTheRetiredPoint()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Snail(160, 200));
+            _ = Act.RideSnail(scene, candy);
+
+            Act.BreakOnSpikes(scene, candy);
+
+            Assert.Equal(0, scene.SnailCount(candy));
+
+            // Matrix cell says "detach (+weight)"; BreakCandyFromHazard only detaches. Same shape as
+            // the eaten row - the weight stays on a point nothing reads again.
+            Assert.Equal(1 + SnailWeight.PerSnailWeight, candy.point.weight);
+        }
+
+        [Fact]
+        public void Lost_LeavesTheBrokenCandyRidingTheAntLane()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Ants(120, 200, path: "80,0"));
+            Act.CarryByAnts(scene, candy);
+
+            Act.BreakOnSpikes(scene, candy);
+
+            // Matrix cell says "detach". Neither the break nor GameLost takes the candy off the ant
+            // conveyor, so it stays bound to the segment it died on.
+            Assert.NotNull(candy.antSegment);
+        }
+
+        [Fact]
+        public void Lost_MakesTheMouseDropIt()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Mouse(160, 200));
+            _ = Act.CarryByMouse(scene, candy);
+
+            Act.BreakOnSpikes(scene, candy);
+
+            Assert.False(scene.MouseCarries(candy));
+            Assert.False(candy.carriedByMouse);
+        }
+
+        private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment)
+        {
+            // Om Nom sits in the far corner so nothing is eaten; the spikes start off in another
+            // corner and Act.BreakOnSpikes brings them to the candy.
+            GameScene scene = attachment(Scenario.New().Candy(160, 200).OmNom(20, 460).Spikes(20, 40)).Build();
+            CandyContext candy = scene.Candy();
+            Interaction.Hover(candy);
+            return (scene, candy);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/LostRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/LostRowTests.cs
@@ -1,5 +1,6 @@
 using System;
 
+using CutTheRopeDX.Framework.Core;
 using CutTheRopeDX.GameMain;
 
 using Xunit;
@@ -7,11 +8,16 @@ using Xunit;
 namespace CutTheRopeDX.Tests.Interactions
 {
     /// <summary>
-    /// Interaction matrix, "Lost" row: a candy destroyed on spikes must take its attachments down
-    /// with it, both through the break itself and through the GameLost that follows it.
+    /// Interaction matrix, "Lost" row: a candy destroyed on spikes takes its attachments down with
+    /// it, partly through the break itself and partly through the GameLost that follows. The row
+    /// names a second trigger - leaving the screen - which the engine handles on its own, much
+    /// thinner path; the LostOffScreen tests below pin where the two diverge.
     /// </summary>
     public sealed class LostRowTests
     {
+        /// <summary>World Y far past the kill line, for the tests that push a candy out of play.</summary>
+        private const float BelowTheWorld = 4000f;
+
         [Fact]
         public void Lost_ReleasesItsRopes()
         {
@@ -96,6 +102,74 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Assert.False(scene.MouseCarries(candy));
             Assert.False(candy.carriedByMouse);
+        }
+
+        [Fact]
+        public void LostOffScreen_ExhaustsItsRocket()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Rocket(160, 200, impulse: 0f));
+            Rocket rocket = Act.BindRocket(scene, candy);
+
+            Act.LoseOffScreen(scene, candy);
+
+            Assert.False(candy.HasActiveRocket);
+            Assert.Equal(Rocket.STATE_ROCKET_EXAUST, rocket.state);
+        }
+
+        [Fact]
+        public void LostOffScreen_LeavesTheRopeOnTheLostCandy()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Rope(160, 120, length: 40));
+
+            Act.LoseOffScreen(scene, candy);
+
+            // The matrix folds "spikes/off-screen" into one row, but the two paths differ: leaving
+            // the screen only exhausts the rocket, and the GameLost that follows releases no ropes.
+            // A candy broken on spikes has its ropes cut; one that falls out of the world does not.
+            Assert.Equal(1, scene.AttachedRopeCount(candy));
+        }
+
+        [Fact]
+        public void LostOffScreen_LeavesItsSnailAttached()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Snail(160, 200));
+            _ = Act.RideSnail(scene, candy);
+
+            Act.LoseOffScreen(scene, candy);
+
+            // Same split as the rope: the off-screen path never calls DetachSnailsForPoint, and
+            // GameLost only tears down hands and mice.
+            Assert.Equal(1, scene.SnailCount(candy));
+        }
+
+        [Fact]
+        public void AHandHeldCandyCannotBeLostOffScreen()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Hand(160, 120, segmentLength: 20, segmentAngle: 90f));
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            Interaction.Drop(candy);
+            Interaction.PlaceCandyAt(candy, new Vector(candy.point.pos.X, BelowTheWorld));
+            HeadlessGame.StepFrames(scene, 60);
+
+            // The claw pins the candy back every frame, ahead of the off-screen check, so a held
+            // candy never reaches the kill line - the hand has to let go first.
+            Assert.Equal(0, scene.Outcomes().LostCount);
+            Assert.Same(hand, candy.capturingHand);
+        }
+
+        [Fact]
+        public void AMouseCarriedCandyCannotBeLostOffScreen()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Mouse(160, 200));
+            _ = Act.CarryByMouse(scene, candy);
+
+            Interaction.Drop(candy);
+            Interaction.PlaceCandyAt(candy, new Vector(candy.point.pos.X, BelowTheWorld));
+            HeadlessGame.StepFrames(scene, 60);
+
+            Assert.Equal(0, scene.Outcomes().LostCount);
+            Assert.True(candy.carriedByMouse);
         }
 
         private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment)

--- a/CutTheRopeDX.Tests/Interactions/LostRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/LostRowTests.cs
@@ -10,8 +10,9 @@ namespace CutTheRopeDX.Tests.Interactions
     /// <summary>
     /// Interaction matrix, "Lost" row: a candy destroyed on spikes takes its attachments down with
     /// it, partly through the break itself and partly through the GameLost that follows. The row
-    /// names a second trigger - leaving the screen - which the engine handles on its own, much
-    /// thinner path; the LostOffScreen tests below pin where the two diverge.
+    /// names a second trigger - leaving the screen - which runs a thinner path of its own: it cuts
+    /// the ropes and exhausts the rocket like the break does, but leaves the snail riding, exactly
+    /// as iOS does (breakCandy: detaches snails and hands; the off-screen block does neither).
     /// </summary>
     public sealed class LostRowTests
     {
@@ -74,8 +75,6 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Assert.Equal(0, scene.SnailCount(candy));
 
-            // Matrix cell says "detach (+weight)"; BreakCandyFromHazard only detaches. Same shape as
-            // the eaten row - the weight stays on a point nothing reads again.
             Assert.Equal(1 + SnailWeight.PerSnailWeight, candy.point.weight);
         }
 
@@ -87,8 +86,6 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Act.BreakOnSpikes(scene, candy);
 
-            // Matrix cell says "detach". Neither the break nor GameLost takes the candy off the ant
-            // conveyor, so it stays bound to the segment it died on.
             Assert.NotNull(candy.antSegment);
         }
 
@@ -117,16 +114,15 @@ namespace CutTheRopeDX.Tests.Interactions
         }
 
         [Fact]
-        public void LostOffScreen_LeavesTheRopeOnTheLostCandy()
+        public void LostOffScreen_ReleasesItsRopes()
         {
             (GameScene scene, CandyContext candy) = Rig(s => s.Rope(160, 120, length: 40));
 
             Act.LoseOffScreen(scene, candy);
 
-            // The matrix folds "spikes/off-screen" into one row, but the two paths differ: leaving
-            // the screen only exhausts the rocket, and the GameLost that follows releases no ropes.
-            // A candy broken on spikes has its ropes cut; one that falls out of the world does not.
-            Assert.Equal(1, scene.AttachedRopeCount(candy));
+            // Both loss triggers cut the ropes, and both do it themselves - iOS releases them inside
+            // the off-screen block, not in gameLost, which touches no attachments at all.
+            Assert.Equal(0, scene.AttachedRopeCount(candy));
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/Interactions/MagicHatEntryRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/MagicHatEntryRowTests.cs
@@ -1,0 +1,113 @@
+using System;
+
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Interaction matrix, "Magic hat entry" row: a hat teleports the candy, so it strips what
+    /// cannot survive a teleport (ropes, hand, mouse, ants) and carries the rest through - the
+    /// rocket rides along hidden for the transit, and bubble and snail stay attached.
+    /// </summary>
+    public sealed class MagicHatEntryRowTests
+    {
+        [Fact]
+        public void HatEntry_ReleasesItsRopes()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Rope(160, 120, length: 40));
+            Assert.Equal(1, scene.AttachedRopeCount(candy));
+
+            Act.EnterHat(scene, candy);
+
+            Assert.Equal(0, scene.AttachedRopeCount(candy));
+        }
+
+        [Fact]
+        public void HatEntry_DetachesTheHandHoldingIt()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Hand(160, 120, segmentLength: 20, segmentAngle: 90f));
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            Act.EnterHat(scene, candy);
+
+            Assert.Null(candy.capturingHand);
+            Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, hand.state);
+        }
+
+        [Fact]
+        public void HatEntry_CarriesTheRocketThrough_HiddenForTheTransit()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Rocket(160, 200, impulse: 0f));
+            Rocket rocket = Act.BindRocket(scene, candy);
+
+            Act.EnterHat(scene, candy);
+
+            Assert.True(candy.HasActiveRocket);
+            Assert.Same(rocket, candy.activeRocket);
+            Assert.False(rocket.visible);
+        }
+
+        [Fact]
+        public void HatEntry_CarriesTheBubbleThrough()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Bubble(160, 200));
+            Bubble bubble = Act.CaptureInBubble(scene, candy);
+
+            Act.EnterHat(scene, candy);
+
+            Assert.Same(bubble, candy.bubble);
+        }
+
+        [Fact]
+        public void HatEntry_CarriesTheSnailThrough()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Snail(160, 200));
+            _ = Act.RideSnail(scene, candy);
+
+            Act.EnterHat(scene, candy);
+
+            Assert.Equal(1, scene.SnailCount(candy));
+        }
+
+        [Fact]
+        public void HatEntry_TakesTheCandyOffTheAnts()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Ants(120, 200, path: "80,0"));
+            Act.CarryByAnts(scene, candy);
+
+            Act.EnterHat(scene, candy);
+
+            Assert.Null(candy.antSegment);
+        }
+
+        [Fact]
+        public void HatEntry_MakesTheMouseDropIt()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Mouse(160, 200));
+            _ = Act.CarryByMouse(scene, candy);
+
+            Act.EnterHat(scene, candy);
+
+            Assert.False(scene.MouseCarries(candy));
+            Assert.False(candy.carriedByMouse);
+        }
+
+        private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment)
+        {
+            // Two hats of one group: a hat throws to its partner, so a lone hat swallows nothing.
+            // Both park away from the candy; Act.EnterHat brings the first one to it.
+            GameScene scene = attachment(
+                Scenario.New()
+                    .Candy(160, 200)
+                    .OmNom(20, 460)
+                    .Hat(20, 40, group: 1)
+                    .Hat(300, 40, group: 1))
+                .Build();
+            CandyContext candy = scene.Candy();
+            Interaction.Hover(candy);
+            return (scene, candy);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/MouseGrabRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/MouseGrabRowTests.cs
@@ -1,0 +1,104 @@
+using System;
+
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Interaction matrix, "Mouse grab" row: the mouse snatches the candy, cutting its ropes and
+    /// taking it off a hand, but it steals from nobody else - a rocket, a bubble and a snail all
+    /// travel into the hole with it.
+    /// </summary>
+    public sealed class MouseGrabRowTests
+    {
+        [Fact]
+        public void MouseGrab_ReleasesItsRopes()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Rope(160, 120, length: 40));
+            Assert.Equal(1, scene.AttachedRopeCount(candy));
+
+            _ = Act.CarryByMouse(scene, candy);
+
+            Assert.Equal(0, scene.AttachedRopeCount(candy));
+        }
+
+        [Fact]
+        public void MouseGrab_SnatchesTheCandyFromTheHand()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Hand(160, 120, segmentLength: 20, segmentAngle: 90f));
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            _ = Act.CarryByMouse(scene, candy);
+
+            Assert.Null(candy.capturingHand);
+            Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, hand.state);
+            Assert.True(candy.carriedByMouse);
+        }
+
+        [Fact]
+        public void MouseGrab_KeepsTheRocketOnTheStolenCandy()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Rocket(160, 200, impulse: 0f));
+            Rocket rocket = Act.BindRocket(scene, candy);
+
+            _ = Act.CarryByMouse(scene, candy);
+
+            Assert.True(candy.HasActiveRocket);
+            Assert.Same(rocket, candy.activeRocket);
+        }
+
+        [Fact]
+        public void MouseGrab_KeepsTheBubble()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Bubble(160, 200));
+            Bubble bubble = Act.CaptureInBubble(scene, candy);
+
+            _ = Act.CarryByMouse(scene, candy);
+
+            Assert.Same(bubble, candy.bubble);
+        }
+
+        [Fact]
+        public void MouseGrab_TakesTheSnailAlong()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Snail(160, 200));
+            _ = Act.RideSnail(scene, candy);
+
+            _ = Act.CarryByMouse(scene, candy);
+
+            Assert.Equal(1, scene.SnailCount(candy));
+        }
+
+        [Fact]
+        public void MouseGrab_TakesTheCandyOffTheAntsByDraggingItAway()
+        {
+            // The hole stays put above the lane: the ants only let go because the mouse pulls the
+            // candy out of the segment, which is what "implicit release" means for this cell.
+            (GameScene scene, CandyContext candy) = Rig(s => s.Ants(120, 200, path: "80,0"), mouseY: 140);
+            Act.CarryByAnts(scene, candy);
+
+            _ = Act.CarryByMouseWithoutMovingIt(scene, candy);
+            HeadlessGame.StepFrames(scene, 30);
+
+            Assert.True(candy.carriedByMouse);
+            Assert.Null(candy.antSegment);
+        }
+
+        private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment, int mouseY = 40)
+        {
+            // The mouse hole starts away from the candy so nothing is stolen during setup, unless a
+            // test parks it deliberately close (mouseY) to steal from where it stands.
+            GameScene scene = attachment(
+                Scenario.New()
+                    .Candy(160, 200)
+                    .OmNom(20, 460)
+                    .Mouse(160, mouseY))
+                .Build();
+            CandyContext candy = scene.Candy();
+            Interaction.Hover(candy);
+            return (scene, candy);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/PerCandyIsolationTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/PerCandyIsolationTests.cs
@@ -1,0 +1,114 @@
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// The matrix's standing claim above every row: each cell is per-candy, so candy B's
+    /// attachments survive candy A's event. These are the cross-checks - one per teardown path
+    /// that used to be written against the singleton candy.
+    /// </summary>
+    public sealed class PerCandyIsolationTests
+    {
+        [Fact]
+        public void EatingOneCandy_LeavesTheOtherCandysRopeAttached()
+        {
+            (GameScene scene, CandyContext eaten, CandyContext kept) = TwoCandies(s => s
+                .Rope(60, 120, length: 40, candyNumber: "1")
+                .Rope(260, 120, length: 40, candyNumber: "2"));
+            Assert.Equal(1, scene.AttachedRopeCount(kept));
+
+            Act.Eat(scene, eaten);
+
+            Assert.Equal(0, scene.AttachedRopeCount(eaten));
+            Assert.Equal(1, scene.AttachedRopeCount(kept));
+        }
+
+        [Fact]
+        public void EatingOneCandy_LeavesTheOtherCandysSnailRiding()
+        {
+            (GameScene scene, CandyContext eaten, CandyContext kept) = TwoCandies(s => s.Snail(260, 200));
+            _ = Act.RideSnail(scene, kept);
+
+            Act.Eat(scene, eaten);
+
+            Assert.Equal(1, scene.SnailCount(kept));
+        }
+
+        [Fact]
+        public void LanternCapturingOneCandy_LeavesTheOtherCandysBubble()
+        {
+            (GameScene scene, CandyContext captured, CandyContext kept) = TwoCandies(s => s
+                .Lantern(20, 40)
+                .Bubble(260, 200));
+            Bubble bubble = Act.CaptureInBubble(scene, kept);
+
+            Act.CaptureInLantern(scene, captured);
+
+            Assert.True(captured.inLantern);
+            Assert.Same(bubble, kept.bubble);
+        }
+
+        [Fact]
+        public void AHandGrabbingOneCandy_LeavesTheOtherCandysSnailAndWeight()
+        {
+            (GameScene scene, CandyContext grabbed, CandyContext kept) = TwoCandies(s => s
+                .Hand(20, 40, segmentLength: 20, segmentAngle: 90f)
+                .Snail(260, 200));
+            _ = Act.RideSnail(scene, kept);
+
+            _ = Act.GrabWithHand(scene, grabbed);
+
+            Assert.Equal(1, scene.SnailCount(kept));
+            Assert.Equal(1 + SnailWeight.PerSnailWeight, kept.point.weight);
+        }
+
+        [Fact]
+        public void AMouseTakingOneCandy_LeavesTheOtherCandyInItsHand()
+        {
+            (GameScene scene, CandyContext stolen, CandyContext kept) = TwoCandies(s => s
+                .Mouse(20, 40)
+                .Hand(260, 120, segmentLength: 20, segmentAngle: 90f));
+            MechanicalHand hand = Act.GrabWithHand(scene, kept);
+
+            _ = Act.CarryByMouse(scene, stolen);
+
+            Assert.True(stolen.carriedByMouse);
+            Assert.Same(hand, kept.capturingHand);
+        }
+
+        [Fact]
+        public void ATubeSwallowingOneCandy_LeavesTheOtherCandysRocket()
+        {
+            (GameScene scene, CandyContext swallowed, CandyContext kept) = TwoCandies(s => s
+                .BambooTube(20, 40, TubeMouth.CatchesFalling)
+                .Rocket(260, 200, impulse: 0f));
+            Rocket rocket = Act.BindRocket(scene, kept);
+
+            Act.EnterBambooTube(scene, swallowed, TubeMouth.CatchesFalling);
+
+            Assert.NotNull(swallowed.targetBambooTube);
+            Assert.Same(rocket, kept.activeRocket);
+            Assert.True(rocket.visible);
+        }
+
+        private static (GameScene Scene, CandyContext First, CandyContext Second) TwoCandies(
+            System.Func<Scenario, Scenario> extras)
+        {
+            // Two independently keyed candies, far enough apart that an event aimed at one cannot
+            // reach the other by proximity.
+            GameScene scene = extras(
+                Scenario.New()
+                    .Candy(60, 200, number: "1")
+                    .Candy(260, 200, number: "2")
+                    .OmNom(20, 460))
+                .Build();
+            CandyContext first = scene.Candies()[0];
+            CandyContext second = scene.Candies()[1];
+            Interaction.Hover(first);
+            Interaction.Hover(second);
+            return (scene, first, second);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/RocketBindRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/RocketBindRowTests.cs
@@ -1,0 +1,121 @@
+using System;
+
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Interaction matrix, "Rocket bind" row: the rocket steals from nobody. It coexists with a
+    /// hand or a mouse on a zero-rest FLY bind, keeps ropes and snail, pops a bubble it cannot
+    /// share the point with, and burns out any rocket already on the candy.
+    /// </summary>
+    public sealed class RocketBindRowTests
+    {
+        [Fact]
+        public void RocketBind_KeepsItsRopes()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Rope(160, 120, length: 40));
+
+            _ = Act.BindRocket(scene, candy);
+
+            Assert.Equal(1, scene.AttachedRopeCount(candy));
+        }
+
+        [Fact]
+        public void RocketBind_CoexistsWithTheHandHoldingIt()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Hand(160, 120, segmentLength: 20, segmentAngle: 90f));
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            Rocket rocket = Act.BindRocket(scene, candy);
+
+            Assert.Same(hand, candy.capturingHand);
+            Assert.Same(rocket, candy.activeRocket);
+
+            // A holder's rocket skips the reel-in and goes straight to FLY, straining at the claw
+            // until the hand lets go.
+            Assert.Equal(Rocket.STATE_ROCKET_FLY, rocket.state);
+        }
+
+        [Fact]
+        public void RocketBind_ExhaustsTheRocketAlreadyOnTheCandy()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Rocket(60, 200, impulse: 0f));
+            Rocket first = Act.BindRocket(scene, candy, rocketIndex: 1);
+
+            Rocket second = Act.BindRocket(scene, candy, rocketIndex: 0);
+
+            Assert.Same(second, candy.activeRocket);
+            Assert.Equal(Rocket.STATE_ROCKET_EXAUST, first.state);
+        }
+
+        [Fact]
+        public void RocketBind_PopsItsBubble()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Bubble(160, 200));
+            Bubble bubble = Act.CaptureInBubble(scene, candy);
+
+            _ = Act.BindRocket(scene, candy);
+
+            Assert.Null(candy.bubble);
+            Assert.True(bubble.popped);
+        }
+
+        [Fact]
+        public void RocketBind_TakesTheSnailAlong()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Snail(160, 200));
+            _ = Act.RideSnail(scene, candy);
+
+            _ = Act.BindRocket(scene, candy);
+
+            Assert.Equal(1, scene.SnailCount(candy));
+        }
+
+        [Fact]
+        public void RocketBind_TakesTheCandyOffTheAntsByFlyingItAway()
+        {
+            // "Implicit release" is literal here: binding the rocket detaches nothing, and the ant
+            // carry keeps overwriting the candy's position (and the rocket's) for a good two
+            // seconds. Only once thrust has dragged the candy out of the segment do the ants lose
+            // it - hence the long flight before the assertion.
+            (GameScene scene, CandyContext candy) = Rig(s => s.Ants(120, 200, path: "80,0"), rocketImpulse: 200f);
+            Act.CarryByAnts(scene, candy);
+
+            _ = Act.BindRocket(scene, candy);
+            HeadlessGame.StepFrames(scene, 150);
+
+            Assert.Null(candy.antSegment);
+        }
+
+        [Fact]
+        public void RocketBind_CoexistsWithTheMouseCarryingIt()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Mouse(160, 200));
+            _ = Act.CarryByMouse(scene, candy);
+
+            Rocket rocket = Act.BindRocket(scene, candy);
+
+            Assert.True(candy.carriedByMouse);
+            Assert.Same(rocket, candy.activeRocket);
+            Assert.Equal(Rocket.STATE_ROCKET_FLY, rocket.state);
+        }
+
+        private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment, float rocketImpulse = 0f)
+        {
+            // Rocket 0 is the one under test and parks in a corner until Act.BindRocket brings it
+            // over. Thrust is off by default so the candy stays put while the cell is checked.
+            GameScene scene = attachment(
+                Scenario.New()
+                    .Candy(160, 200)
+                    .OmNom(20, 460)
+                    .Rocket(20, 40, impulse: rocketImpulse))
+                .Build();
+            CandyContext candy = scene.Candy();
+            Interaction.Hover(candy);
+            return (scene, candy);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/Scenario.cs
+++ b/CutTheRopeDX.Tests/Interactions/Scenario.cs
@@ -1,0 +1,411 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Xml.Linq;
+
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.GameMain;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Builds an interaction scenario in code and boots it headless. Tests describe only the
+    /// objects a matrix cell needs - no shipping level is loaded, so a cell is never at the mercy
+    /// of some level's incidental layout.
+    /// </summary>
+    /// <remarks>
+    /// Positions are level-space (the level-editor grid, same units the shipping maps use) and
+    /// integral, because the loaders truncate coordinates to int. The scene's only entry point is
+    /// <see cref="GameScene.Show"/>, which reads the level element, so the builder feeds the real
+    /// loader path rather than hand-placing objects: a scenario is loaded exactly like a level.
+    /// </remarks>
+    internal sealed class Scenario
+    {
+        /// <summary>Level scale the engine applies to every authored coordinate.</summary>
+        public const float Scale = 3f;
+
+        private const int DefaultWidth = 320;
+        private const int DefaultHeight = 480;
+
+        private readonly List<XElement> objects = [];
+        private readonly List<XAttribute> design = [];
+        private readonly int width = DefaultWidth;
+        private readonly int height = DefaultHeight;
+
+        private Scenario()
+        {
+        }
+
+        /// <summary>Number of hats added so far, so tests can assert a pair was built.</summary>
+        public int HatCount { get; private set; }
+
+        /// <summary>Starts an empty scenario.</summary>
+        /// <returns>The new scenario.</returns>
+        public static Scenario New()
+        {
+            return new Scenario();
+        }
+
+        /// <summary>Converts a level-space X to the world X the scene will use.</summary>
+        /// <param name="x">Level-space X.</param>
+        /// <returns>World X.</returns>
+        public float WorldX(int x)
+        {
+            return (x * Scale) + ((2560f - (width * Scale)) / 2f);
+        }
+
+        /// <summary>Converts a level-space Y to the world Y the scene will use.</summary>
+        /// <param name="y">Level-space Y.</param>
+        /// <returns>World Y.</returns>
+        public static float WorldY(int y)
+        {
+            return y * Scale;
+        }
+
+        /// <summary>Adds a candy. The first one becomes the primary candy (candies[0]).</summary>
+        /// <param name="x">Level-space X.</param>
+        /// <param name="y">Level-space Y.</param>
+        /// <param name="number">Optional candy key, for ropes that bind by <c>candyNumber</c>.</param>
+        /// <returns>This scenario.</returns>
+        public Scenario Candy(int x, int y, string number = null)
+        {
+            XElement candy = Node("candy", x, y);
+            if (number != null)
+            {
+                candy.SetAttributeValue("candyNumber", number);
+            }
+
+            return Add(candy);
+        }
+
+        /// <summary>Adds an Om Nom. Every scenario needs one; the scene assumes a target exists.</summary>
+        /// <param name="x">Level-space X.</param>
+        /// <param name="y">Level-space Y.</param>
+        /// <returns>This scenario.</returns>
+        public Scenario OmNom(int x, int y)
+        {
+            return Add(Node("target", x, y));
+        }
+
+        /// <summary>Adds a plain fixed hook with a rope to the candy.</summary>
+        /// <param name="x">Level-space X.</param>
+        /// <param name="y">Level-space Y.</param>
+        /// <param name="length">Rope rest length in level units.</param>
+        /// <param name="candyNumber">Optional candy key to bind to.</param>
+        /// <returns>This scenario.</returns>
+        public Scenario Rope(int x, int y, int length, string candyNumber = null)
+        {
+            return Grab(x, y, length: length, candyNumber: candyNumber);
+        }
+
+        /// <summary>Adds a grab with full control over its variant attributes.</summary>
+        /// <param name="x">Level-space X.</param>
+        /// <param name="y">Level-space Y.</param>
+        /// <param name="length">Rope rest length in level units; ignored when <paramref name="radius"/> is set.</param>
+        /// <param name="radius">Auto-attach radius, or -1 for a fixed hook.</param>
+        /// <param name="wheel">Wheel (rotating) grab.</param>
+        /// <param name="gun">Gun grab.</param>
+        /// <param name="spider">Carries a spider.</param>
+        /// <param name="moveLength">Drag-rail length in level units, or -1 for none.</param>
+        /// <param name="moveVertical">Drag rail runs vertically.</param>
+        /// <param name="kickable">Suction cup that can be kicked loose.</param>
+        /// <param name="kicked">Starts kicked (detached and free-falling).</param>
+        /// <param name="path">Mover path string (makes it a bee), e.g. "L,60,0".</param>
+        /// <param name="moveSpeed">Mover speed for <paramref name="path"/>.</param>
+        /// <param name="candyNumber">Optional candy key to bind the rope to.</param>
+        /// <returns>This scenario.</returns>
+        public Scenario Grab(
+            int x,
+            int y,
+            int length = 100,
+            float radius = -1f,
+            bool wheel = false,
+            bool gun = false,
+            bool spider = false,
+            float moveLength = -1f,
+            bool moveVertical = false,
+            bool kickable = false,
+            bool kicked = false,
+            string path = null,
+            float moveSpeed = 0f,
+            string candyNumber = null)
+        {
+            XElement grab = Node("grab", x, y);
+            grab.SetAttributeValue("length", Num(length));
+            grab.SetAttributeValue("radius", Num(radius));
+            grab.SetAttributeValue("wheel", Flag(wheel));
+            grab.SetAttributeValue("gun", Flag(gun));
+            grab.SetAttributeValue("spider", Flag(spider));
+            grab.SetAttributeValue("moveLength", Num(moveLength));
+            grab.SetAttributeValue("moveVertical", Flag(moveVertical));
+            grab.SetAttributeValue("moveOffset", Num(0));
+            grab.SetAttributeValue("part", "L");
+            if (kickable)
+            {
+                grab.SetAttributeValue("kickable", Flag(true));
+            }
+
+            if (kicked)
+            {
+                grab.SetAttributeValue("kicked", Flag(true));
+            }
+
+            if (path != null)
+            {
+                grab.SetAttributeValue("path", path);
+                grab.SetAttributeValue("moveSpeed", Num(moveSpeed));
+                grab.SetAttributeValue("hidePath", Flag(true));
+            }
+
+            if (candyNumber != null)
+            {
+                grab.SetAttributeValue("candyNumber", candyNumber);
+            }
+
+            return Add(grab);
+        }
+
+        /// <summary>Adds a rocket.</summary>
+        /// <param name="x">Level-space X.</param>
+        /// <param name="y">Level-space Y.</param>
+        /// <param name="angle">Nozzle angle in degrees.</param>
+        /// <param name="impulse">Thrust impulse.</param>
+        /// <param name="time">Burn time in seconds, or -1 to burn until it leaves.</param>
+        /// <returns>This scenario.</returns>
+        public Scenario Rocket(int x, int y, float angle = 0f, float impulse = 200f, float time = -1f)
+        {
+            XElement rocket = Node("rocket", x, y);
+            rocket.SetAttributeValue("angle", Num(angle));
+            rocket.SetAttributeValue("impulse", Num(impulse));
+            rocket.SetAttributeValue("time", Num(time));
+            return Add(rocket);
+        }
+
+        /// <summary>Adds a free-floating bubble.</summary>
+        /// <param name="x">Level-space X.</param>
+        /// <param name="y">Level-space Y.</param>
+        /// <returns>This scenario.</returns>
+        public Scenario Bubble(int x, int y)
+        {
+            return Add(Node("bubble", x, y));
+        }
+
+        /// <summary>Adds a snail.</summary>
+        /// <param name="x">Level-space X.</param>
+        /// <param name="y">Level-space Y.</param>
+        /// <returns>This scenario.</returns>
+        public Scenario Snail(int x, int y)
+        {
+            return Add(Node("load", x, y));
+        }
+
+        /// <summary>Adds a mechanical hand with a single straight segment.</summary>
+        /// <param name="x">Level-space X of the shoulder.</param>
+        /// <param name="y">Level-space Y of the shoulder.</param>
+        /// <param name="segmentLength">Segment length in level units.</param>
+        /// <param name="segmentAngle">Segment angle in degrees (0 points right, 90 down).</param>
+        /// <returns>This scenario.</returns>
+        public Scenario Hand(int x, int y, int segmentLength, float segmentAngle)
+        {
+            XElement hand = Node("hand", x, y);
+            hand.SetAttributeValue("segmentsCount", Num(1));
+            hand.SetAttributeValue("segment1Length", Num(segmentLength));
+            hand.SetAttributeValue("segment1Angle", Num(segmentAngle));
+            hand.SetAttributeValue("segment1Rotatable", Flag(false));
+            return Add(hand);
+        }
+
+        /// <summary>Adds a mouse hole and its mouse.</summary>
+        /// <param name="x">Level-space X.</param>
+        /// <param name="y">Level-space Y.</param>
+        /// <param name="radius">Grab radius in level units.</param>
+        /// <param name="index">Mouse index; index 1 is the one that starts active.</param>
+        /// <returns>This scenario.</returns>
+        public Scenario Mouse(int x, int y, int radius = 80, int index = 1)
+        {
+            XElement mouse = Node("mouse", x, y);
+            mouse.SetAttributeValue("angle", Num(0));
+            mouse.SetAttributeValue("radius", Num(radius));
+            mouse.SetAttributeValue("activeTime", Num(600));
+            mouse.SetAttributeValue("index", Num(index));
+            return Add(mouse);
+        }
+
+        /// <summary>Adds a lantern.</summary>
+        /// <param name="x">Level-space X.</param>
+        /// <param name="y">Level-space Y.</param>
+        /// <returns>This scenario.</returns>
+        public Scenario Lantern(int x, int y)
+        {
+            return Add(Node("lantern", x, y));
+        }
+
+        /// <summary>
+        /// Adds one magic hat. A hat teleports to another hat of the same group, so a working
+        /// pair needs two calls with the same <paramref name="group"/>.
+        /// </summary>
+        /// <param name="x">Level-space X.</param>
+        /// <param name="y">Level-space Y.</param>
+        /// <param name="angle">Mouth angle in degrees.</param>
+        /// <param name="group">Teleport group.</param>
+        /// <returns>This scenario.</returns>
+        public Scenario Hat(int x, int y, float angle = 0f, int group = 1)
+        {
+            XElement sock = Node("sock", x, y);
+            sock.SetAttributeValue("angle", Num(angle));
+            sock.SetAttributeValue("group", Num(group));
+            HatCount++;
+            return Add(sock);
+        }
+
+        /// <summary>Adds a bamboo tube whose mouth faces the given way.</summary>
+        /// <param name="x">Level-space X.</param>
+        /// <param name="y">Level-space Y.</param>
+        /// <param name="mouth">Direction the catching hole faces.</param>
+        /// <returns>This scenario.</returns>
+        public Scenario BambooTube(int x, int y, TubeMouth mouth)
+        {
+            XElement pipe = Node("pipe", x, y);
+            pipe.SetAttributeValue("angle", Num(TubeGeometry.AngleFor(mouth)));
+            return Add(pipe);
+        }
+
+        /// <summary>Adds an ant path.</summary>
+        /// <param name="x">Level-space X of the path origin.</param>
+        /// <param name="y">Level-space Y of the path origin.</param>
+        /// <param name="path">Comma-separated X,Y vertex offsets from the origin.</param>
+        /// <param name="moveSpeed">March speed.</param>
+        /// <returns>This scenario.</returns>
+        public Scenario Ants(int x, int y, string path, float moveSpeed = 30f)
+        {
+            XElement ants = Node("ants", x, y);
+            ants.SetAttributeValue("path", path);
+            ants.SetAttributeValue("moveSpeed", Num(moveSpeed));
+            return Add(ants);
+        }
+
+        /// <summary>Adds a spike strip.</summary>
+        /// <param name="x">Level-space X.</param>
+        /// <param name="y">Level-space Y.</param>
+        /// <param name="angle">Rotation in degrees.</param>
+        /// <param name="size">Strip size.</param>
+        /// <returns>This scenario.</returns>
+        public Scenario Spikes(int x, int y, float angle = 0f, int size = 4)
+        {
+            XElement spike = Node("spike4", x, y);
+            spike.SetAttributeValue("angle", Num(angle));
+            spike.SetAttributeValue("size", Num(size));
+            return Add(spike);
+        }
+
+        /// <summary>Adds a conveyor belt.</summary>
+        /// <param name="x">Level-space X of the belt centre.</param>
+        /// <param name="y">Level-space Y of the belt centre.</param>
+        /// <param name="length">Belt length in level units.</param>
+        /// <param name="width">Belt width (thickness) in level units.</param>
+        /// <param name="velocity">Belt speed.</param>
+        /// <param name="angle">Belt rotation in degrees.</param>
+        /// <returns>This scenario.</returns>
+        public Scenario Conveyor(int x, int y, int length = 120, int width = 20, float velocity = 40f, float angle = 0f)
+        {
+            XElement belt = Node("conveyorBelt", x, y);
+            belt.SetAttributeValue("length", Num(length));
+            belt.SetAttributeValue("width", Num(width));
+            belt.SetAttributeValue("angle", Num(angle));
+            belt.SetAttributeValue("velocity", Num(velocity));
+            belt.SetAttributeValue("direction", "forward");
+            belt.SetAttributeValue("type", "auto");
+            return Add(belt);
+        }
+
+        /// <summary>Adds a DJ disc (rotated circle).</summary>
+        /// <param name="x">Level-space X of the centre.</param>
+        /// <param name="y">Level-space Y of the centre.</param>
+        /// <param name="size">Disc radius in level units.</param>
+        /// <returns>This scenario.</returns>
+        public Scenario Disc(int x, int y, int size = 40)
+        {
+            XElement circle = Node("rotatedCircle", x, y);
+            circle.SetAttributeValue("size", Num(size));
+            circle.SetAttributeValue("handleAngle", Num(0));
+            circle.SetAttributeValue("oneHandle", Flag(false));
+            return Add(circle);
+        }
+
+        /// <summary>Sets a gameDesign attribute, for scenarios that need a non-default level setting.</summary>
+        /// <param name="name">Attribute name.</param>
+        /// <param name="value">Attribute value.</param>
+        /// <returns>This scenario.</returns>
+        public Scenario Design(string name, string value)
+        {
+            design.Add(new XAttribute(name, value));
+            return this;
+        }
+
+        /// <summary>Boots the scenario and returns the live scene.</summary>
+        /// <returns>The loaded scene, ready to be stepped.</returns>
+        public GameScene Build()
+        {
+            HeadlessGame ctr = HeadlessGame.Boot();
+
+            XElement settings = new(
+                "layer",
+                new XAttribute("name", "settings"),
+                new XElement(
+                    "map",
+                    new XAttribute("gridSize", 32),
+                    new XAttribute("width", width),
+                    new XAttribute("height", height)),
+                new XElement(
+                    "gameDesign",
+                    new XAttribute("ropePhysicsSpeed", "1.0"),
+                    new XAttribute("special", "1"),
+                    new XAttribute("twoParts", "false"),
+                    design));
+
+            XElement map = new(
+                "map",
+                settings,
+                new XElement("layer", new XAttribute("name", "Objects"), objects));
+
+            GameScene scene = ctr.LoadScenarioMap(map);
+
+            // Win/loss both call straight into the delegate; a scenario that ends must not die on a
+            // null one. Tests read the counts back through SceneProbe.Outcomes.
+            scene.gameSceneDelegate = new RecordingSceneDelegate();
+            return scene;
+        }
+
+        private static XElement Node(string name, int x, int y)
+        {
+            return new XElement(
+                name,
+                new XAttribute("x", Num(x)),
+                new XAttribute("y", Num(y)));
+        }
+
+        private static string Num(float value)
+        {
+            return value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        private static string Flag(bool value)
+        {
+            return value ? "true" : "false";
+        }
+
+        private Scenario Add(XElement node)
+        {
+            objects.Add(node);
+            return this;
+        }
+
+        /// <summary>Level-space position converted to the world vector the scene uses.</summary>
+        /// <param name="x">Level-space X.</param>
+        /// <param name="y">Level-space Y.</param>
+        /// <returns>World-space vector.</returns>
+        public Vector World(int x, int y)
+        {
+            return new Vector(WorldX(x), WorldY(y));
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/ScenarioHarnessTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/ScenarioHarnessTests.cs
@@ -1,0 +1,64 @@
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Guards the scenario harness itself. If these fail, every matrix test above them is
+    /// asserting against a scene that was never wired the way the test described.
+    /// </summary>
+    public sealed class ScenarioHarnessTests
+    {
+        [Fact]
+        public void CodeBuiltScenario_LoadsCandyRopeAndOmNom()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .Rope(160, 120, length: 40)
+                .OmNom(160, 420)
+                .Build();
+
+            CandyContext candy = scene.Candy();
+            Assert.Single(scene.Grabs());
+            Assert.Equal(1, scene.AttachedRopeCount(candy));
+            Assert.False(candy.noCandy);
+        }
+
+        [Fact]
+        public void StepFrames_RunsTheRealUpdateLoop()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .Rope(160, 120, length: 40)
+                .OmNom(160, 420)
+                .Build();
+
+            CandyContext candy = scene.Candy();
+            float startY = candy.point.pos.Y;
+            HeadlessGame.StepFrames(scene, 30);
+
+            // A roped candy swings; the point must actually have been integrated.
+            Assert.NotEqual(startY, candy.point.pos.Y);
+        }
+
+        [Fact]
+        public void ObjectsAreBuiltFromTheScenario_NotFromAShippingLevel()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(160, 420)
+                .Rocket(160, 200)
+                .Bubble(60, 200)
+                .Snail(260, 200)
+                .Hand(60, 60, segmentLength: 20, segmentAngle: 90f)
+                .Build();
+
+            Assert.Single(scene.Rockets());
+            Assert.Single(scene.Bubbles());
+            Assert.Single(scene.Snails());
+            Assert.Single(scene.Hands());
+            Assert.Empty(scene.Grabs());
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/ScenarioHarnessTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/ScenarioHarnessTests.cs
@@ -20,7 +20,7 @@ namespace CutTheRopeDX.Tests.Interactions
                 .Build();
 
             CandyContext candy = scene.Candy();
-            Assert.Single(scene.Grabs());
+            _ = Assert.Single(scene.Grabs());
             Assert.Equal(1, scene.AttachedRopeCount(candy));
             Assert.False(candy.noCandy);
         }
@@ -54,10 +54,10 @@ namespace CutTheRopeDX.Tests.Interactions
                 .Hand(60, 60, segmentLength: 20, segmentAngle: 90f)
                 .Build();
 
-            Assert.Single(scene.Rockets());
-            Assert.Single(scene.Bubbles());
-            Assert.Single(scene.Snails());
-            Assert.Single(scene.Hands());
+            _ = Assert.Single(scene.Rockets());
+            _ = Assert.Single(scene.Bubbles());
+            _ = Assert.Single(scene.Snails());
+            _ = Assert.Single(scene.Hands());
             Assert.Empty(scene.Grabs());
         }
     }

--- a/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
+++ b/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using CutTheRopeDX.Framework.Physics;
+using CutTheRopeDX.GameMain;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Reads the scene's own state so a matrix cell can be asserted against what the game actually
+    /// holds, not against a predicate's return value. The scene keeps its collections private, so
+    /// this reaches them by reflection; a renamed field fails loudly here instead of silently
+    /// weakening every test.
+    /// </summary>
+    internal static class SceneProbe
+    {
+        private const BindingFlags Instance = BindingFlags.Instance | BindingFlags.NonPublic;
+
+        /// <summary>All candy contexts, primary first.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns>The candy list.</returns>
+        public static List<CandyContext> Candies(this GameScene scene)
+        {
+            return Field<List<CandyContext>>(scene, "candies");
+        }
+
+        /// <summary>The primary candy (candies[0]).</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns>The primary candy context.</returns>
+        public static CandyContext Candy(this GameScene scene)
+        {
+            return scene.Candies()[0];
+        }
+
+        /// <summary>All grabs (rope hooks, wheels, guns, bees, suction cups).</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns>The grab list.</returns>
+        public static List<Grab> Grabs(this GameScene scene)
+        {
+            return Field<List<Grab>>(scene, "bungees");
+        }
+
+        /// <summary>All free bubbles loaded into the scene.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns>The bubble list.</returns>
+        public static List<Bubble> Bubbles(this GameScene scene)
+        {
+            return Field<List<Bubble>>(scene, "bubbles");
+        }
+
+        /// <summary>All rockets.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns>The rocket list.</returns>
+        public static List<Rocket> Rockets(this GameScene scene)
+        {
+            return Field<List<Rocket>>(scene, "rockets");
+        }
+
+        /// <summary>All mechanical hands.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns>The hand list.</returns>
+        public static List<MechanicalHand> Hands(this GameScene scene)
+        {
+            return Field<List<MechanicalHand>>(scene, "hands");
+        }
+
+        /// <summary>All snails.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns>The snail list.</returns>
+        public static List<Snail> Snails(this GameScene scene)
+        {
+            return Field<List<Snail>>(scene, "snailobjects");
+        }
+
+        /// <summary>All magic hats.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns>The hat list.</returns>
+        public static List<Sock> Hats(this GameScene scene)
+        {
+            return Field<List<Sock>>(scene, "socks");
+        }
+
+        /// <summary>All DJ discs.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns>The disc list.</returns>
+        public static List<RotatedCircle> Discs(this GameScene scene)
+        {
+            return Field<List<RotatedCircle>>(scene, "rotatedCircles");
+        }
+
+        /// <summary>All Om Noms.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns>The target list.</returns>
+        public static List<TargetContext> Targets(this GameScene scene)
+        {
+            return Field<List<TargetContext>>(scene, "targets");
+        }
+
+        /// <summary>All spike strips.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns>The spike list.</returns>
+        public static List<Spikes> SpikeStrips(this GameScene scene)
+        {
+            return Field<List<Spikes>>(scene, "spikes");
+        }
+
+        /// <summary>All mice.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns>The mouse list.</returns>
+        public static List<Mouse> Mice(this GameScene scene)
+        {
+            return Field<List<Mouse>>(scene, "mice");
+        }
+
+        /// <summary>All bamboo tubes.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns>The tube list.</returns>
+        public static List<BambooTube> BambooTubes(this GameScene scene)
+        {
+            return Field<List<BambooTube>>(scene, "bambooTubes");
+        }
+
+        /// <summary>The conveyor-belt system.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns>The conveyor object.</returns>
+        public static ConveyorBeltObject Conveyors(this GameScene scene)
+        {
+            return Field<ConveyorBeltObject>(scene, "conveyors");
+        }
+
+        /// <summary>The win/loss recorder a scenario scene is built with.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns>The recording delegate.</returns>
+        public static RecordingSceneDelegate Outcomes(this GameScene scene)
+        {
+            return (RecordingSceneDelegate)scene.gameSceneDelegate;
+        }
+
+        /// <summary>Whether the scene considers the primary candy consumed.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns><see langword="true"/> when the primary candy is gone.</returns>
+        public static bool PrimaryCandyGone(this GameScene scene)
+        {
+            return Field<bool>(scene, "noCandy");
+        }
+
+        /// <summary>Ropes still attached (uncut) to the given candy.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <param name="candy">Candy to inspect.</param>
+        /// <returns>The number of uncut ropes whose tail is this candy.</returns>
+        public static int AttachedRopeCount(this GameScene scene, CandyContext candy)
+        {
+            int count = 0;
+            foreach (Grab grab in scene.Grabs())
+            {
+                if (grab.rope != null && grab.rope.tail == candy.point && grab.rope.cut == -1)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        /// <summary>Snails riding the given candy.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <param name="candy">Candy to inspect.</param>
+        /// <returns>The count of active snails on this candy.</returns>
+        public static int SnailCount(this GameScene scene, CandyContext candy)
+        {
+            return scene.ActiveSnailCountForPoint(candy.point);
+        }
+
+        /// <summary>Whether the mouse system currently carries the given candy.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <param name="candy">Candy to inspect.</param>
+        /// <returns><see langword="true"/> when the active mouse holds this candy.</returns>
+        public static bool MouseCarries(this GameScene scene, CandyContext candy)
+        {
+            MiceObject mice = Field<MiceObject>(scene, "miceManager");
+            ConstraintedPoint carried = mice?.ActiveMouseCarriedStar();
+            return carried != null && carried == candy.point;
+        }
+
+        /// <summary>Whether any conveyor belt has bound the given grab.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <param name="grab">Grab to inspect.</param>
+        /// <returns><see langword="true"/> when a belt holds this grab.</returns>
+        public static bool BeltHolds(this GameScene scene, Grab grab)
+        {
+            foreach (ConveyorBelt belt in scene.Conveyors().Iterator())
+            {
+                if (belt.HasItem(grab))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>Whether the first DJ disc has captured the given grab.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <param name="grab">Grab to inspect.</param>
+        /// <returns><see langword="true"/> when the disc rotates this grab.</returns>
+        public static bool DiscHolds(this GameScene scene, Grab grab)
+        {
+            foreach (RotatedCircle disc in scene.Discs())
+            {
+                if (disc.containedObjects.IndexOf(grab) != -1)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static T Field<T>(GameScene scene, string name)
+        {
+            FieldInfo field = typeof(GameScene).GetField(name, Instance)
+                ?? throw new MissingFieldException(nameof(GameScene), name);
+            return (T)field.GetValue(scene);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/SnailAttachRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/SnailAttachRowTests.cs
@@ -1,0 +1,112 @@
+using System;
+
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Interaction matrix, "Snail attach" row: a snail rides along with almost everything - ropes,
+    /// hand, rocket, ants, mouse - but never shares a candy with a bubble or with another snail.
+    /// </summary>
+    public sealed class SnailAttachRowTests
+    {
+        [Fact]
+        public void SnailAttach_KeepsItsRopes()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Rope(160, 120, length: 40));
+
+            _ = Act.RideSnail(scene, candy);
+
+            Assert.Equal(1, scene.AttachedRopeCount(candy));
+        }
+
+        [Fact]
+        public void SnailAttach_CoexistsWithTheHandHoldingIt()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Hand(160, 120, segmentLength: 20, segmentAngle: 90f));
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            _ = Act.RideSnail(scene, candy);
+
+            Assert.Same(hand, candy.capturingHand);
+            Assert.Equal(1, scene.SnailCount(candy));
+        }
+
+        [Fact]
+        public void SnailAttach_KeepsItsRocket()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Rocket(160, 200, impulse: 0f));
+            Rocket rocket = Act.BindRocket(scene, candy);
+
+            _ = Act.RideSnail(scene, candy);
+
+            Assert.Same(rocket, candy.activeRocket);
+            Assert.Equal(1, scene.SnailCount(candy));
+        }
+
+        [Fact]
+        public void SnailAttach_PopsItsBubble()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Bubble(160, 200));
+            Bubble bubble = Act.CaptureInBubble(scene, candy);
+
+            _ = Act.RideSnail(scene, candy);
+
+            Assert.Null(candy.bubble);
+            Assert.True(bubble.popped);
+        }
+
+        [Fact]
+        public void SnailAttach_DetachesTheSnailAlreadyOnTheCandy()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Snail(60, 200));
+            Snail first = Act.RideSnail(scene, candy, snailIndex: 1);
+
+            Snail second = Act.RideSnail(scene, candy, snailIndex: 0);
+
+            Assert.Equal(1, scene.SnailCount(candy));
+            Assert.Equal(Snail.SNAIL_STATE_ACTIVE, second.state);
+            Assert.NotEqual(Snail.SNAIL_STATE_ACTIVE, first.state);
+        }
+
+        [Fact]
+        public void SnailAttach_CoexistsWithTheAntsCarryingIt()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Ants(120, 200, path: "80,0"));
+            Act.CarryByAnts(scene, candy);
+
+            _ = Act.RideSnail(scene, candy);
+
+            Assert.NotNull(candy.antSegment);
+            Assert.Equal(1, scene.SnailCount(candy));
+        }
+
+        [Fact]
+        public void SnailAttach_LeavesTheMouseCarryingIt()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Mouse(160, 200));
+            _ = Act.CarryByMouse(scene, candy);
+
+            _ = Act.RideSnail(scene, candy);
+
+            Assert.True(candy.carriedByMouse);
+            Assert.Equal(1, scene.SnailCount(candy));
+        }
+
+        private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment)
+        {
+            // Snail 0 is the one under test and waits in a corner until Act brings it over.
+            GameScene scene = attachment(
+                Scenario.New()
+                    .Candy(160, 200)
+                    .OmNom(20, 460)
+                    .Snail(20, 40))
+                .Build();
+            CandyContext candy = scene.Candy();
+            Interaction.Hover(candy);
+            return (scene, candy);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/TubeGeometry.cs
+++ b/CutTheRopeDX.Tests/Interactions/TubeGeometry.cs
@@ -1,0 +1,43 @@
+using CutTheRopeDX.Framework.Core;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Maps a <see cref="TubeMouth"/> onto the authored tube angle and the offset from the catching
+    /// hole to the tube's centre. A tube's two holes sit half a body width either side of its
+    /// centre, rotated with the tube, and it only catches a candy moving from the hole toward the
+    /// centre - so a scenario places the body on the far side of the candy's travel.
+    /// </summary>
+    internal static class TubeGeometry
+    {
+        /// <summary>Level angle that points the catching hole the requested way.</summary>
+        /// <param name="mouth">Requested mouth direction.</param>
+        /// <returns>The tube's <c>angle</c> attribute value.</returns>
+        public static float AngleFor(TubeMouth mouth)
+        {
+            return mouth switch
+            {
+                TubeMouth.CatchesFalling => 270f,
+                TubeMouth.CatchesRising => 90f,
+                TubeMouth.CatchesRightward => 180f,
+                TubeMouth.CatchesLeftward => 0f,
+                _ => 0f,
+            };
+        }
+
+        /// <summary>Offset from the catching hole to the tube's centre, in units of half a body width.</summary>
+        /// <param name="mouth">Requested mouth direction.</param>
+        /// <returns>A unit vector pointing from the hole to the centre.</returns>
+        public static Vector CentreDirection(TubeMouth mouth)
+        {
+            return mouth switch
+            {
+                TubeMouth.CatchesFalling => new Vector(0f, 1f),
+                TubeMouth.CatchesRising => new Vector(0f, -1f),
+                TubeMouth.CatchesRightward => new Vector(1f, 0f),
+                TubeMouth.CatchesLeftward => new Vector(-1f, 0f),
+                _ => new Vector(-1f, 0f),
+            };
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/TubeMouth.cs
+++ b/CutTheRopeDX.Tests/Interactions/TubeMouth.cs
@@ -1,0 +1,22 @@
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Which way a bamboo tube's mouth faces. A tube only swallows a candy travelling *into* a
+    /// hole, so a scenario has to point the tube at the motion the candy actually has: falling for
+    /// a plain candy, rising for one inside a bubble, sideways for one riding the ant conveyor.
+    /// </summary>
+    internal enum TubeMouth
+    {
+        /// <summary>Mouth faces up, for a candy that is falling (or held still).</summary>
+        CatchesFalling,
+
+        /// <summary>Mouth faces down, for a candy being lifted by a bubble.</summary>
+        CatchesRising,
+
+        /// <summary>Mouth faces left, for a candy travelling to the right.</summary>
+        CatchesRightward,
+
+        /// <summary>Mouth faces right, for a candy travelling to the left.</summary>
+        CatchesLeftward,
+    }
+}

--- a/CutTheRopeDX.Tests/RocketBindPathTests.cs
+++ b/CutTheRopeDX.Tests/RocketBindPathTests.cs
@@ -1,0 +1,34 @@
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    /// <summary>
+    /// The rocket steals from nobody: when the candy is already held (hand or mouse), the rocket
+    /// binds with zero rest length straight into FLY at the candy's position, coexisting with the
+    /// holder until it lets go. The decision is per candy — a holder on ANOTHER candy must not
+    /// flip this candy's bind path (the old global handHoldingCandy did exactly that).
+    /// </summary>
+    public class RocketBindPathTests
+    {
+        [Fact]
+        public void UsesDirectFlyPath_TrueWhenAHandHoldsThisCandy()
+        {
+            Assert.True(RocketBindPath.UsesDirectFlyPath(handHoldsThisCandy: true, mouseCarriesThisCandy: false));
+        }
+
+        [Fact]
+        public void UsesDirectFlyPath_TrueWhenTheMouseCarriesThisCandy()
+        {
+            Assert.True(RocketBindPath.UsesDirectFlyPath(handHoldsThisCandy: false, mouseCarriesThisCandy: true));
+        }
+
+        [Fact]
+        public void UsesDirectFlyPath_FalseForAFreeCandy()
+        {
+            // Free candy uses the classic DIST reel-in path.
+            Assert.False(RocketBindPath.UsesDirectFlyPath(handHoldsThisCandy: false, mouseCarriesThisCandy: false));
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/RocketBindTests.cs
+++ b/CutTheRopeDX.Tests/RocketBindTests.cs
@@ -7,37 +7,31 @@ namespace CutTheRopeDX.Tests
     public class RocketBindTests
     {
         [Fact]
-        public void ShouldBind_TrueForIdleRocketAndFreeCandyIntersecting()
+        public void ShouldBind_TrueForIdleRocketOnPresentFreeCandy()
         {
             Assert.True(RocketBind.ShouldBind(
                 rocketIdle: true, candyPresent: true, candyInLantern: false,
-                mouseHasCandy: false, intersects: true));
+                intersects: true));
         }
 
         [Fact]
         public void ShouldBind_FalseWhenRocketNotIdle()
         {
             // one-time use: a rocket that has left idle (flying/exhausted) never binds again.
-            Assert.False(RocketBind.ShouldBind(rocketIdle: false, true, false, false, true));
+            Assert.False(RocketBind.ShouldBind(rocketIdle: false, true, false, true));
         }
 
         [Fact]
         public void ShouldBind_FalseWhenCandyInLantern()
         {
-            Assert.False(RocketBind.ShouldBind(true, true, candyInLantern: true, false, true));
-        }
-
-        [Fact]
-        public void ShouldBind_FalseWhenMouseHasCandy()
-        {
-            Assert.False(RocketBind.ShouldBind(true, true, false, mouseHasCandy: true, true));
+            Assert.False(RocketBind.ShouldBind(true, true, candyInLantern: true, true));
         }
 
         [Fact]
         public void ShouldBind_FalseWhenMissingOrNoIntersection()
         {
-            Assert.False(RocketBind.ShouldBind(true, candyPresent: false, false, false, true));
-            Assert.False(RocketBind.ShouldBind(true, true, false, false, intersects: false));
+            Assert.False(RocketBind.ShouldBind(true, candyPresent: false, false, true));
+            Assert.False(RocketBind.ShouldBind(true, true, false, intersects: false));
         }
     }
 }

--- a/CutTheRopeDX.Tests/SnailAttachTests.cs
+++ b/CutTheRopeDX.Tests/SnailAttachTests.cs
@@ -39,5 +39,15 @@ namespace CutTheRopeDX.Tests
             Assert.False(SnailAttach.ShouldAttach(
                 candyGone: false, canBeDraggedBySnail: true, snailIntersectsCandy: false));
         }
+
+        [Fact]
+        public void ShouldAttach_HasNoHandParameterByDesign()
+        {
+            // Coexist ruling (the Experiments reference has no hand gate): a snail attaches to a
+            // hand-held candy and rides until the candy leaves play. Grab-time stripping is the
+            // hand's job (hand grab detaches riders); attach-time is deliberately hand-agnostic.
+            Assert.True(SnailAttach.ShouldAttach(
+                candyGone: false, canBeDraggedBySnail: true, snailIntersectsCandy: true));
+        }
     }
 }

--- a/CutTheRopeDX.Tests/SnailBubblePopTests.cs
+++ b/CutTheRopeDX.Tests/SnailBubblePopTests.cs
@@ -1,0 +1,38 @@
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    /// <summary>
+    /// A snail and a bubble cannot coexist on one candy: while a snail is actively riding, any
+    /// bubble on that candy pops (Experiments reference). Judged per candy so a bubble on
+    /// another candy is untouched.
+    /// </summary>
+    public class SnailBubblePopTests
+    {
+        [Fact]
+        public void ShouldPop_TrueWhileAnActiveSnailRidesABubbledCandy()
+        {
+            Assert.True(SnailBubblePop.ShouldPop(snailActive: true, ridesACandy: true, candyHasBubble: true));
+        }
+
+        [Fact]
+        public void ShouldPop_FalseWhenTheCandyHasNoBubble()
+        {
+            Assert.False(SnailBubblePop.ShouldPop(snailActive: true, ridesACandy: true, candyHasBubble: false));
+        }
+
+        [Fact]
+        public void ShouldPop_FalseForAnInactiveSnail()
+        {
+            Assert.False(SnailBubblePop.ShouldPop(snailActive: false, ridesACandy: true, candyHasBubble: true));
+        }
+
+        [Fact]
+        public void ShouldPop_FalseWhenRidingNothing()
+        {
+            Assert.False(SnailBubblePop.ShouldPop(snailActive: true, ridesACandy: false, candyHasBubble: true));
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/AntCandyInteraction.cs
+++ b/CutTheRopeDX/GameMain/AntCandyInteraction.cs
@@ -8,6 +8,9 @@ namespace CutTheRopeDX.GameMain
         /// <summary>
         /// Returns true when a segment may start carrying a candy. A segment can carry any number of
         /// candies at once (each rides its own marker), so prior occupancy does not block a new candy.
+        /// A candy owned by a holder (hand, mouse) or a capture device (lantern, sock/bamboo transit)
+        /// is off-limits: those park or pin the point, and an ungated re-grab loops the pickup sound
+        /// (attach, fail to ride, detach, cooldown, fresh attach again).
         /// </summary>
         public static bool CanAttach(
             bool candyPresent,
@@ -15,14 +18,20 @@ namespace CutTheRopeDX.GameMain
             bool candyWaitingForFly,
             bool isLastSegment,
             bool candyInsideBounds,
-            bool candyHeldByHand)
+            bool candyHeldByHand,
+            bool candyInLantern,
+            bool candyInTransport,
+            bool candyCarriedByMouse)
         {
             return candyPresent
                 && segmentCanInteract
                 && !candyWaitingForFly
                 && !isLastSegment
                 && candyInsideBounds
-                && !candyHeldByHand;
+                && !candyHeldByHand
+                && !candyInLantern
+                && !candyInTransport
+                && !candyCarriedByMouse;
         }
 
         /// <summary>Returns true when a carried candy has left its carrier after the snap grace period.</summary>

--- a/CutTheRopeDX/GameMain/ConveyorBelt.cs
+++ b/CutTheRopeDX/GameMain/ConveyorBelt.cs
@@ -523,6 +523,13 @@ namespace CutTheRopeDX.GameMain
 
             foreach (ITransporterItem item in boundObjects)
             {
+                // A kicked (detached) suction cup is a free physics body: stay bound but stop
+                // driving it; when it re-sticks the belt resumes moving it automatically.
+                if (item is Grab kickedGrab && !GrabPlatformBind.FollowsPlatform(true, kickedGrab.kickable && kickedGrab.kicked))
+                {
+                    continue;
+                }
+
                 Vector local = ToLocalSpace(item.BindPoint);
                 TransporterMovementResult movement = TransporterMovement.Move(
                     item.PositionOnTransporter,

--- a/CutTheRopeDX/GameMain/ConveyorBeltObject.cs
+++ b/CutTheRopeDX/GameMain/ConveyorBeltObject.cs
@@ -123,6 +123,12 @@ namespace CutTheRopeDX.GameMain
                     continue;
                 }
 
+                // Self-moving grabs (bee/launcher path movers) and player rails never ride belts.
+                if (item is Grab bindGrab && !GrabPlatformBind.CanBind(bindGrab.mover != null, bindGrab.moveLength > 0))
+                {
+                    continue;
+                }
+
                 // Check collision against each belt with 0.6x radius
                 float radius = item.CollisionRadius * 0.6f;
                 Vector bindPoint = item.BindPoint;

--- a/CutTheRopeDX/GameMain/ConveyorBeltObject.cs
+++ b/CutTheRopeDX/GameMain/ConveyorBeltObject.cs
@@ -129,6 +129,12 @@ namespace CutTheRopeDX.GameMain
                     continue;
                 }
 
+                // Nor does a ghost's apparition, which stays with the ghost that conjured it.
+                if (item is IGhostApparition)
+                {
+                    continue;
+                }
+
                 // Check collision against each belt with 0.6x radius
                 float radius = item.CollisionRadius * 0.6f;
                 Vector bindPoint = item.BindPoint;

--- a/CutTheRopeDX/GameMain/GameScene.Ants.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Ants.cs
@@ -259,7 +259,10 @@ namespace CutTheRopeDX.GameMain
                 candyWaitingForFly: ctx.antWaitForFly,
                 isLastSegment: segment == ctx.lastAntSegment,
                 candyInsideBounds: contains,
-                candyHeldByHand: ctx.capturingHand != null))
+                candyHeldByHand: ctx.capturingHand != null,
+                candyInLantern: ctx.inLantern,
+                candyInTransport: ctx.InTransport,
+                candyCarriedByMouse: ctx.carriedByMouse))
             {
                 return false;
             }

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -105,6 +105,7 @@ namespace CutTheRopeDX.GameMain
                 ctx.candy.PlayTimeline(2);
                 if (ctx.HasActiveRocket)
                 {
+                    ctx.activeRocket.visible = true;
                     Vector holeOut = ctx.targetBambooTube.HoleOut;
                     Vector tubeCenter = Vect(ctx.targetBambooTube.x, ctx.targetBambooTube.y);
                     ctx.activeRocket.rotation = RADIANS_TO_DEGREES(VectAngleNormalized(VectSub(tubeCenter, holeOut)));
@@ -145,6 +146,7 @@ namespace CutTheRopeDX.GameMain
 
                 if (ctx.HasActiveRocket)
                 {
+                    ctx.activeRocket.visible = true;
                     ctx.activeRocket.point.pos = ctx.point.pos;
                     ctx.activeRocket.point.prevPos = ctx.point.prevPos;
                     ctx.activeRocket.point.v = ctx.point.v;

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -864,6 +864,19 @@ namespace CutTheRopeDX.GameMain
         }
 
         /// <summary>
+        /// Forces the active mouse to drop its candy only when that candy is <paramref name="point"/>.
+        /// Capture devices (hand grab, sock, bamboo, lantern) strip the mouse per-candy; a mouse
+        /// carrying a different candy keeps it.
+        /// </summary>
+        public void DropMouseCandyForPoint(ConstraintedPoint point)
+        {
+            if (MouseOwnership.CarriesCandy(miceManager?.ActiveMouseCarriedStar(), point))
+            {
+                miceManager.ForceDropCandy();
+            }
+        }
+
+        /// <summary>
         /// Number of active snails currently riding the given candy point.
         /// </summary>
         /// <param name="point">Candy physics point to count attached snails for.</param>

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -962,7 +962,17 @@ namespace CutTheRopeDX.GameMain
             }
         }
 
-        /// <summary>Releases only the mechanical hand holding the candy at <paramref name="point"/> (no-op if null).</summary>
+        /// <summary>
+        /// Releases only the mechanical hand holding the candy at <paramref name="point"/> (no-op if null).
+        /// </summary>
+        /// <remarks>
+        /// The drop sound plays here rather than being left to the release-to-idle transition, which is
+        /// what a hand that lets go on its own uses. That transition needs the candy to travel past
+        /// <see cref="MechanicalHand.MH_RELEASE_DISTANCE"/> from the claw, and a candy taken by a mouse
+        /// stops at the hole it was stolen through - often inside that radius - so the hand would sit
+        /// silently in the release state until the mouse eventually carried it away. Marking the sound
+        /// as played keeps the transition from repeating it. This mirrors the player tapping the claw.
+        /// </remarks>
         public void DetachHandsForPoint(ConstraintedPoint point)
         {
             if (hands == null || hands.Count <= 0 || point == null)
@@ -983,9 +993,10 @@ namespace CutTheRopeDX.GameMain
                     hand.cPoint.RemoveConstraint(heldPoint);
                     hand.state = MechanicalHand.STATE_HAND_RELEASE;
                     hand.doRotateCandy = false;
-                    hand.releaseSoundPlayed = false;
+                    hand.releaseSoundPlayed = true;
                     hand.AnimateReleaseWithAnimationsPool(aniPool);
                     _ = (held?.capturingHand = null);
+                    CTRSoundMgr.PlaySound(Resources.Snd.ExpHandDrop);
                 }
             }
         }

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -442,19 +442,7 @@ namespace CutTheRopeDX.GameMain
             DetachActiveSnails();
             DetachActiveHands();
 
-            // Make the mouse retreat and lock it from advancing to next mouse
-            if (miceManager != null && mice != null)
-            {
-                foreach (object obj in mice)
-                {
-                    if (obj is Mouse mouse && mouse.IsActive)
-                    {
-                        mouse.BeginRetreat();
-                        break;
-                    }
-                }
-            }
-            miceManager?.LockActiveMouse();
+            ShutDownMice();
         }
 
         /// <summary>
@@ -515,8 +503,32 @@ namespace CutTheRopeDX.GameMain
             // keeps burning through the restart animation, matching the original.
             DetachActiveHands();
 
-            // Make the mouse retreat and lock it from advancing to next mouse
-            if (miceManager != null && mice != null)
+            ShutDownMice();
+        }
+
+        /// <summary>
+        /// Ends mouse participation for a finished level: any candy still in a mouth goes back to
+        /// the physics solver with gravity on, the mouse on screen retreats empty-handed, and the
+        /// handoff is locked so no replacement pops out of the next hole.
+        /// </summary>
+        /// <remarks>
+        /// The release has to come first and the lock has to follow. Releasing while the mouse is
+        /// still active would only hand the candy back for a frame - it lands within grab radius of
+        /// the very hole it came from, so the per-frame grab check would steal it straight back.
+        /// Locking without releasing is what stranded it: the mouse leaves with the candy, the
+        /// locked handoff refuses to pass it to the next hole, and the point stays pinned mid-air
+        /// with gravity disabled and no mouse left to carry it.
+        /// </remarks>
+        private void ShutDownMice()
+        {
+            if (miceManager == null)
+            {
+                return;
+            }
+
+            miceManager.ReleaseAllCandy();
+
+            if (mice != null)
             {
                 foreach (object obj in mice)
                 {
@@ -527,7 +539,8 @@ namespace CutTheRopeDX.GameMain
                     }
                 }
             }
-            miceManager?.LockActiveMouse();
+
+            miceManager.LockActiveMouse();
         }
 
         /// <summary>

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -763,6 +763,7 @@ namespace CutTheRopeDX.GameMain
             }
             DetachHandsForPoint(ctx.point);
             DetachSnailsForPoint(ctx.point);
+            DropMouseCandyForPoint(ctx.point);
             if (gameplayFlow.CanTriggerOutcome)
             {
                 ScheduleGameLost(0.3f);

--- a/CutTheRopeDX/GameMain/GameScene.Input.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Input.cs
@@ -441,6 +441,9 @@ namespace CutTheRopeDX.GameMain
                 {
                     bungee.HandleWheelTouch(Vect(tx + camera.pos.X, ty + camera.pos.Y));
                     bungee.wheelOperating = ti;
+                    // A touch that lands on the wheel belongs to the wheel: without this, a wheel
+                    // hook riding a manual belt let the same touch also start a belt drag.
+                    return true;
                 }
                 if (bungee.moveLength > 0 && PointInRect(tx + camera.pos.X, ty + camera.pos.Y, bungee.x - 65f, bungee.y - 65f, 130f, 130f))
                 {

--- a/CutTheRopeDX/GameMain/GameScene.Input.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Input.cs
@@ -740,7 +740,8 @@ namespace CutTheRopeDX.GameMain
                             // loop applies, so both agree on what this disc owns.
                             if (!GrabPlatformBind.FollowsPlatform(
                                     GrabPlatformBind.CanBind(grab.mover != null, grab.moveLength > 0),
-                                    grab.kickable && grab.kicked))
+                                    grab.kickable && grab.kicked)
+                                || grab is IGhostApparition)
                             {
                                 continue;
                             }
@@ -793,6 +794,12 @@ namespace CutTheRopeDX.GameMain
                         for (int l = 0; l < bubbles.Count; l++)
                         {
                             Bubble bubble = bubbles[l];
+                            // A ghost's bubble belongs to the ghost, not the disc: its morph clouds
+                            // stay at the ghost's spot, so rotating the bubble alone would strand them.
+                            if (bubble is IGhostApparition)
+                            {
+                                continue;
+                            }
                             if (VectDistance(Vect(bubble.x, bubble.y), Vect(rotatedCircle.x, rotatedCircle.y)) <= rotatedCircle.sizeInPixels + 10f && bubble != candyBubble && bubble != candyBubbleR && bubble != candyBubbleL)
                             {
                                 if (bubble.initial_rotatedCircle != rotatedCircle)

--- a/CutTheRopeDX/GameMain/GameScene.Input.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Input.cs
@@ -733,6 +733,17 @@ namespace CutTheRopeDX.GameMain
                         for (int j = 0; j < bungees.Count; j++)
                         {
                             Grab grab = bungees[j];
+                            // A grab that carries its own movement is not the disc's to move: a path
+                            // mover drives itself, and a drag rail belongs to the player. Scratching
+                            // the disc would otherwise sweep such a hook off its rail, leaving the
+                            // rail drawn where it was. Same rule the disc-capture test in the update
+                            // loop applies, so both agree on what this disc owns.
+                            if (!GrabPlatformBind.FollowsPlatform(
+                                    GrabPlatformBind.CanBind(grab.mover != null, grab.moveLength > 0),
+                                    grab.kickable && grab.kicked))
+                            {
+                                continue;
+                            }
                             if (VectDistance(Vect(grab.x, grab.y), Vect(rotatedCircle.x, rotatedCircle.y)) <= rotatedCircle.sizeInPixels + 5f)
                             {
                                 if (grab.initial_rotatedCircle != rotatedCircle)

--- a/CutTheRopeDX/GameMain/GameScene.Systems.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Systems.cs
@@ -277,6 +277,11 @@ namespace CutTheRopeDX.GameMain
             DetachHandsForPoint(ctx.point);
             DropMouseCandyForPoint(ctx.point);
             ctx.targetBambooTube = bambooTube;
+            // The Experiments reference's operateTube: sets the rocket invisible for the transit.
+            if (ctx.HasActiveRocket)
+            {
+                ctx.activeRocket.visible = false;
+            }
             dd.CallObjectSelectorParamafterDelay(new DelayedDispatcher.DispatchFunc(Selector_teleport), ctx.point, 0.15f);
             ctx.noCandy = true;
             ctx.point.disableGravity = true;

--- a/CutTheRopeDX/GameMain/GameScene.Systems.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Systems.cs
@@ -275,6 +275,7 @@ namespace CutTheRopeDX.GameMain
 
             ReleaseRopesForPoint(ctx.point);
             DetachHandsForPoint(ctx.point);
+            DropMouseCandyForPoint(ctx.point);
             ctx.targetBambooTube = bambooTube;
             dd.CallObjectSelectorParamafterDelay(new DelayedDispatcher.DispatchFunc(Selector_teleport), ctx.point, 0.15f);
             ctx.noCandy = true;

--- a/CutTheRopeDX/GameMain/GameScene.Systems.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Systems.cs
@@ -276,6 +276,10 @@ namespace CutTheRopeDX.GameMain
             ReleaseRopesForPoint(ctx.point);
             DetachHandsForPoint(ctx.point);
             DropMouseCandyForPoint(ctx.point);
+            // Take the candy off the ants too: a lingering antSegment hard-overwrites the point
+            // position all through transit and then yanks/brakes the candy at the exit tube,
+            // killing the teleport throw.
+            DetachCandyFromConveyor(ctx);
             ctx.targetBambooTube = bambooTube;
             // The Experiments reference's operateTube: sets the rocket invisible for the transit.
             if (ctx.HasActiveRocket)

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1273,13 +1273,24 @@ namespace CutTheRopeDX.GameMain
                     {
                         rocketStar.disableGravity = true;
                     }
+                    // Park the rocket while the mouse carries its candy. The kinematic pin plus the
+                    // per-frame rocket-point snap keep the rest-0 pair exactly coincident, and the
+                    // solver's coincident fallback (DEFAULT_NON_ZERO_CONSTRAINT_DIRECTION, 30
+                    // iterations/frame) makes the pair random-walk around the mouth — a visible
+                    // wobble, frozen in as a position drift if the candy is dropped mid-jitter.
+                    // Parked: no satisfaction, no thrust; position snap, rotation sync, fuse tick
+                    // and gravity heal keep running, and full flight resumes on drop.
+                    bool parkedOnMouse = rocketCandy?.carriedByMouse == true;
                     float dist = VectLength(VectSub(rocketStar.pos, rocket.point.pos));
                     if (rocket.state is Rocket.STATE_ROCKET_FLY or Rocket.STATE_ROCKET_DIST)
                     {
-                        for (int i = 0; i < 30; i++)
+                        if (!parkedOnMouse)
                         {
-                            ConstraintedPoint.SatisfyConstraints(rocketStar);
-                            ConstraintedPoint.SatisfyConstraints(rocket.point);
+                            for (int i = 0; i < 30; i++)
+                            {
+                                ConstraintedPoint.SatisfyConstraints(rocketStar);
+                                ConstraintedPoint.SatisfyConstraints(rocket.point);
+                            }
                         }
                         rocket.rotation = AngleTo0_360(rocket.startRotation + rocketCandyMain.rotation - rocket.startCandyRotation);
                     }
@@ -1341,7 +1352,10 @@ namespace CutTheRopeDX.GameMain
                         {
                             impulse = VectMult(impulse, rocket.impulseFactor);
                         }
-                        rocketStar.ApplyImpulseDelta(impulse, delta);
+                        if (!parkedOnMouse)
+                        {
+                            rocketStar.ApplyImpulseDelta(impulse, delta);
+                        }
                         rocketStar.gravity = vectZero;
                         rocket.point.pos.X = rocketStar.pos.X;
                         rocket.point.pos.Y = rocketStar.pos.Y;

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -161,18 +161,6 @@ namespace CutTheRopeDX.GameMain
             {
                 time += delta;
             }
-            bool handHoldingCandy = false;
-            if (hands != null)
-            {
-                foreach (MechanicalHand hand in hands)
-                {
-                    if (hand != null && hand.state == MechanicalHand.STATE_HAND_CANDY)
-                    {
-                        handHoldingCandy = true;
-                        break;
-                    }
-                }
-            }
             if (bungees.Count > 0)
             {
                 bool flag = false;
@@ -283,8 +271,9 @@ namespace CutTheRopeDX.GameMain
                                     grab.hideRadius = true;
                                     grab.SetRope(bungee);
 
-                                    // If mouse already has this candy, immediately cut the rope
-                                    if (miceManager?.ActiveMouseHasCandy() ?? false)
+                                    // If the mouse already has THIS half, immediately cut the rope.
+                                    // Per-candy: a mouse carrying another candy must not cut it.
+                                    if (MouseOwnership.CarriesCandy(miceManager?.ActiveMouseCarriedStar(), starL))
                                     {
                                         bungee.SetCut(bungee.parts.Count - 2);
                                     }
@@ -302,8 +291,9 @@ namespace CutTheRopeDX.GameMain
                                     grab.hideRadius = true;
                                     grab.SetRope(bungee2);
 
-                                    // If mouse already has this candy, immediately cut the rope
-                                    if (miceManager?.ActiveMouseHasCandy() ?? false)
+                                    // If the mouse already has THIS half, immediately cut the rope.
+                                    // Per-candy: a mouse carrying another candy must not cut it.
+                                    if (MouseOwnership.CarriesCandy(miceManager?.ActiveMouseCarriedStar(), starR))
                                     {
                                         bungee2.SetCut(bungee2.parts.Count - 2);
                                     }
@@ -459,7 +449,9 @@ namespace CutTheRopeDX.GameMain
                         CandyContext ctx = candies[ci];
                         if (ci == 0)
                         {
-                            if (!flag && !noCandy && !handHoldingCandy)
+                            // Per-candy, matching the extras branch below: only a hand holding
+                            // THIS candy freezes its rotation coast.
+                            if (!flag && !noCandy && ctx.capturingHand == null)
                             {
                                 candyMain.rotation += MIN(5, lastCandyRotateDelta);
                                 lastCandyRotateDelta *= 0.98f;
@@ -1302,7 +1294,7 @@ namespace CutTheRopeDX.GameMain
                                 if (bungee != null)
                                 {
                                     Bungee rope = bungee.rope;
-                                    if (rope != null && rope.tail == rocketStar && rope.cut == -1 && rope.relaxed > 0 && !handHoldingCandy)
+                                    if (rope != null && rope.tail == rocketStar && rope.cut == -1 && rope.relaxed > 0 && rocketCandy?.capturingHand == null)
                                     {
                                         ropeRelaxed = true;
                                         AlignRocketAngleToRope(rocket, rope, delta);
@@ -1312,7 +1304,7 @@ namespace CutTheRopeDX.GameMain
                         }
                         // iOS steers the rocket off the candy connector too. It lives outside the grab
                         // list and joins two candy points, so there is no rocketStar tail check and no
-                        // handHoldingCandy gate. The connector counts as relaxed while it is nearly
+                        // hand gate. The connector counts as relaxed while it is nearly
                         // straight: |straight-line span - polyline length| < polyline length / 4.
                         if (candyConnector != null && candyConnector.cut == -1)
                         {
@@ -1350,7 +1342,8 @@ namespace CutTheRopeDX.GameMain
                     }
                     if (rocket.state == Rocket.STATE_ROCKET_DIST)
                     {
-                        if (handHoldingCandy || Mover.MoveVariableToTarget(ref dist, 0f, ActivePhysicsConstants.RocketReelSpeed, delta))
+                        // Per-candy: only a hand holding THIS rocket's candy skips the reel-in.
+                        if (rocketCandy?.capturingHand != null || Mover.MoveVariableToTarget(ref dist, 0f, ActivePhysicsConstants.RocketReelSpeed, delta))
                         {
                             rocket.state = Rocket.STATE_ROCKET_FLY;
                         }

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1088,7 +1088,9 @@ namespace CutTheRopeDX.GameMain
                 {
                     Grab bungee4 = (Grab)obj9;
                     // Self-moving grabs and player rails never ride the disc.
-                    bool discBindable = GrabPlatformBind.CanBind(bungee4.mover != null, bungee4.moveLength > 0);
+                    bool discBindable = GrabPlatformBind.FollowsPlatform(
+                        GrabPlatformBind.CanBind(bungee4.mover != null, bungee4.moveLength > 0),
+                        bungee4.kickable && bungee4.kicked);
                     if (discBindable && VectDistance(Vect(bungee4.x, bungee4.y), Vect(rotatedCircle7.x, rotatedCircle7.y)) <= rotatedCircle7.sizeInPixels + (RTPD(5) * 3f))
                     {
                         if (rotatedCircle7.containedObjects.IndexOf(bungee4) == -1)

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -842,6 +842,17 @@ namespace CutTheRopeDX.GameMain
                             {
                                 continue;
                             }
+                            if (ctx.HasActiveRocket)
+                            {
+                                // Rocket-bound candy pops bubbles it touches instead of entering
+                                // them (Experiments reference): the bubble is consumed, never captured.
+                                PopBubbleAtXY(bubble3.x, bubble3.y);
+                                bubble3.popped = true;
+                                bubble3.RemoveChildWithID(0);
+                                conveyors.Remove(bubble3);
+                                captured = true;
+                                break;
+                            }
                             if (candyBubble != null)
                             {
                                 PopBubbleAtXY(bubble3.x, bubble3.y);
@@ -883,6 +894,15 @@ namespace CutTheRopeDX.GameMain
                             || !BubbleCapture.Captures(Vect(ctx.candy.x, ctx.candy.y), Vect(bubble3.x, bubble3.y), bubbleCaptureRadius))
                         {
                             continue;
+                        }
+                        if (ctx.HasActiveRocket)
+                        {
+                            PopBubbleAtXY(bubble3.x, bubble3.y);
+                            bubble3.popped = true;
+                            bubble3.RemoveChildWithID(0);
+                            conveyors.Remove(bubble3);
+                            captured = true;
+                            break;
                         }
                         // Already carried by a different bubble: release the old one and swap to the
                         // new bubble, mirroring the candies[0] path. Without this, a bubbled body

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1329,6 +1329,20 @@ namespace CutTheRopeDX.GameMain
                                 continue;
                             }
 
+                            // A rocket and a bubble are contradictory drivers on the same point;
+                            // the Experiments reference pops the bubble at bind.
+                            if (ctx == candies[0])
+                            {
+                                if (candyBubble != null)
+                                {
+                                    PopCandyBubble(false);
+                                }
+                            }
+                            else if (ctx.bubble != null)
+                            {
+                                PopCandyBubble(ctx);
+                            }
+
                             rocket.mover?.Pause();
                             rocket.startRotation = rocket.rotation;
                             if (handHoldingCandy)

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1217,6 +1217,12 @@ namespace CutTheRopeDX.GameMain
                             ctx.savedSockSpeed = ActivePhysicsConstants.SockSpeedKoeff * VectLength(ctx.point.v);
                             ctx.savedSockSpeed *= ActivePhysicsConstants.SockTeleportSpeedMultiplier;
                             ctx.targetSock = sock4;
+                            // The rocket teleports with the candy; hide it for the transit like the
+                            // reference (Gift catch sets visible = 0; Teleport re-shows it).
+                            if (ctx.HasActiveRocket)
+                            {
+                                ctx.activeRocket.visible = false;
+                            }
                             ctx.lightBulb?.SyncFromContext(ctx);
                             sock3.light.PlayTimeline(0);
                             sock3.light.visible = true;

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1253,6 +1253,14 @@ namespace CutTheRopeDX.GameMain
                     CandyContext rocketCandy = RocketBoundCandy(rocket);
                     ConstraintedPoint rocketStar = rocketCandy?.point ?? star;
                     GameObject rocketCandyMain = rocketCandy?.candyMain ?? candyMain;
+                    // Rocket flight requires zero gravity on the candy point. Any drop path (e.g.
+                    // Mouse.DropCandy re-enabling gravity when the mouse lets go of a rocket-bound
+                    // candy) is healed here every frame while the rocket is bound — mirrors the
+                    // reference's recurring `star->disableGravity = activeRocket != 0`.
+                    if (rocket.state is Rocket.STATE_ROCKET_FLY or Rocket.STATE_ROCKET_DIST)
+                    {
+                        rocketStar.disableGravity = true;
+                    }
                     float dist = VectLength(VectSub(rocketStar.pos, rocket.point.pos));
                     if (rocket.state is Rocket.STATE_ROCKET_FLY or Rocket.STATE_ROCKET_DIST)
                     {

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1087,7 +1087,9 @@ namespace CutTheRopeDX.GameMain
                 foreach (object obj9 in bungees)
                 {
                     Grab bungee4 = (Grab)obj9;
-                    if (VectDistance(Vect(bungee4.x, bungee4.y), Vect(rotatedCircle7.x, rotatedCircle7.y)) <= rotatedCircle7.sizeInPixels + (RTPD(5) * 3f))
+                    // Self-moving grabs and player rails never ride the disc.
+                    bool discBindable = GrabPlatformBind.CanBind(bungee4.mover != null, bungee4.moveLength > 0);
+                    if (discBindable && VectDistance(Vect(bungee4.x, bungee4.y), Vect(rotatedCircle7.x, rotatedCircle7.y)) <= rotatedCircle7.sizeInPixels + (RTPD(5) * 3f))
                     {
                         if (rotatedCircle7.containedObjects.IndexOf(bungee4) == -1)
                         {

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1218,6 +1218,10 @@ namespace CutTheRopeDX.GameMain
                             ReleaseRopesForPoint(ctx.point);
                             DetachHandsForPoint(ctx.point);
                             DropMouseCandyForPoint(ctx.point);
+                            // Take the candy off the ants too: a lingering antSegment hard-overwrites
+                            // the point position all through transit and then yanks/brakes the candy
+                            // at the exit sock, killing the teleport throw.
+                            DetachCandyFromConveyor(ctx);
                             ctx.savedSockSpeed = ActivePhysicsConstants.SockSpeedKoeff * VectLength(ctx.point.v);
                             ctx.savedSockSpeed *= ActivePhysicsConstants.SockTeleportSpeedMultiplier;
                             ctx.targetSock = sock4;

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1285,7 +1285,18 @@ namespace CutTheRopeDX.GameMain
                     }
                     if (rocket.state == Rocket.STATE_ROCKET_FLY)
                     {
-                        lastCandyRotateDelta = 0f;
+                        // Silence THIS candy's rope-spin coast: the rocket's heading tracks
+                        // candyMain.rotation, so a leftover coast (e.g. after the rope is cut)
+                        // curves the flight as if it were still steering along the rope.
+                        // candies[0] uses the singleton field, extras their own (see ~410).
+                        if (rocketCandy == null || rocketCandy == candies[0])
+                        {
+                            lastCandyRotateDelta = 0f;
+                        }
+                        else
+                        {
+                            rocketCandy.lastCandyRotateDelta = 0f;
+                        }
                         bool ropeRelaxed = false;
                         if (bungees != null)
                         {
@@ -1397,7 +1408,15 @@ namespace CutTheRopeDX.GameMain
                                 rocket.point.AddConstraintwithRestLengthofType(ctx.point, dist, Constraint.CONSTRAINT.NOT_MORE_THAN);
                                 rocket.state = Rocket.STATE_ROCKET_DIST;
                             }
-                            lastCandyRotateDelta = 0f;
+                            // Per-candy: zero the bound candy's rope-spin coast, not candy 0's.
+                            if (ctx == candies[0])
+                            {
+                                lastCandyRotateDelta = 0f;
+                            }
+                            else
+                            {
+                                ctx.lastCandyRotateDelta = 0f;
+                            }
                             Vector deltaPos = VectSub(ctx.point.pos, ctx.point.prevPos);
                             ctx.point.prevPos = VectAdd(ctx.point.prevPos, VectDiv(deltaPos, ctx.point.disableGravity ? 2f : 1.25f));
                             ctx.point.disableGravity = true;

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1259,20 +1259,14 @@ namespace CutTheRopeDX.GameMain
                     {
                         continue;
                     }
-                    rocket.Update(delta);
-                    rocket.UpdateRotation();
                     // The rocket flies exactly one candy; resolve it (null while idle/unbound).
+                    // Resolved BEFORE rocket.Update so a parked rocket can pre-snap: the mice
+                    // update (which teleports the candy across the level on a mouse handoff) runs
+                    // earlier in the frame, and rocket.Update syncs the visual from point.pos — a
+                    // post-Update snap would leave the rocket rendered at the old mouth for one frame.
                     CandyContext rocketCandy = RocketBoundCandy(rocket);
                     ConstraintedPoint rocketStar = rocketCandy?.point ?? star;
                     GameObject rocketCandyMain = rocketCandy?.candyMain ?? candyMain;
-                    // Rocket flight requires zero gravity on the candy point. Any drop path (e.g.
-                    // Mouse.DropCandy re-enabling gravity when the mouse lets go of a rocket-bound
-                    // candy) is healed here every frame while the rocket is bound — mirrors the
-                    // reference's recurring `star->disableGravity = activeRocket != 0`.
-                    if (rocket.state is Rocket.STATE_ROCKET_FLY or Rocket.STATE_ROCKET_DIST)
-                    {
-                        rocketStar.disableGravity = true;
-                    }
                     // Park the rocket while the mouse carries its candy. The kinematic pin plus the
                     // per-frame rocket-point snap keep the rest-0 pair exactly coincident, and the
                     // solver's coincident fallback (DEFAULT_NON_ZERO_CONSTRAINT_DIRECTION, 30
@@ -1281,6 +1275,23 @@ namespace CutTheRopeDX.GameMain
                     // Parked: no satisfaction, no thrust; position snap, rotation sync, fuse tick
                     // and gravity heal keep running, and full flight resumes on drop.
                     bool parkedOnMouse = rocketCandy?.carriedByMouse == true;
+                    if (parkedOnMouse && rocket.state is Rocket.STATE_ROCKET_FLY or Rocket.STATE_ROCKET_DIST)
+                    {
+                        // prevPos too: rocket.Update integrates the point next, and a bare pos
+                        // teleport would replay the whole jump as one frame of velocity.
+                        rocket.point.pos = rocketStar.pos;
+                        rocket.point.prevPos = rocketStar.pos;
+                    }
+                    rocket.Update(delta);
+                    rocket.UpdateRotation();
+                    // Rocket flight requires zero gravity on the candy point. Any drop path (e.g.
+                    // Mouse.DropCandy re-enabling gravity when the mouse lets go of a rocket-bound
+                    // candy) is healed here every frame while the rocket is bound — mirrors the
+                    // reference's recurring `star->disableGravity = activeRocket != 0`.
+                    if (rocket.state is Rocket.STATE_ROCKET_FLY or Rocket.STATE_ROCKET_DIST)
+                    {
+                        rocketStar.disableGravity = true;
+                    }
                     float dist = VectLength(VectSub(rocketStar.pos, rocket.point.pos));
                     if (rocket.state is Rocket.STATE_ROCKET_FLY or Rocket.STATE_ROCKET_DIST)
                     {

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1033,6 +1033,15 @@ namespace CutTheRopeDX.GameMain
                     ReleaseRopesForPoint(ctx.point);
                     DetachHandsForPoint(ctx.point);
                     DropMouseCandyForPoint(ctx.point);
+                    // Lantern capture is terminal for this candy's riders: snails hop off (giving
+                    // their weight back) and ants stop carrying it, mirroring hand-grab.
+                    int lanternDetachedSnails = ActiveSnailCountForPoint(ctx.point);
+                    DetachSnailsForPoint(ctx.point);
+                    if (lanternDetachedSnails > 0)
+                    {
+                        ctx.point.SetWeight(SnailWeight.AfterForceDetach(ctx.point.weight, lanternDetachedSnails));
+                    }
+                    DetachCandyFromConveyor(ctx);
                     if (ci == 0)
                     {
                         if (candyBubble != null)

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1141,7 +1141,13 @@ namespace CutTheRopeDX.GameMain
                         if (MouseGrab.ShouldGrab(miceManager.ActiveMouseHasCandy(), !ctx.noCandy, miceManager.IsActiveMouseInRange(ctx.point)))
                         {
                             miceManager.GrabWithActiveMouse(ctx.point, ctx.candy);
-                            ExhaustRocketForCandy(ctx);
+                            // The rocket steals from nobody and nobody kills it (PD 2026-07-24):
+                            // a stolen rocket-bound candy keeps its rocket, which strains at the
+                            // mouse's mouth and launches when the mouse drops the candy. The
+                            // per-frame gravity enforcement in the rocket update keeps flight
+                            // physics intact across the mouse's drop path. The mouse likewise
+                            // keeps a bubble (official levels carry bubbled candy) and any
+                            // riding snail.
                             TriggerSpecialTutorial(4);
                             break;
                         }

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1633,6 +1633,21 @@ namespace CutTheRopeDX.GameMain
                     if (snail.state == Snail.SNAIL_STATE_ACTIVE)
                     {
                         snail.rotation = CandyForPoint(snail.AttachedPoint()).InteractionRotation - snail.startRotation;
+                        // The snail wins over a bubble: pop the ridden candy's bubble
+                        // (Experiments reference) so the pair never floats up together.
+                        CandyContext ridden = CandyForPoint(snail.AttachedPoint());
+                        bool riddenHasBubble = ridden == candies[0] ? candyBubble != null : ridden.bubble != null;
+                        if (SnailBubblePop.ShouldPop(true, snail.AttachedPoint() != null, riddenHasBubble))
+                        {
+                            if (ridden == candies[0])
+                            {
+                                PopCandyBubble(false);
+                            }
+                            else
+                            {
+                                PopCandyBubble(ridden);
+                            }
+                        }
                     }
 
                     if (snail.state == Snail.SNAIL_STATE_INACTIVE)

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1341,10 +1341,7 @@ namespace CutTheRopeDX.GameMain
                                 continue;
                             }
                             bool intersects = GameObject.ObjectsIntersectRotatedWithUnrotated(rocket, ctx.candy);
-                            // Per-candy: only the candy the mouse actually holds is blocked from binding,
-                            // not every candy while the mouse holds any one of them.
-                            bool mouseHasCandy = ctx.carriedByMouse;
-                            if (!RocketBind.ShouldBind(rocket.state == Rocket.STATE_ROCKET_IDLE, !ctx.noCandy, ctx.inLantern, mouseHasCandy, intersects))
+                            if (!RocketBind.ShouldBind(rocket.state == Rocket.STATE_ROCKET_IDLE, !ctx.noCandy, ctx.inLantern, intersects))
                             {
                                 continue;
                             }
@@ -1365,7 +1362,10 @@ namespace CutTheRopeDX.GameMain
 
                             rocket.mover?.Pause();
                             rocket.startRotation = rocket.rotation;
-                            if (handHoldingCandy)
+                            // Per-candy: only a holder of THIS candy selects the direct-FLY bind.
+                            // The rocket steals from nobody — it coexists with hand or mouse and
+                            // launches when the holder releases.
+                            if (RocketBindPath.UsesDirectFlyPath(ctx.capturingHand != null, ctx.carriedByMouse))
                             {
                                 rocket.point.pos = ctx.point.pos;
                                 rocket.point.AddConstraintwithRestLengthofType(ctx.point, 0f, Constraint.CONSTRAINT.NOT_MORE_THAN);

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1032,6 +1032,7 @@ namespace CutTheRopeDX.GameMain
                     ctx.candy.PlayTimeline(0);
                     ReleaseRopesForPoint(ctx.point);
                     DetachHandsForPoint(ctx.point);
+                    DropMouseCandyForPoint(ctx.point);
                     if (ci == 0)
                     {
                         if (candyBubble != null)
@@ -1177,6 +1178,7 @@ namespace CutTheRopeDX.GameMain
                             sock4.idleTimeout = 0.8f;
                             ReleaseRopesForPoint(ctx.point);
                             DetachHandsForPoint(ctx.point);
+                            DropMouseCandyForPoint(ctx.point);
                             ctx.savedSockSpeed = ActivePhysicsConstants.SockSpeedKoeff * VectLength(ctx.point.v);
                             ctx.savedSockSpeed *= ActivePhysicsConstants.SockTeleportSpeedMultiplier;
                             ctx.targetSock = sock4;
@@ -2202,7 +2204,7 @@ namespace CutTheRopeDX.GameMain
                     {
                         ctx.point.SetWeight(SnailWeight.AfterForceDetach(ctx.point.weight, detachedSnails));
                     }
-                    miceManager?.ForceDropCandy();
+                    DropMouseCandyForPoint(ctx.point);
                     RestoreCandyProperties(ctx);
                     hand.AnimateCatchWithCandyPartsandAnimationsPool(ctx.HandCatchVisuals(), ctx.HandCatchScale, aniPool);
                     CTRSoundMgr.PlaySound(Resources.Snd.ExpHandCatch);

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1976,18 +1976,18 @@ namespace CutTheRopeDX.GameMain
                 {
                     noCandy = true;
                 }
-                // Only the leaver's own rocket dies (C breakCandy stops candy+392, not all rockets).
-                // A body that does not lose the level (e.g. a light bulb) still has to release its
-                // rope and exhaust its rocket when it leaves the screen: C's generic-object loop
-                // tears down any unguarded off-screen object, not just losable candy.
                 ExhaustRocketForCandy(ctx);
-                if (ctx.Capabilities.CanLoseLevelWhenOffScreen)
+                if (ci == 0)
                 {
-                    anyLeft = true;
+                    ReleaseAllRopes(false);
                 }
                 else
                 {
                     ReleaseRopesForPoint(ctx.point);
+                }
+                if (ctx.Capabilities.CanLoseLevelWhenOffScreen)
+                {
+                    anyLeft = true;
                 }
             }
             if (twoParts != 2)

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -941,6 +941,22 @@ namespace CutTheRopeDX.GameMain
                         }
                     }
                 }
+
+                // A bubble lying on a belt drops its ground shadow the same way, or the shadow is
+                // stamped across the plates. An ordinary bubble gets that from being bound to the
+                // belt; a ghost's bubble never binds (it stays with the ghost that conjured it) and
+                // is conjured long after the one-off bind pass, so it needs the test here.
+                if (!bubble3.withoutShadow && bubble3 is IGhostApparition && conveyors != null)
+                {
+                    foreach (ConveyorBelt belt in conveyors.Iterator())
+                    {
+                        if (belt.CollidesWithCircle(Vect(bubble3.x, bubble3.y), bubble3.CollisionRadius * 0.6f))
+                        {
+                            bubble3.withoutShadow = true;
+                            break;
+                        }
+                    }
+                }
             }
             if (ghosts != null)
             {
@@ -1079,10 +1095,11 @@ namespace CutTheRopeDX.GameMain
                 foreach (object obj9 in bungees)
                 {
                     Grab bungee4 = (Grab)obj9;
-                    // Self-moving grabs and player rails never ride the disc.
+                    // Self-moving grabs, player rails, and ghost apparitions never ride the disc.
                     bool discBindable = GrabPlatformBind.FollowsPlatform(
                         GrabPlatformBind.CanBind(bungee4.mover != null, bungee4.moveLength > 0),
-                        bungee4.kickable && bungee4.kicked);
+                        bungee4.kickable && bungee4.kicked)
+                        && bungee4 is not IGhostApparition;
                     if (discBindable && VectDistance(Vect(bungee4.x, bungee4.y), Vect(rotatedCircle7.x, rotatedCircle7.y)) <= rotatedCircle7.sizeInPixels + (RTPD(5) * 3f))
                     {
                         if (rotatedCircle7.containedObjects.IndexOf(bungee4) == -1)
@@ -1098,7 +1115,8 @@ namespace CutTheRopeDX.GameMain
                 foreach (object obj10 in bubbles)
                 {
                     Bubble bubble4 = (Bubble)obj10;
-                    if (VectDistance(Vect(bubble4.x, bubble4.y), Vect(rotatedCircle7.x, rotatedCircle7.y)) <= rotatedCircle7.sizeInPixels + (RTPD(10) * 3f))
+                    if (bubble4 is not IGhostApparition
+                        && VectDistance(Vect(bubble4.x, bubble4.y), Vect(rotatedCircle7.x, rotatedCircle7.y)) <= rotatedCircle7.sizeInPixels + (RTPD(10) * 3f))
                     {
                         if (rotatedCircle7.containedObjects.IndexOf(bubble4) == -1)
                         {

--- a/CutTheRopeDX/GameMain/GhostBouncer.cs
+++ b/CutTheRopeDX/GameMain/GhostBouncer.cs
@@ -8,7 +8,7 @@ namespace CutTheRopeDX.GameMain
     /// <summary>
     /// Ghost-transformed bouncer variant with ambient supporting cloud visuals.
     /// </summary>
-    internal sealed class GhostBouncer : Bouncer
+    internal sealed class GhostBouncer : Bouncer, IGhostApparition
     {
         /// <inheritdoc />
         public override Bouncer InitWithPosXYWidthAndAngle(float px, float py, int width, float angle)

--- a/CutTheRopeDX/GameMain/GhostBubble.cs
+++ b/CutTheRopeDX/GameMain/GhostBubble.cs
@@ -6,7 +6,7 @@ namespace CutTheRopeDX.GameMain
     /// <summary>
     /// Ghost-transformed bubble variant with supporting cloud visuals and custom draw behavior.
     /// </summary>
-    internal sealed class GhostBubble : Bubble
+    internal sealed class GhostBubble : Bubble, IGhostApparition
     {
         /// <summary>
         /// Creates a ghost bubble from a texture.

--- a/CutTheRopeDX/GameMain/GhostGrab.cs
+++ b/CutTheRopeDX/GameMain/GhostGrab.cs
@@ -10,7 +10,7 @@ namespace CutTheRopeDX.GameMain
     /// <summary>
     /// Ghost-transformed grab variant with ambient cloud visuals and a tinted grab radius.
     /// </summary>
-    internal sealed class GhostGrab : Grab
+    internal sealed class GhostGrab : Grab, IGhostApparition
     {
         /// <summary>
         /// Initializes the ghost grab at a level position and creates its supporting cloud visuals.

--- a/CutTheRopeDX/GameMain/Grab.cs
+++ b/CutTheRopeDX/GameMain/Grab.cs
@@ -778,7 +778,7 @@ namespace CutTheRopeDX.GameMain
         /// <inheritdoc />
         public void DidMoveToOtherSide()
         {
-            if (candyNumber != -1 && rope != null && rope.cut == -1)
+            if (rope != null && rope.cut == -1)
             {
                 rope.MoveAnchor(Vect(x, y));
             }

--- a/CutTheRopeDX/GameMain/GrabPlatformBind.cs
+++ b/CutTheRopeDX/GameMain/GrabPlatformBind.cs
@@ -1,0 +1,23 @@
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// Platforms (conveyor belt, DJ disc) never move a grab that has its own movement. Static
+    /// exclusion at bind time for autonomous movers (bee, launcher) and player drag rails;
+    /// dynamic per-frame exclusion for a kicked (detached, free-falling) suction cup, which
+    /// resumes following when it re-sticks.
+    /// </summary>
+    internal static class GrabPlatformBind
+    {
+        /// <summary>Static: may this grab be bound/captured by a platform at all?</summary>
+        public static bool CanBind(bool hasOwnMover, bool isMoveableRail)
+        {
+            return !hasOwnMover && !isMoveableRail;
+        }
+
+        /// <summary>Dynamic: should the platform drive this grab this frame?</summary>
+        public static bool FollowsPlatform(bool canBind, bool isKickedFree)
+        {
+            return canBind && !isKickedFree;
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/HandGrab.cs
+++ b/CutTheRopeDX/GameMain/HandGrab.cs
@@ -2,7 +2,9 @@ namespace CutTheRopeDX.GameMain
 {
     /// <summary>
     /// Pure grab-gate for the mechanical hand. An idle hand grabs a candy only when the candy exists,
-    /// is not captured in a lantern, is not in a sock, and is within grab range. <c>inRange</c>
+    /// is not captured in a lantern, is not in sock transit, and is within grab range. Bamboo transit
+    /// is covered by <c>candyPresent</c>: bamboo entry sets <c>noCandy</c> for the transit while sock
+    /// entry does not, which is why only the sock needs an explicit parameter. <c>inRange</c>
     /// is precomputed by the caller (distance &lt; <c>MechanicalHand.MH_GRAB_DISTANCE</c>). One candy per hand.
     /// </summary>
     internal static class HandGrab

--- a/CutTheRopeDX/GameMain/IGhostApparition.cs
+++ b/CutTheRopeDX/GameMain/IGhostApparition.cs
@@ -1,0 +1,16 @@
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// Marks a shape conjured by a <see cref="Ghost"/> at the ghost's own position - the bubble, rope
+    /// hook, or bouncer it currently wears.
+    /// </summary>
+    /// <remarks>
+    /// Platforms (DJ disc, conveyor belt) never carry an apparition. The morph clouds drawn around one
+    /// are separate elements fixed at the spot the ghost occupies, so moving the apparition on its own
+    /// tears it away from its own decoration and leaves the clouds hanging in mid-air. The apparition
+    /// is scenery belonging to the ghost rather than cargo, so platforms leave it where it is.
+    /// </remarks>
+    internal interface IGhostApparition
+    {
+    }
+}

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadGrabs.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadGrabs.cs
@@ -44,7 +44,9 @@ namespace CutTheRopeDX.GameMain
             grab.initial_y = grab.y = hy;
             grab.initial_rotation = 0f;
             grab.wheel = wheel;
-            grab.gun = gun;
+            // A grab is either a wheel or a gun, never both; malformed XML with both set
+            // resolves to the wheel (PD 2026-07-24).
+            grab.gun = gun && !wheel;
             grab.kickable = kickable;
             grab.kicked = kicked;
             grab.invisible = invisible;
@@ -121,7 +123,9 @@ namespace CutTheRopeDX.GameMain
                 }
             }
             grab.SetRadius(grabRadius);
-            grab.SetMoveLengthVerticalOffset(k, v, o);
+            // A path mover (bee/launcher) and a drag rail are mutually exclusive movement
+            // mechanisms; the authored path wins and rail attributes are ignored (PD 2026-07-24).
+            grab.SetMoveLengthVerticalOffset(grab.mover != null ? 0f : k, v, o);
             if (grab.gun && grab.gunArrow != null)
             {
                 ConstraintedPoint constraintedPoint = star;

--- a/CutTheRopeDX/GameMain/MiceObject.cs
+++ b/CutTheRopeDX/GameMain/MiceObject.cs
@@ -198,6 +198,24 @@ namespace CutTheRopeDX.GameMain
         }
 
         /// <summary>
+        /// Returns every candy still held by a mouse to the physics solver, gravity back on. Used
+        /// when the level ends: a mouse that keeps its candy through the outcome leaves that point
+        /// pinned at the hole with gravity off, which strands the candy once the mice stop cycling.
+        /// The manager-level handoff references are cleared too, so a mouse spawning afterwards is
+        /// not handed a candy that has already been let go.
+        /// </summary>
+        public void ReleaseAllCandy()
+        {
+            foreach (Mouse mouse in mice)
+            {
+                _ = mouse?.ReleaseCarriedCandy();
+            }
+
+            carriedStar = null;
+            carriedCandy = null;
+        }
+
+        /// <summary>
         /// Locks the active mouse, preventing further advancement
         /// to other mice.
         /// </summary>

--- a/CutTheRopeDX/GameMain/Mouse.cs
+++ b/CutTheRopeDX/GameMain/Mouse.cs
@@ -347,13 +347,15 @@ namespace CutTheRopeDX.GameMain
         }
 
         /// <summary>
-        /// Releases the currently carried candy, re-enabling gravity and clearing references.
+        /// Hands the carried candy back to the physics solver, re-enabling gravity and clearing
+        /// references. Silent: the tap sound belongs to the player-driven drop, not to this.
         /// </summary>
-        public void DropCandy()
+        /// <returns><see langword="true"/> when candy was actually carried and has been released.</returns>
+        public bool ReleaseCarriedCandy()
         {
             if (carriedStar == null)
             {
-                return;
+                return false;
             }
 
             carriedStar.disableGravity = false;
@@ -361,7 +363,19 @@ namespace CutTheRopeDX.GameMain
             carriedStar = null;
             carriedCandy = null;
             grabAnimating = false;
-            CTRSoundMgr.PlaySound(Resources.Snd.MouseTap);
+            return true;
+        }
+
+        /// <summary>
+        /// Releases the currently carried candy in response to the player, re-enabling gravity and
+        /// clearing references.
+        /// </summary>
+        public void DropCandy()
+        {
+            if (ReleaseCarriedCandy())
+            {
+                CTRSoundMgr.PlaySound(Resources.Snd.MouseTap);
+            }
         }
 
         /// <summary>

--- a/CutTheRopeDX/GameMain/RocketBind.cs
+++ b/CutTheRopeDX/GameMain/RocketBind.cs
@@ -1,10 +1,11 @@
 namespace CutTheRopeDX.GameMain
 {
     /// <summary>
-    /// Pure bind-gate for rockets. A rocket binds a candy only while the rocket is idle (one-time use:
-    /// after it leaves idle it is permanently consumed), the candy exists, is not captured in a lantern,
-    /// is not held by the active mouse, and physically intersects the rocket. Intersects is precomputed by the caller
-    /// (<c>GameObject.ObjectsIntersectRotatedWithUnrotated</c>).
+    /// Pure bind-gate for rockets. A rocket binds a candy only while the rocket is idle (one-time
+    /// use: after it leaves idle it is permanently consumed), the candy exists, is not captured in
+    /// a lantern, and physically intersects the rocket. A mouse-held candy IS bindable — the
+    /// rocket coexists with the mouse via <see cref="RocketBindPath"/> (it steals from nobody).
+    /// Intersects is precomputed by the caller.
     /// </summary>
     internal static class RocketBind
     {
@@ -12,13 +13,11 @@ namespace CutTheRopeDX.GameMain
             bool rocketIdle,
             bool candyPresent,
             bool candyInLantern,
-            bool mouseHasCandy,
             bool intersects)
         {
             return rocketIdle
                 && candyPresent
                 && !candyInLantern
-                && !mouseHasCandy
                 && intersects;
         }
     }

--- a/CutTheRopeDX/GameMain/RocketBindPath.cs
+++ b/CutTheRopeDX/GameMain/RocketBindPath.cs
@@ -1,0 +1,15 @@
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// Selects how a rocket binds: a held candy (hand or mouse, judged per candy) gets the
+    /// zero-rest-length direct-FLY bind so the rocket coexists with the holder and launches when
+    /// released; a free candy gets the classic DIST reel-in.
+    /// </summary>
+    internal static class RocketBindPath
+    {
+        public static bool UsesDirectFlyPath(bool handHoldsThisCandy, bool mouseCarriesThisCandy)
+        {
+            return handHoldsThisCandy || mouseCarriesThisCandy;
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/SnailBubblePop.cs
+++ b/CutTheRopeDX/GameMain/SnailBubblePop.cs
@@ -1,0 +1,18 @@
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// A snail and a bubble cannot coexist on one candy. While a snail actively rides, the ridden
+    /// candy's bubble pops — the snail wins (Experiments reference). Per candy: only the
+    /// ridden candy's bubble is affected.
+    /// </summary>
+    internal static class SnailBubblePop
+    {
+        /// <param name="snailActive">True when the snail is in its riding state.</param>
+        /// <param name="ridesACandy">True when the snail's attached point resolves to a candy.</param>
+        /// <param name="candyHasBubble">True when that candy currently has a bubble.</param>
+        public static bool ShouldPop(bool snailActive, bool ridesACandy, bool candyHasBubble)
+        {
+            return snailActive && ridesACandy && candyHasBubble;
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/SnailWeight.cs
+++ b/CutTheRopeDX/GameMain/SnailWeight.cs
@@ -4,8 +4,10 @@ namespace CutTheRopeDX.GameMain
     /// Pure weight bookkeeping for snails riding a candy point. Each attached snail adds
     /// <see cref="PerSnailWeight"/> to the point so the candy is dragged down; force-detaching a snail
     /// (hand grab, capture, etc.) must remove that exact amount, otherwise the candy keeps falling as if
-    /// the snail were still attached. The result never drops below <see cref="MinWeight"/>, so a base
-    /// candy weight (including a heavier rocket candy) is preserved rather than clobbered to a flat value.
+    /// the snail were still attached. iOS instead assigns a flat 1.0 at its two reset sites (boarding the
+    /// ant conveyor and tapping the candy); subtracting reaches the same number here, because every candy
+    /// point is created at <see cref="MinWeight"/> and a snail is the only thing that ever adds to it -
+    /// a rocket carries its own point, not a heavier candy. The floor keeps that true if it ever changes.
     /// </summary>
     internal static class SnailWeight
     {


### PR DESCRIPTION
## Description

Depends on #270.

Allow more cross-game interactions, e.g. let the mouse carry rocket.

See this gist for more info about the interaction matrix: https://gist.github.com/yell0wsuit/89299114ed8a76967195fd9adb5ab6c3