### PR TITLE
fix: don't truncate stashed dim time on pause to integer

### DIFF
--- a/CutTheRopeDX/GameMain/GameController.cs
+++ b/CutTheRopeDX/GameMain/GameController.cs
@@ -475,7 +475,7 @@ namespace CutTheRopeDX.GameMain
             {
                 case var id when id == GameControllerButtonId.Continue:
                     ((GameScene)view.GetChild(0)).dimTime = tmpDimTime;
-                    tmpDimTime = 0;
+                    tmpDimTime = 0f;
                     SetPaused(false);
                     CTRRootController.LogEvent("IM_CONTINUE_PRESSED");
                     return;
@@ -530,7 +530,7 @@ namespace CutTheRopeDX.GameMain
                         {
                             return;
                         }
-                        tmpDimTime = (int)gameScene4.dimTime;
+                        tmpDimTime = gameScene4.dimTime;
                         gameScene4.dimTime = 0f;
                         SetPaused(true);
                         CTRRootController.LogEvent("IG_MENU_PRESSED");
@@ -963,8 +963,13 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Maps tracked touch slots to platform touch IDs.</summary>
         private readonly int[] touchAddressMap = new int[5];
 
-        /// <summary>Temporary dim-time value saved while the pause menu is open.</summary>
-        private int tmpDimTime;
+        /// <summary>
+        /// Temporary dim-time value saved while the pause menu is open. Must stay floating point:
+        /// <c>dimTime</c> only ever holds 0..0.15, so truncating it to an integer would always
+        /// restore 0 and strand the restart state machine at <c>restartState == 0</c>, which
+        /// silently disables every win/loss path.
+        /// </summary>
+        private float tmpDimTime;
 
         /// <summary>Whether the result box close flow has already persisted score and achievement state.</summary>
         private bool boxCloseHandled;


### PR DESCRIPTION
## Description

Previously, user can restart and pause within 0.15s (about 9 frames) of the restart's white flash, and this causes softlock where the level does not trigger game win or loss.

This PR fixes that by remove the integer cast, so the 0.15s is properly used instead of trimming to just 0.