### PR TITLE
chore: remove CI skip from asset fetch

### DIFF
--- a/content/Builder/Commands/AssetCommands.cs
+++ b/content/Builder/Commands/AssetCommands.cs
@@ -74,11 +74,6 @@ namespace CutTheRopeDX.Content.Commands
 
         private static async Task<int> RunFetchAsync(string contentDirectory)
         {
-            if (Environment.GetEnvironmentVariable("CI") == "true")
-            {
-                return 0;
-            }
-
             AssetManifest manifest = ReadRequiredManifest(contentDirectory);
             AssetStore store = new(contentDirectory, manifest);
             IReadOnlyList<string> missing = store.FindMissing();


### PR DESCRIPTION
## Description

Follow-up to #277, fix assets being skipped in automated workflow.