### PR TITLE
feat: Make final score no longer be rounded by 10

### DIFF
--- a/CutTheRopeDX/GameMain/BoxOpenClose.cs
+++ b/CutTheRopeDX/GameMain/BoxOpenClose.cs
@@ -725,7 +725,7 @@ namespace CutTheRopeDX.GameMain
         public int raState;
 
         /// <summary>Time bonus score used by the result countdown.</summary>
-        public int timeBonus;
+        public float timeBonus;
 
         /// <summary>Star bonus score used by the result countdown.</summary>
         public int starBonus;

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -430,9 +430,7 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         public void CalculateScore()
         {
-            timeBonus = (int)MAX(0f, 30f - time) * 100;
-            timeBonus /= 10;
-            timeBonus *= 10;
+            timeBonus = MAX(0f, 30f - time) * 100f;
             starBonus = 1000 * starsCollected;
             score = (int)Ceil(timeBonus + starBonus);
         }

--- a/CutTheRopeDX/GameMain/GameScene.cs
+++ b/CutTheRopeDX/GameMain/GameScene.cs
@@ -1042,7 +1042,7 @@ namespace CutTheRopeDX.GameMain
         /// <summary>
         /// The score bonus awarded from remaining time.
         /// </summary>
-        public int timeBonus;
+        public float timeBonus;
 
         /// <summary>
         /// The current total score.


### PR DESCRIPTION
## Description

This PR makes the time bonus more precise, so scores are no longer limited to multiples of 10. The time bonus now keeps its fractional value until the final score is rounded.

Closes #173.

Supersedes #263.