### PR TITLE
refactor: Refactor level results into a single immutable source of truth

### DIFF
--- a/CutTheRopeDX.Tests/BoxOpenCloseLevelResultTests.cs
+++ b/CutTheRopeDX.Tests/BoxOpenCloseLevelResultTests.cs
@@ -1,0 +1,78 @@
+using CutTheRopeDX.Framework.Visual;
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class BoxOpenCloseLevelResultTests
+    {
+        private static readonly LevelResult FractionalResult = new(
+            ElapsedTime: 29.875f,
+            StarsCollected: 2,
+            StarBonus: 2000,
+            TimeBonus: 12.5f,
+            FinalScore: 2013);
+
+        private static BoxOpenClose CreateBox()
+        {
+            _ = HeadlessGame.Boot();
+            return new BoxOpenClose().InitWithButtonDelegate(new NoOpButtonDelegate());
+        }
+
+        private static void AdvanceToTimeCountdown(BoxOpenClose box)
+        {
+            for (int frame = 0; frame < 100 && box.raState != BoxOpenClose.RESULT_STATE_COUNTDOWN_TIME_BONUS; frame++)
+            {
+                box.Update(0.1f);
+            }
+
+            Assert.Equal(BoxOpenClose.RESULT_STATE_COUNTDOWN_TIME_BONUS, box.raState);
+        }
+
+        [Fact]
+        public void InitialAnimationStateComesFromLevelResult()
+        {
+            BoxOpenClose box = CreateBox();
+
+            box.LevelWon(FractionalResult);
+            box.Update(0f);
+
+            Assert.Equal(FractionalResult, box.ActiveResult);
+            Assert.Equal(FractionalResult.StarBonus, box.cstarBonus);
+            Assert.Equal(FractionalResult.ElapsedTime, box.ctime);
+        }
+
+        [Fact]
+        public void TimeCountdownUsesElapsedTimeAndPreciseTimeBonus()
+        {
+            BoxOpenClose box = CreateBox();
+            box.LevelWon(FractionalResult);
+            AdvanceToTimeCountdown(box);
+
+            box.Update(0.5f);
+
+            Assert.Equal(FractionalResult.ElapsedTime * 0.5f, box.ctime);
+            Assert.Equal(2006, box.cscore);
+        }
+
+        [Fact]
+        public void CompletedCountdownUsesExactFinalScore()
+        {
+            BoxOpenClose box = CreateBox();
+            box.LevelWon(FractionalResult);
+            AdvanceToTimeCountdown(box);
+
+            box.Update(1f);
+
+            Assert.Equal(FractionalResult.FinalScore, box.cscore);
+        }
+
+        private sealed class NoOpButtonDelegate : IButtonDelegation
+        {
+            public void OnButtonPressed(ButtonId buttonId)
+            {
+            }
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/GameControllerLevelResultTests.cs
+++ b/CutTheRopeDX.Tests/GameControllerLevelResultTests.cs
@@ -1,0 +1,138 @@
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.Framework.Visual;
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class GameControllerLevelResultTests
+    {
+        private const int Pack = 1;
+        private const int Level = 4;
+
+        private static (GameController Controller, GameScene Scene, BoxOpenClose Box, CTRRootController Root) Load()
+        {
+            _ = HeadlessGame.Boot();
+            GameController controller = HeadlessGame.LoadLevelWithController(Pack, Level);
+            View view = controller.GetView(0);
+            return (
+                controller,
+                (GameScene)view.GetChild(0),
+                (BoxOpenClose)view.GetChild(4),
+                (CTRRootController)Application.SharedRootController());
+        }
+
+        private static void SetConflictingSceneResult(GameScene scene)
+        {
+            scene.time = 1f;
+            scene.starsCollected = 3;
+        }
+
+        [Fact]
+        public void SuppliedResultDrivesPresentationAnimationAndPersistence()
+        {
+            (GameController controller, GameScene scene, BoxOpenClose box, CTRRootController root) = Load();
+            int saveBox = root.GetBox();
+            int originalScore = CTRPreferences.GetScoreForPackLevel(saveBox, Pack, Level);
+            int originalStars = CTRPreferences.GetStarsForPackLevel(saveBox, Pack, Level);
+            LevelResult result = LevelResultCalculator.Calculate(elapsedTime: 20f, starsCollected: 2);
+
+            try
+            {
+                CTRPreferences.SetScoreForPackLevel(saveBox, 100, Pack, Level);
+                CTRPreferences.SetStarsForPackLevel(saveBox, 1, Pack, Level);
+                SetConflictingSceneResult(scene);
+
+                controller.LevelWon(result);
+
+                Assert.Equal(13, ((Image)box.result.GetChildWithName("star1")).quadToDraw);
+                Assert.Equal(13, ((Image)box.result.GetChildWithName("star2")).quadToDraw);
+                Assert.Equal(14, ((Image)box.result.GetChildWithName("star3")).quadToDraw);
+                Assert.Equal(Application.GetString("LEVEL_CLEARED3"), ((Text)box.result.GetChildWithName("passText")).GetString());
+                Assert.Equal(result, box.ActiveResult);
+                Assert.True(box.shouldShowImprovedResult);
+                Assert.False(box.shouldShowConfetti);
+                Assert.Equal(result.FinalScore, CTRPreferences.GetScoreForPackLevel(saveBox, Pack, Level));
+                Assert.Equal(result.StarsCollected, CTRPreferences.GetStarsForPackLevel(saveBox, Pack, Level));
+            }
+            finally
+            {
+                CTRPreferences.SetScoreForPackLevel(saveBox, originalScore, Pack, Level);
+                CTRPreferences.SetStarsForPackLevel(saveBox, originalStars, Pack, Level);
+            }
+        }
+
+        [Fact]
+        public void SuppliedResultControlsImprovementComparisons()
+        {
+            (GameController controller, GameScene scene, BoxOpenClose box, CTRRootController root) = Load();
+            int saveBox = root.GetBox();
+            int originalScore = CTRPreferences.GetScoreForPackLevel(saveBox, Pack, Level);
+            int originalStars = CTRPreferences.GetStarsForPackLevel(saveBox, Pack, Level);
+            LevelResult result = LevelResultCalculator.Calculate(elapsedTime: 20f, starsCollected: 2);
+
+            try
+            {
+                CTRPreferences.SetScoreForPackLevel(saveBox, 4000, Pack, Level);
+                CTRPreferences.SetStarsForPackLevel(saveBox, 3, Pack, Level);
+                SetConflictingSceneResult(scene);
+
+                controller.LevelWon(result);
+
+                Assert.False(box.shouldShowImprovedResult);
+                Assert.Equal(4000, CTRPreferences.GetScoreForPackLevel(saveBox, Pack, Level));
+                Assert.Equal(3, CTRPreferences.GetStarsForPackLevel(saveBox, Pack, Level));
+            }
+            finally
+            {
+                CTRPreferences.SetScoreForPackLevel(saveBox, originalScore, Pack, Level);
+                CTRPreferences.SetStarsForPackLevel(saveBox, originalStars, Pack, Level);
+            }
+        }
+
+        [Fact]
+        public void CustomLevelDisplaysResultWithoutPersistingIt()
+        {
+            (GameController controller, GameScene scene, BoxOpenClose box, CTRRootController root) = Load();
+            int saveBox = root.GetBox();
+            int originalScore = CTRPreferences.GetScoreForPackLevel(saveBox, Pack, Level);
+            int originalStars = CTRPreferences.GetStarsForPackLevel(saveBox, Pack, Level);
+            LevelResult result = LevelResultCalculator.Calculate(elapsedTime: 12.5f, starsCollected: 3);
+
+            try
+            {
+                CTRPreferences.SetScoreForPackLevel(saveBox, 100, Pack, Level);
+                CTRPreferences.SetStarsForPackLevel(saveBox, 1, Pack, Level);
+                SetConflictingSceneResult(scene);
+                CustomLevelSession.Activate("controller-result-test.xml");
+
+                controller.LevelWon(result);
+
+                Assert.Equal(result, box.ActiveResult);
+                Assert.Equal(Application.GetString("LEVEL_CLEARED4"), ((Text)box.result.GetChildWithName("passText")).GetString());
+                Assert.True(box.shouldShowConfetti);
+                Assert.Equal(100, CTRPreferences.GetScoreForPackLevel(saveBox, Pack, Level));
+                Assert.Equal(1, CTRPreferences.GetStarsForPackLevel(saveBox, Pack, Level));
+            }
+            finally
+            {
+                CustomLevelSession.Clear();
+                CTRPreferences.SetScoreForPackLevel(saveBox, originalScore, Pack, Level);
+                CTRPreferences.SetStarsForPackLevel(saveBox, originalStars, Pack, Level);
+            }
+        }
+
+        [Fact]
+        public void RpcPayloadComesFromSuppliedResult()
+        {
+            LevelResult result = LevelResultCalculator.Calculate(elapsedTime: 29.875f, starsCollected: 2);
+
+            LevelResultRpcPayload payload = LevelResultRpcPayload.From(result);
+
+            Assert.Equal(2, payload.Stars);
+            Assert.Equal(2013, payload.Score);
+            Assert.Equal(29, payload.ElapsedSeconds);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/GameSceneLevelResultTests.cs
+++ b/CutTheRopeDX.Tests/GameSceneLevelResultTests.cs
@@ -1,0 +1,69 @@
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class GameSceneLevelResultTests
+    {
+        private static (GameScene Scene, RecordingSceneDelegate Delegate) Load()
+        {
+            _ = HeadlessGame.Boot();
+            GameScene scene = HeadlessGame.LoadLevel(pack: 1, level: 4);
+            RecordingSceneDelegate recorder = new();
+            scene.gameSceneDelegate = recorder;
+            return (scene, recorder);
+        }
+
+        [Fact]
+        public void WinCallbackReceivesResultCapturedWhenGameWonBegins()
+        {
+            (GameScene scene, RecordingSceneDelegate recorder) = Load();
+            scene.time = 29.875f;
+            scene.starsCollected = 2;
+
+            scene.GameWon();
+            scene.time = 100f;
+            scene.starsCollected = 0;
+            HeadlessGame.StepFrames(scene, 150);
+
+            Assert.Equal(1, recorder.WonCount);
+            LevelResult result = Assert.IsType<LevelResult>(recorder.LastResult);
+            Assert.Equal(29.875f, result.ElapsedTime);
+            Assert.Equal(2, result.StarsCollected);
+            Assert.Equal(12.5f, result.TimeBonus);
+            Assert.Equal(2000, result.StarBonus);
+            Assert.Equal(2013, result.FinalScore);
+        }
+
+        [Fact]
+        public void RepeatedGameWonDeliversOnlyTheFirstResult()
+        {
+            (GameScene scene, RecordingSceneDelegate recorder) = Load();
+            scene.time = 29.875f;
+            scene.starsCollected = 2;
+
+            scene.GameWon();
+            scene.time = 5f;
+            scene.starsCollected = 3;
+            scene.GameWon();
+            HeadlessGame.StepFrames(scene, 150);
+
+            Assert.Equal(1, recorder.WonCount);
+            Assert.Equal(2013, recorder.LastResult?.FinalScore);
+        }
+
+        [Fact]
+        public void RestartClearsResultAwaitingDelayedDelivery()
+        {
+            (GameScene scene, RecordingSceneDelegate recorder) = Load();
+            scene.GameWon();
+
+            scene.Restart();
+            HeadlessGame.StepFrames(scene, 150);
+
+            Assert.Equal(0, recorder.WonCount);
+            Assert.Null(recorder.LastResult);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/LevelResultTests.cs
+++ b/CutTheRopeDX.Tests/LevelResultTests.cs
@@ -1,0 +1,30 @@
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class LevelResultTests
+    {
+        [Theory]
+        [InlineData(30f, 0, 0f, 0, 0)]
+        [InlineData(40f, 3, 0f, 3000, 3000)]
+        [InlineData(12.5f, 2, 1750f, 2000, 3750)]
+        [InlineData(29.875f, 2, 12.5f, 2000, 2013)]
+        public void CalculatePreservesPreciseTimeBonusUntilFinalCeiling(
+            float elapsedTime,
+            int stars,
+            float expectedTimeBonus,
+            int expectedStarBonus,
+            int expectedFinalScore)
+        {
+            LevelResult result = LevelResultCalculator.Calculate(elapsedTime, stars);
+
+            Assert.Equal(elapsedTime, result.ElapsedTime);
+            Assert.Equal(stars, result.StarsCollected);
+            Assert.Equal(expectedTimeBonus, result.TimeBonus);
+            Assert.Equal(expectedStarBonus, result.StarBonus);
+            Assert.Equal(expectedFinalScore, result.FinalScore);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/PauseDuringRestartTests.cs
+++ b/CutTheRopeDX.Tests/PauseDuringRestartTests.cs
@@ -1,3 +1,5 @@
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.Framework.Visual;
 using CutTheRopeDX.GameMain;
 
 using Xunit;
@@ -11,6 +13,65 @@ namespace CutTheRopeDX.Tests
             _ = HeadlessGame.Boot();
             GameController controller = HeadlessGame.LoadLevelWithController(pack: 1, level: 4);
             return (controller, (GameScene)controller.GetView(0).GetChild(0));
+        }
+
+        private static Text PauseMapNameLabel(GameController controller)
+        {
+            return (Text)controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_PAUSE_MENU).GetChildWithName("mapNameLabel");
+        }
+
+        [Fact]
+        public void PausingNamedCustomLevelShowsResolvedLevelName()
+        {
+            (GameController controller, GameScene scene) = Load();
+            scene.levelName = "My Custom Level";
+
+            try
+            {
+                CustomLevelSession.Activate("pause-name-test.xml");
+
+                controller.SetPaused(true);
+
+                Assert.Equal("My Custom Level", PauseMapNameLabel(controller).GetString());
+            }
+            finally
+            {
+                CustomLevelSession.Clear();
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("   ")]
+        public void PausingUnnamedCustomLevelShowsBlankLabel(string levelName)
+        {
+            (GameController controller, GameScene scene) = Load();
+            scene.levelName = levelName;
+
+            try
+            {
+                CustomLevelSession.Activate("pause-name-test.xml");
+
+                controller.SetPaused(true);
+
+                Assert.Equal(string.Empty, PauseMapNameLabel(controller).GetString());
+            }
+            finally
+            {
+                CustomLevelSession.Clear();
+            }
+        }
+
+        [Fact]
+        public void PausingNormalLevelShowsBestScore()
+        {
+            (GameController controller, _) = Load();
+            CTRRootController root = (CTRRootController)Application.SharedRootController();
+            int score = CTRPreferences.GetScoreForPackLevel(root.GetBox(), root.GetPack(), root.GetLevel());
+
+            controller.SetPaused(true);
+
+            Assert.Equal(Application.GetString("BEST_SCORE") + ": " + score, PauseMapNameLabel(controller).GetString());
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/RecordingSceneDelegate.cs
+++ b/CutTheRopeDX.Tests/RecordingSceneDelegate.cs
@@ -11,10 +11,14 @@ namespace CutTheRopeDX.Tests
         /// <summary>Number of times the level was lost.</summary>
         public int LostCount { get; private set; }
 
+        /// <summary>The most recently delivered completed-level result.</summary>
+        public LevelResult? LastResult { get; private set; }
+
         /// <inheritdoc />
-        public void GameWon()
+        public void GameWon(LevelResult result)
         {
             WonCount++;
+            LastResult = result;
         }
 
         /// <inheritdoc />

--- a/CutTheRopeDX/GameMain/BoxOpenClose.cs
+++ b/CutTheRopeDX/GameMain/BoxOpenClose.cs
@@ -28,8 +28,8 @@ namespace CutTheRopeDX.GameMain
                 case -1:
                     {
                         cscore = 0;
-                        ctime = time;
-                        cstarBonus = starBonus;
+                        ctime = ActiveResult.ElapsedTime;
+                        cstarBonus = ActiveResult.StarBonus;
                         ((Text)result.GetChildWithName("scoreValue")).SetString(cscore.ToString(CultureInfo.InvariantCulture));
                         Text text27 = (Text)result.GetChildWithName("dataTitle");
                         Image.SetElementPositionWithQuadOffset(text27, Resources.Img.MenuResults, 5);
@@ -66,8 +66,8 @@ namespace CutTheRopeDX.GameMain
                     }
                 case 2:
                     {
-                        cstarBonus = (int)(starBonus * raDelay);
-                        cscore = (int)((1f - raDelay) * starBonus);
+                        cstarBonus = (int)(ActiveResult.StarBonus * raDelay);
+                        cscore = (int)((1f - raDelay) * ActiveResult.StarBonus);
                         ((Text)result.GetChildWithName("dataValue")).SetString(cstarBonus.ToString(CultureInfo.InvariantCulture));
                         Text text29 = (Text)result.GetChildWithName("scoreValue");
                         text29.SetEnabled(true);
@@ -89,8 +89,8 @@ namespace CutTheRopeDX.GameMain
                         {
                             raState = 4;
                             raDelay = 0.2f;
-                            int minutes = (int)MathF.Floor(Round(time) / 60f);
-                            int seconds = (int)(Round(time) - (minutes * 60f));
+                            int minutes = (int)MathF.Floor(Round(ActiveResult.ElapsedTime) / 60f);
+                            int seconds = (int)(Round(ActiveResult.ElapsedTime) - (minutes * 60f));
                             ((Text)result.GetChildWithName("dataTitle")).SetString(Application.GetString("TIME"));
                             ((Text)result.GetChildWithName("dataValue")).SetString(minutes.ToString(CultureInfo.InvariantCulture) + ":" + seconds.ToString("D2", CultureInfo.InvariantCulture));
                             return;
@@ -112,14 +112,16 @@ namespace CutTheRopeDX.GameMain
                     }
                 case 5:
                     {
-                        ctime = time * raDelay;
-                        cscore = (int)(starBonus + ((1f - raDelay) * timeBonus));
+                        ctime = ActiveResult.ElapsedTime * raDelay;
+                        cscore = (int)(ActiveResult.StarBonus + ((1f - raDelay) * ActiveResult.TimeBonus));
                         int minutes = (int)MathF.Floor(Round(ctime) / 60);
                         int seconds = (int)(Round(ctime) - (minutes * 60));
                         ((Text)result.GetChildWithName("dataValue")).SetString(minutes.ToString(CultureInfo.InvariantCulture) + ":" + seconds.ToString("D2", CultureInfo.InvariantCulture));
                         ((Text)result.GetChildWithName("scoreValue")).SetString(cscore.ToString(CultureInfo.InvariantCulture));
                         if (flag)
                         {
+                            cscore = ActiveResult.FinalScore;
+                            ((Text)result.GetChildWithName("scoreValue")).SetString(cscore.ToString(CultureInfo.InvariantCulture));
                             raState = 6;
                             raDelay = 0.2f;
                             return;
@@ -335,8 +337,10 @@ namespace CutTheRopeDX.GameMain
         /// <summary>
         /// Starts the closing transition for a won level and prepares the result panel countdown.
         /// </summary>
-        public void LevelWon()
+        /// <param name="levelResult">The immutable result that drives the presentation.</param>
+        public void LevelWon(LevelResult levelResult)
         {
+            ActiveResult = levelResult;
             boxAnim = 2;
             raState = -1;
             RemoveOpenCloseAnims();
@@ -724,17 +728,8 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Current result panel countdown state.</summary>
         public int raState;
 
-        /// <summary>Time bonus score used by the result countdown.</summary>
-        public float timeBonus;
-
-        /// <summary>Star bonus score used by the result countdown.</summary>
-        public int starBonus;
-
-        /// <summary>Base score before result countdown bonuses are applied.</summary>
-        public int score;
-
-        /// <summary>Level completion time used by the result countdown.</summary>
-        public float time;
+        /// <summary>The immutable result driving the active result presentation.</summary>
+        internal LevelResult ActiveResult { get; private set; }
 
         /// <summary>Displayed countdown time value.</summary>
         public float ctime;

--- a/CutTheRopeDX/GameMain/GameController.cs
+++ b/CutTheRopeDX/GameMain/GameController.cs
@@ -657,6 +657,12 @@ namespace CutTheRopeDX.GameMain
                 mapNameLabel.SetString("");
                 return;
             }
+            if (CustomLevelSession.IsActive)
+            {
+                GameScene gameScene = (GameScene)view.GetChild(0);
+                mapNameLabel.SetString(gameScene.ResolveLevelDisplayName() ?? string.Empty);
+                return;
+            }
             int scoreForPackLevel = CTRPreferences.GetScoreForPackLevel(cTRRootController.GetBox(), cTRRootController.GetPack(), cTRRootController.GetLevel());
             mapNameLabel.SetString(Application.GetString("BEST_SCORE") + ": " + scoreForPackLevel);
         }

--- a/CutTheRopeDX/GameMain/GameController.cs
+++ b/CutTheRopeDX/GameMain/GameController.cs
@@ -418,7 +418,8 @@ namespace CutTheRopeDX.GameMain
         /// <summary>
         /// Handles the game-scene win callback.
         /// </summary>
-        public void GameWon()
+        /// <param name="result">The completed level's immutable result.</param>
+        public void GameWon(LevelResult result)
         {
             PostFlurryLevelEvent("LEVEL_WON");
             LevelWon();

--- a/CutTheRopeDX/GameMain/GameController.cs
+++ b/CutTheRopeDX/GameMain/GameController.cs
@@ -321,7 +321,8 @@ namespace CutTheRopeDX.GameMain
         /// <summary>
         /// Updates level result UI, persists improved score data, and starts the level-won result flow.
         /// </summary>
-        public void LevelWon()
+        /// <param name="result">The completed level's immutable result.</param>
+        public void LevelWon(LevelResult result)
         {
             boxCloseHandled = false;
             _ = Application.SharedPreferences();
@@ -349,10 +350,6 @@ namespace CutTheRopeDX.GameMain
                 _ => "LEVEL_CLEARED1"
             };
             ((Text)boxOpenClose.result.GetChildWithName("passText")).SetString(Application.GetString(clearText));
-            boxOpenClose.time = gameScene.time;
-            boxOpenClose.starBonus = gameScene.starBonus;
-            boxOpenClose.timeBonus = gameScene.timeBonus;
-            boxOpenClose.score = gameScene.score;
             isGamePaused = true;
             gameScene.touchable = false;
             view.GetChild(2).touchable = false;
@@ -395,7 +392,7 @@ namespace CutTheRopeDX.GameMain
                     gameScene,
                     0.5f);
             };
-            boxOpenClose.LevelWon();
+            boxOpenClose.LevelWon(result);
 
             // Update RPC to show win state with stars and score
             CTRRootController ctrRoot = (CTRRootController)Application.SharedRootController();
@@ -422,7 +419,7 @@ namespace CutTheRopeDX.GameMain
         public void GameWon(LevelResult result)
         {
             PostFlurryLevelEvent("LEVEL_WON");
-            LevelWon();
+            LevelWon(result);
         }
 
         /// <summary>

--- a/CutTheRopeDX/GameMain/GameController.cs
+++ b/CutTheRopeDX/GameMain/GameController.cs
@@ -339,10 +339,10 @@ namespace CutTheRopeDX.GameMain
             Image image = (Image)boxOpenClose.result.GetChildWithName("star1");
             Image image2 = (Image)boxOpenClose.result.GetChildWithName("star2");
             Image image3 = (Image)boxOpenClose.result.GetChildWithName("star3");
-            image.SetDrawQuad(gameScene.starsCollected > 0 ? 13 : 14);
-            image2.SetDrawQuad(gameScene.starsCollected > 1 ? 13 : 14);
-            image3.SetDrawQuad(gameScene.starsCollected > 2 ? 13 : 14);
-            string clearText = gameScene.starsCollected switch
+            image.SetDrawQuad(result.StarsCollected > 0 ? 13 : 14);
+            image2.SetDrawQuad(result.StarsCollected > 1 ? 13 : 14);
+            image3.SetDrawQuad(result.StarsCollected > 2 ? 13 : 14);
+            string clearText = result.StarsCollected switch
             {
                 1 => "LEVEL_CLEARED2",
                 2 => "LEVEL_CLEARED3",
@@ -360,23 +360,23 @@ namespace CutTheRopeDX.GameMain
             int scoreForPackLevel = CTRPreferences.GetScoreForPackLevel(box, pack, level);
             int starsForPackLevel = CTRPreferences.GetStarsForPackLevel(box, pack, level);
             boxOpenClose.shouldShowImprovedResult = false;
-            if (LevelProgressPersistence.ShouldPersist(CustomLevelSession.IsActive, gameScene.score, scoreForPackLevel))
+            if (LevelProgressPersistence.ShouldPersist(CustomLevelSession.IsActive, result.FinalScore, scoreForPackLevel))
             {
-                CTRPreferences.SetScoreForPackLevel(box, gameScene.score, pack, level);
+                CTRPreferences.SetScoreForPackLevel(box, result.FinalScore, pack, level);
                 if (scoreForPackLevel > 0)
                 {
                     boxOpenClose.shouldShowImprovedResult = true;
                 }
             }
-            if (LevelProgressPersistence.ShouldPersist(CustomLevelSession.IsActive, gameScene.starsCollected, starsForPackLevel))
+            if (LevelProgressPersistence.ShouldPersist(CustomLevelSession.IsActive, result.StarsCollected, starsForPackLevel))
             {
-                CTRPreferences.SetStarsForPackLevel(box, gameScene.starsCollected, pack, level);
+                CTRPreferences.SetStarsForPackLevel(box, result.StarsCollected, pack, level);
                 if (starsForPackLevel > 0)
                 {
                     boxOpenClose.shouldShowImprovedResult = true;
                 }
             }
-            boxOpenClose.shouldShowConfetti = gameScene.starsCollected == 3;
+            boxOpenClose.shouldShowConfetti = result.StarsCollected == 3;
             boxOpenClose.delegateboxClosed = () =>
             {
                 // Freeze the game scene a bit after the door closing animation finishes
@@ -396,7 +396,8 @@ namespace CutTheRopeDX.GameMain
 
             // Update RPC to show win state with stars and score
             CTRRootController ctrRoot = (CTRRootController)Application.SharedRootController();
-            Game1.RPC?.SetLevelPresence(ctrRoot.GetPack(), ctrRoot.GetLevel(), gameScene.starsCollected, true, gameScene.levelName, gameScene.score, (int)gameScene.time);
+            LevelResultRpcPayload rpcPayload = LevelResultRpcPayload.From(result);
+            Game1.RPC?.SetLevelPresence(ctrRoot.GetPack(), ctrRoot.GetLevel(), rpcPayload.Stars, true, gameScene.levelName, rpcPayload.Score, rpcPayload.ElapsedSeconds);
 
             if (!CustomLevelSession.IsActive)
             {

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -430,11 +430,10 @@ namespace CutTheRopeDX.GameMain
         /// <summary>
         /// Calculates time, star, and total score bonuses for the completed level.
         /// </summary>
-        public void CalculateScore()
+        /// <returns>The immutable result calculated from the scene's current gameplay state.</returns>
+        public LevelResult CalculateScore()
         {
-            timeBonus = MAX(0f, 30f - time) * 100f;
-            starBonus = 1000 * starsCollected;
-            score = (int)Ceil(timeBonus + starBonus);
+            return LevelResultCalculator.Calculate(time, starsCollected);
         }
 
         /// <summary>
@@ -447,6 +446,7 @@ namespace CutTheRopeDX.GameMain
                 return;
             }
             gameplayFlow.MarkWon();
+            pendingLevelResult = CalculateScore();
 
             EndActiveFingerTraces();
             conveyors?.CancelAllDrags();
@@ -501,7 +501,10 @@ namespace CutTheRopeDX.GameMain
             timeline.delegateTimelineDelegate = aniPool;
             _ = aniPool.AddChild(candy);
             dd.CallObjectSelectorParamafterDelay(new DelayedDispatcher.DispatchFunc(Selector_gameWon), null, 2);
-            CalculateScore();
+            LevelResult result = pendingLevelResult.Value;
+            timeBonus = result.TimeBonus;
+            starBonus = result.StarBonus;
+            score = result.FinalScore;
             ReleaseRopesForBody(candies[0].WholeBody);
             ExhaustAllActiveRockets();
             DetachActiveSnails();

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -501,10 +501,6 @@ namespace CutTheRopeDX.GameMain
             timeline.delegateTimelineDelegate = aniPool;
             _ = aniPool.AddChild(candy);
             dd.CallObjectSelectorParamafterDelay(new DelayedDispatcher.DispatchFunc(Selector_gameWon), null, 2);
-            LevelResult result = pendingLevelResult.Value;
-            timeBonus = result.TimeBonus;
-            starBonus = result.StarBonus;
-            score = result.FinalScore;
             ReleaseRopesForBody(candies[0].WholeBody);
             ExhaustAllActiveRockets();
             DetachActiveSnails();

--- a/CutTheRopeDX/GameMain/GameScene.Initialize.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Initialize.cs
@@ -81,6 +81,7 @@ namespace CutTheRopeDX.GameMain
             targetBaseScaleX = 1f;
             targetBaseScaleY = 1f;
             gameplayFlow.ResetOutcome();
+            pendingLevelResult = null;
             levelName = null;
         }
 

--- a/CutTheRopeDX/GameMain/GameScene.Show.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Show.cs
@@ -67,7 +67,6 @@ namespace CutTheRopeDX.GameMain
             }
             // spiderTookCandy = false;
             time = 0f;
-            score = 0;
             gravityNormal = true;
             MaterialPoint.globalGravity = Vect(globalGravityX, globalGravityY);
             MaterialPoint.globalDisableGravity = VectEqual(MaterialPoint.globalGravity, vectZero);

--- a/CutTheRopeDX/GameMain/GameScene.Show.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Show.cs
@@ -130,7 +130,7 @@ namespace CutTheRopeDX.GameMain
         /// entry in the string tables and fall through <see cref="Application.GetString"/> verbatim.
         /// </remarks>
         /// <returns>The name to display, or <see langword="null"/> when the level has none.</returns>
-        private string ResolveLevelDisplayName()
+        internal string ResolveLevelDisplayName()
         {
             return string.IsNullOrWhiteSpace(levelName) ? null : Application.GetString(levelName);
         }

--- a/CutTheRopeDX/GameMain/GameScene.cs
+++ b/CutTheRopeDX/GameMain/GameScene.cs
@@ -1042,21 +1042,6 @@ namespace CutTheRopeDX.GameMain
         public int starsCollected;
 
         /// <summary>
-        /// The score bonus awarded from collected stars.
-        /// </summary>
-        public int starBonus;
-
-        /// <summary>
-        /// The score bonus awarded from remaining time.
-        /// </summary>
-        public float timeBonus;
-
-        /// <summary>
-        /// The current total score.
-        /// </summary>
-        public int score;
-
-        /// <summary>
         /// The elapsed level time.
         /// </summary>
         public float time;

--- a/CutTheRopeDX/GameMain/GameScene.cs
+++ b/CutTheRopeDX/GameMain/GameScene.cs
@@ -314,7 +314,11 @@ namespace CutTheRopeDX.GameMain
         {
             CTRSoundMgr.EnableLoopedSounds(false);
             gameplayFlow.EndTransition();
-            gameSceneDelegate?.GameWon();
+            if (pendingLevelResult is LevelResult result)
+            {
+                pendingLevelResult = null;
+                gameSceneDelegate?.GameWon(result);
+            }
         }
 
         /// <summary>
@@ -1056,6 +1060,9 @@ namespace CutTheRopeDX.GameMain
         /// The elapsed level time.
         /// </summary>
         public float time;
+
+        /// <summary>The completed result awaiting the delayed win callback.</summary>
+        private LevelResult? pendingLevelResult;
 
         /// <summary>
         /// The initial camera distance to the candy anchor.

--- a/CutTheRopeDX/GameMain/GameSceneDelegate.cs
+++ b/CutTheRopeDX/GameMain/GameSceneDelegate.cs
@@ -6,7 +6,8 @@ namespace CutTheRopeDX.GameMain
     internal interface IGameSceneDelegate
     {
         /// <summary>Called when the player wins the level.</summary>
-        void GameWon();
+        /// <param name="result">The completed level's immutable result.</param>
+        void GameWon(LevelResult result);
 
         /// <summary>Called when the player loses the level.</summary>
         void GameLost();

--- a/CutTheRopeDX/GameMain/LevelResult.cs
+++ b/CutTheRopeDX/GameMain/LevelResult.cs
@@ -30,4 +30,19 @@ namespace CutTheRopeDX.GameMain
             return new LevelResult(elapsedTime, starsCollected, starBonus, timeBonus, finalScore);
         }
     }
+
+    /// <summary>Projects a completed-level result into the values sent to RPC.</summary>
+    /// <param name="Stars">Number of collected stars.</param>
+    /// <param name="Score">Final level score.</param>
+    /// <param name="ElapsedSeconds">Whole elapsed seconds.</param>
+    internal readonly record struct LevelResultRpcPayload(int Stars, int Score, int ElapsedSeconds)
+    {
+        /// <summary>Creates an RPC payload from an immutable level result.</summary>
+        /// <param name="result">The completed level's immutable result.</param>
+        /// <returns>The RPC values projected from <paramref name="result"/>.</returns>
+        public static LevelResultRpcPayload From(LevelResult result)
+        {
+            return new LevelResultRpcPayload(result.StarsCollected, result.FinalScore, (int)result.ElapsedTime);
+        }
+    }
 }

--- a/CutTheRopeDX/GameMain/LevelResult.cs
+++ b/CutTheRopeDX/GameMain/LevelResult.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>Captures the authoritative outcome of a completed level.</summary>
+    /// <param name="ElapsedTime">Elapsed gameplay time when the win began.</param>
+    /// <param name="StarsCollected">Number of stars collected when the win began.</param>
+    /// <param name="StarBonus">Score awarded for collected stars.</param>
+    /// <param name="TimeBonus">Score awarded for remaining time.</param>
+    /// <param name="FinalScore">Final score after rounding the combined bonuses upward.</param>
+    internal readonly record struct LevelResult(
+        float ElapsedTime,
+        int StarsCollected,
+        int StarBonus,
+        float TimeBonus,
+        int FinalScore);
+
+    /// <summary>Calculates completed-level results from live gameplay state.</summary>
+    internal static class LevelResultCalculator
+    {
+        /// <summary>Calculates a completed-level result.</summary>
+        /// <param name="elapsedTime">Elapsed gameplay time when the win began.</param>
+        /// <param name="starsCollected">Number of stars collected when the win began.</param>
+        /// <returns>The immutable result calculated from the supplied gameplay state.</returns>
+        public static LevelResult Calculate(float elapsedTime, int starsCollected)
+        {
+            float timeBonus = MathF.Max(0f, 30f - elapsedTime) * 100f;
+            int starBonus = 1000 * starsCollected;
+            int finalScore = (int)MathF.Ceiling(timeBonus + starBonus);
+            return new LevelResult(elapsedTime, starsCollected, starBonus, timeBonus, finalScore);
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Add an immutable `LevelResult` snapshot that preserves fractional time bonuses until the final score ceiling.
- Create the result once when a win begins and pass it through scene callbacks, presentation, persistence, and RPC.
- Remove duplicated mutable score fields from `GameScene` and `BoxOpenClose`.
- Preserve custom-level result presentation without persisting progress.
- Ensure the result countdown finishes at the exact final score.
- In custom level mode, the "Best Score" text in pause menu is now either hidden or replaced by custom level's name.