### PR TITLE
fix: reshape the canvas when the window is first sized

### DIFF
--- a/CutTheRopeDX/Desktop/ScreenSizeManager.cs
+++ b/CutTheRopeDX/Desktop/ScreenSizeManager.cs
@@ -148,6 +148,8 @@ namespace CutTheRopeDX.Desktop
             }
             ApplyWindowSize(WindowWidth);
             CenterWindow();
+            // Size the canvas to the window that was just established.
+            Application.SharedCanvas().Reshape();
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

Fix an issue where the game starts with 2560x1440 resolution in windowed mode.