### PR TITLE
fix: Prevent streamed music cutoff at loop boundary

### DIFF
--- a/CutTheRopeDX.Tests/SongLoopWorkaroundTests.cs
+++ b/CutTheRopeDX.Tests/SongLoopWorkaroundTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Reflection;
+
+using CutTheRopeDX.Framework.Media;
+
+using Microsoft.Xna.Framework.Media;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class SongLoopWorkaroundTests
+    {
+        [Fact]
+        public void Scheduler_WaitsForDecodedTailToFinishPlaying()
+        {
+            SongLoopScheduler scheduler = new();
+            scheduler.Schedule(
+                duration: TimeSpan.FromSeconds(64),
+                position: TimeSpan.FromSeconds(63.5));
+
+            Assert.False(scheduler.Advance(TimeSpan.FromMilliseconds(499), isPlaying: true));
+            Assert.True(scheduler.Advance(TimeSpan.FromMilliseconds(1), isPlaying: true));
+        }
+
+        [Fact]
+        public void Scheduler_DoesNotAdvanceWhileMusicIsPaused()
+        {
+            SongLoopScheduler scheduler = new();
+            scheduler.Schedule(
+                duration: TimeSpan.FromSeconds(64),
+                position: TimeSpan.FromSeconds(63.5));
+
+            Assert.False(scheduler.Advance(TimeSpan.FromSeconds(1), isPlaying: false));
+            Assert.False(scheduler.Advance(TimeSpan.FromMilliseconds(499), isPlaying: true));
+            Assert.True(scheduler.Advance(TimeSpan.FromMilliseconds(1), isPlaying: true));
+        }
+
+        [Fact]
+        public void Scheduler_ReusesFirstTailEstimateAcrossLoops()
+        {
+            SongLoopScheduler scheduler = new();
+            scheduler.Schedule(
+                duration: TimeSpan.FromSeconds(64),
+                position: TimeSpan.FromSeconds(63.5));
+            Assert.True(scheduler.Advance(TimeSpan.FromMilliseconds(500), isPlaying: true));
+
+            scheduler.Schedule(
+                duration: TimeSpan.FromSeconds(64),
+                position: TimeSpan.FromSeconds(63.4));
+
+            Assert.False(scheduler.Advance(TimeSpan.FromMilliseconds(499), isPlaying: true));
+            Assert.True(scheduler.Advance(TimeSpan.FromMilliseconds(1), isPlaying: true));
+        }
+
+        [Fact]
+        public void Installer_ReplacesMonoGameCompletionHandler()
+        {
+            using Song song = Song.FromUri(
+                "missing",
+                new Uri("file:///cut-the-rope-dx-missing-test-song.ogg"));
+            completionCalled = false;
+            EventHandler replacement = OnCompletion;
+
+            bool installed = MonoGameSongCompletionWorkaround.TryInstall(song, replacement);
+
+            Assert.True(installed);
+            FieldInfo field = typeof(Song).GetField(
+                "DonePlaying",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Delegate handler = Assert.IsAssignableFrom<Delegate>(field?.GetValue(song));
+            _ = handler.DynamicInvoke(song, EventArgs.Empty);
+            Assert.True(completionCalled);
+        }
+
+        private static void OnCompletion(object sender, EventArgs args)
+        {
+            completionCalled = true;
+        }
+
+        private static bool completionCalled;
+    }
+}

--- a/CutTheRopeDX.Tests/SongLoopWorkaroundTests.cs
+++ b/CutTheRopeDX.Tests/SongLoopWorkaroundTests.cs
@@ -15,9 +15,7 @@ namespace CutTheRopeDX.Tests
         public void Scheduler_WaitsForDecodedTailToFinishPlaying()
         {
             SongLoopScheduler scheduler = new();
-            scheduler.Schedule(
-                duration: TimeSpan.FromSeconds(64),
-                position: TimeSpan.FromSeconds(63.5));
+            scheduler.Schedule(duration: TimeSpan.FromSeconds(64));
 
             Assert.False(scheduler.Advance(TimeSpan.FromMilliseconds(499), isPlaying: true));
             Assert.True(scheduler.Advance(TimeSpan.FromMilliseconds(1), isPlaying: true));
@@ -27,9 +25,7 @@ namespace CutTheRopeDX.Tests
         public void Scheduler_DoesNotAdvanceWhileMusicIsPaused()
         {
             SongLoopScheduler scheduler = new();
-            scheduler.Schedule(
-                duration: TimeSpan.FromSeconds(64),
-                position: TimeSpan.FromSeconds(63.5));
+            scheduler.Schedule(duration: TimeSpan.FromSeconds(64));
 
             Assert.False(scheduler.Advance(TimeSpan.FromSeconds(1), isPlaying: false));
             Assert.False(scheduler.Advance(TimeSpan.FromMilliseconds(499), isPlaying: true));
@@ -37,17 +33,24 @@ namespace CutTheRopeDX.Tests
         }
 
         [Fact]
-        public void Scheduler_ReusesFirstTailEstimateAcrossLoops()
+        public void Scheduler_UsesSameDecoderTailAcrossLoops()
         {
             SongLoopScheduler scheduler = new();
-            scheduler.Schedule(
-                duration: TimeSpan.FromSeconds(64),
-                position: TimeSpan.FromSeconds(63.5));
+            scheduler.Schedule(duration: TimeSpan.FromSeconds(64));
             Assert.True(scheduler.Advance(TimeSpan.FromMilliseconds(500), isPlaying: true));
 
-            scheduler.Schedule(
-                duration: TimeSpan.FromSeconds(64),
-                position: TimeSpan.FromSeconds(63.4));
+            scheduler.Schedule(duration: TimeSpan.FromSeconds(64));
+
+            Assert.False(scheduler.Advance(TimeSpan.FromMilliseconds(499), isPlaying: true));
+            Assert.True(scheduler.Advance(TimeSpan.FromMilliseconds(1), isPlaying: true));
+        }
+
+        [Fact]
+        public void Scheduler_UsesDecoderTailForCachedMenuSong()
+        {
+            SongLoopScheduler scheduler = new();
+
+            scheduler.Schedule(duration: TimeSpan.FromSeconds(60));
 
             Assert.False(scheduler.Advance(TimeSpan.FromMilliseconds(499), isPlaying: true));
             Assert.True(scheduler.Advance(TimeSpan.FromMilliseconds(1), isPlaying: true));

--- a/CutTheRopeDX/Framework/Media/MonoGameSongCompletionWorkaround.cs
+++ b/CutTheRopeDX/Framework/Media/MonoGameSongCompletionWorkaround.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Reflection;
+
+using Microsoft.Xna.Framework.Media;
+
+namespace CutTheRopeDX.Framework.Media
+{
+    /// <summary>
+    /// Tracks the decoded song tail that MonoGame has queued but not played yet.
+    /// </summary>
+    internal sealed class SongLoopScheduler
+    {
+        /// <summary>
+        /// Starts waiting for the unplayed portion of a decoded song.
+        /// </summary>
+        public void Schedule(TimeSpan duration, TimeSpan position)
+        {
+            if (!hasTailEstimate)
+            {
+                tailEstimate = duration > position ? duration - position : TimeSpan.Zero;
+                hasTailEstimate = true;
+            }
+
+            remaining = tailEstimate;
+            scheduled = true;
+        }
+
+        /// <summary>
+        /// Advances the wait while playback is active.
+        /// </summary>
+        /// <returns><see langword="true"/> once the queued tail has had time to play.</returns>
+        public bool Advance(TimeSpan elapsed, bool isPlaying)
+        {
+            if (!scheduled || !isPlaying)
+            {
+                return false;
+            }
+
+            remaining -= elapsed;
+            if (remaining > TimeSpan.Zero)
+            {
+                return false;
+            }
+
+            scheduled = false;
+            return true;
+        }
+
+        /// <summary>
+        /// Cancels a pending loop restart.
+        /// </summary>
+        public void Cancel()
+        {
+            scheduled = false;
+            remaining = TimeSpan.Zero;
+            tailEstimate = TimeSpan.Zero;
+            hasTailEstimate = false;
+        }
+
+        private TimeSpan remaining;
+        private TimeSpan tailEstimate;
+        private bool scheduled;
+        private bool hasTailEstimate;
+    }
+
+    /// <summary>
+    /// Replaces MonoGame 3.8.5's native Song completion callback so MediaPlayer
+    /// does not flush the final queued audio buffers before they play.
+    /// </summary>
+    /// <remarks>
+    /// This should be removed once MonoGame resolves the issue.
+    /// </remarks>
+    internal static class MonoGameSongCompletionWorkaround
+    {
+        /// <summary>
+        /// Replaces the completion handler installed by <see cref="MediaPlayer"/>.
+        /// Returns false when MonoGame's internal implementation no longer matches,
+        /// allowing callers to retain its default behavior.
+        /// </summary>
+        public static bool TryInstall(Song song, EventHandler replacement)
+        {
+            ArgumentNullException.ThrowIfNull(song);
+            ArgumentNullException.ThrowIfNull(replacement);
+
+            FieldInfo completionField = typeof(Song).GetField(
+                "DonePlaying",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            if (completionField?.FieldType == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                Delegate handler = Delegate.CreateDelegate(
+                    completionField.FieldType,
+                    replacement.Target,
+                    replacement.Method);
+                completionField.SetValue(song, handler);
+                return true;
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+            catch (FieldAccessException)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/CutTheRopeDX/Framework/Media/MonoGameSongCompletionWorkaround.cs
+++ b/CutTheRopeDX/Framework/Media/MonoGameSongCompletionWorkaround.cs
@@ -10,18 +10,18 @@ namespace CutTheRopeDX.Framework.Media
     /// </summary>
     internal sealed class SongLoopScheduler
     {
-        /// <summary>
-        /// Starts waiting for the unplayed portion of a decoded song.
-        /// </summary>
-        public void Schedule(TimeSpan duration, TimeSpan position)
-        {
-            if (!hasTailEstimate)
-            {
-                tailEstimate = duration > position ? duration - position : TimeSpan.Zero;
-                hasTailEstimate = true;
-            }
+        private static readonly TimeSpan DecoderBufferDuration = TimeSpan.FromMilliseconds(250);
 
-            remaining = tailEstimate;
+        /// <summary>
+        /// Starts waiting for the two decoded buffers MonoGame leaves queued at EOF.
+        /// </summary>
+        public void Schedule(TimeSpan duration)
+        {
+            long partialBufferTicks = duration.Ticks % DecoderBufferDuration.Ticks;
+            remaining = DecoderBufferDuration +
+                (partialBufferTicks == 0
+                    ? DecoderBufferDuration
+                    : TimeSpan.FromTicks(partialBufferTicks));
             scheduled = true;
         }
 
@@ -53,14 +53,10 @@ namespace CutTheRopeDX.Framework.Media
         {
             scheduled = false;
             remaining = TimeSpan.Zero;
-            tailEstimate = TimeSpan.Zero;
-            hasTailEstimate = false;
         }
 
         private TimeSpan remaining;
-        private TimeSpan tailEstimate;
         private bool scheduled;
-        private bool hasTailEstimate;
     }
 
     /// <summary>

--- a/CutTheRopeDX/Framework/Media/SoundMgr.cs
+++ b/CutTheRopeDX/Framework/Media/SoundMgr.cs
@@ -206,7 +206,7 @@ namespace CutTheRopeDX.Framework.Media
                 return;
             }
 
-            songLoopScheduler.Schedule(activeSong.Duration, XnaMediaPlayer.PlayPosition);
+            songLoopScheduler.Schedule(activeSong.Duration);
         }
 
         /// <summary>

--- a/CutTheRopeDX/Framework/Media/SoundMgr.cs
+++ b/CutTheRopeDX/Framework/Media/SoundMgr.cs
@@ -150,14 +150,63 @@ namespace CutTheRopeDX.Framework.Media
             StopMusic();
             string musicPath = ContentPaths.GetMusicPath(CTRResourceMgr.XNA_ResName(localizedName));
             XnaSong song = _contentManager.Load<XnaSong>(musicPath);
+            activeSong = song;
             XnaMediaPlayer.IsRepeating = true;
+            try
+            {
+                XnaMediaPlayer.Play(song);
+                usesSongCompletionWorkaround =
+                    MonoGameSongCompletionWorkaround.TryInstall(song, OnSongDecoderFinished);
+            }
+            catch (Exception)
+            {
+                activeSong = null;
+                usesSongCompletionWorkaround = false;
+            }
+        }
+
+        /// <summary>
+        /// Advances a pending music-loop restart after MonoGame's queued decoded tail
+        /// has had time to reach the audio device.
+        /// </summary>
+        /// <param name="elapsed">Elapsed game time since the previous update.</param>
+        public static void Update(TimeSpan elapsed)
+        {
+            if (!usesSongCompletionWorkaround ||
+                !songLoopScheduler.Advance(
+                    elapsed,
+                    XnaMediaPlayer.State == XnaMediaState.Playing))
+            {
+                return;
+            }
+
+            XnaSong song = activeSong;
+            if (song == null)
+            {
+                return;
+            }
+
             try
             {
                 XnaMediaPlayer.Play(song);
             }
             catch (Exception)
             {
+                StopMusic();
             }
+        }
+
+        /// <summary>
+        /// Records how much audio remains queued when MonoGame reports decoder EOF.
+        /// </summary>
+        private static void OnSongDecoderFinished(object sender, EventArgs args)
+        {
+            if (!usesSongCompletionWorkaround || !ReferenceEquals(sender, activeSong))
+            {
+                return;
+            }
+
+            songLoopScheduler.Schedule(activeSong.Duration, XnaMediaPlayer.PlayPosition);
         }
 
         /// <summary>
@@ -246,6 +295,9 @@ namespace CutTheRopeDX.Framework.Media
         /// </summary>
         public static void StopMusic()
         {
+            usesSongCompletionWorkaround = false;
+            activeSong = null;
+            songLoopScheduler.Cancel();
             try
             {
                 XnaMediaPlayer.Stop();
@@ -430,6 +482,21 @@ namespace CutTheRopeDX.Framework.Media
         /// Content manager used to load sound effects and songs.
         /// </summary>
         private static ContentManager _contentManager;
+
+        /// <summary>
+        /// Song currently owned by the media player.
+        /// </summary>
+        private static XnaSong activeSong;
+
+        /// <summary>
+        /// Waits for the native voice's queued tail before restarting <see cref="activeSong"/>.
+        /// </summary>
+        private static readonly SongLoopScheduler songLoopScheduler = new();
+
+        /// <summary>
+        /// Whether MonoGame's premature completion callback was replaced successfully.
+        /// </summary>
+        private static bool usesSongCompletionWorkaround;
 
         /// <summary>
         /// Cache of loaded sound effects keyed by localized resource name.

--- a/CutTheRopeDX/Game1.cs
+++ b/CutTheRopeDX/Game1.cs
@@ -235,6 +235,7 @@ namespace CutTheRopeDX
         /// <inheritdoc />
         protected override void Update(GameTime gameTime)
         {
+            SoundMgr.Update(gameTime.ElapsedGameTime);
             KeyboardState keyboardState = Keyboard.GetState();
             HandleFullscreenToggle(keyboardState);
             elapsedTime += gameTime.ElapsedGameTime;


### PR DESCRIPTION
## Description

MonoGame v3.8.5 decodes songs in 250 ms chunks and reports EOF while roughly two chunks remain queued. `MediaPlayer` then restarts the song and flushes those buffers, cutting off up to approximately 500 ms of audio.

This PR adds a temporary workaround that allows the queued audio to finish playing before restarting the song, preventing music from being cut off at the loop boundary.