### PR TITLE
refactor: Centralize game controller input state

### DIFF
--- a/CutTheRopeDX.Tests/GameControllerInputTests.cs
+++ b/CutTheRopeDX.Tests/GameControllerInputTests.cs
@@ -78,7 +78,8 @@ namespace CutTheRopeDX.Tests
                     (GameControllerInputKind)input,
                     (GameControllerOverlayMode)overlay,
                     RestartPhase.Playing,
-                    outcomeTransitionActive: false));
+                    outcomeTransitionActive: false,
+                    resultExitAllowed: true));
         }
 
         [Theory]
@@ -95,7 +96,21 @@ namespace CutTheRopeDX.Tests
                     (GameControllerInputKind)input,
                     (GameControllerOverlayMode)overlay,
                     (RestartPhase)restartPhase,
-                    outcomeTransitionActive));
+                    outcomeTransitionActive,
+                    resultExitAllowed: true));
+        }
+
+        [Fact]
+        public void ResolveIgnoresResultBackWhenResultExitIsDisallowed()
+        {
+            Assert.Equal(
+                GameControllerInputCommand.Ignore,
+                GameControllerInput.Resolve(
+                    GameControllerInputKind.Back,
+                    GameControllerOverlayMode.Results,
+                    RestartPhase.Playing,
+                    outcomeTransitionActive: false,
+                    resultExitAllowed: false));
         }
 
         [Fact]
@@ -173,6 +188,26 @@ namespace CutTheRopeDX.Tests
             Assert.Equal(GameController.EXIT_CODE_FROM_PAUSE_MENU, controller.exitCode);
             Assert.False(scene.touchable);
             Assert.False(PauseMenu(controller).IsEnabled());
+        }
+
+        [Fact]
+        public void BackIsIgnoredOnCustomLevelResults()
+        {
+            (GameController controller, _) = Load();
+
+            try
+            {
+                CustomLevelSession.Activate("custom-result-input-test.xml");
+                controller.LevelWon(LevelResultCalculator.Calculate(elapsedTime: 20f, starsCollected: 2));
+
+                _ = controller.BackButtonPressed();
+
+                Assert.Equal(GameController.EXIT_CODE_FROM_PAUSE_MENU, controller.exitCode);
+            }
+            finally
+            {
+                CustomLevelSession.Clear();
+            }
         }
 
         [Theory]

--- a/CutTheRopeDX.Tests/GameControllerInputTests.cs
+++ b/CutTheRopeDX.Tests/GameControllerInputTests.cs
@@ -1,4 +1,5 @@
 using CutTheRopeDX.GameMain;
+using CutTheRopeDX.Framework.Visual;
 
 using Xunit;
 
@@ -6,6 +7,18 @@ namespace CutTheRopeDX.Tests
 {
     public class GameControllerInputTests
     {
+        private static (GameController Controller, GameScene Scene) Load()
+        {
+            _ = HeadlessGame.Boot();
+            GameController controller = HeadlessGame.LoadLevelWithController(pack: 1, level: 4);
+            return (controller, (GameScene)controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_GAME_SCENE));
+        }
+
+        private static BaseElement PauseMenu(GameController controller)
+        {
+            return controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_PAUSE_MENU);
+        }
+
         [Fact]
         public void CanPauseFromGameplayFalseDuringOutcomeTransition()
         {
@@ -56,6 +69,99 @@ namespace CutTheRopeDX.Tests
             Assert.True(GameControllerInput.CanExitResultWithBack(
                 resultTouchable: true,
                 outcomeTransitionActive: false));
+        }
+
+        [Fact]
+        public void BackOpensPauseDuringNormalGameplay()
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+
+            _ = controller.BackButtonPressed();
+
+            Assert.False(scene.updateable);
+            Assert.True(PauseMenu(controller).IsEnabled());
+        }
+
+        [Fact]
+        public void MenuOpensPauseDuringNormalGameplay()
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+
+            _ = controller.MenuButtonPressed();
+
+            Assert.False(scene.updateable);
+            Assert.True(PauseMenu(controller).IsEnabled());
+        }
+
+        [Fact]
+        public void BackResumesFromPause()
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+            controller.OnButtonPressed(GameControllerButtonId.Pause);
+
+            _ = controller.BackButtonPressed();
+
+            Assert.True(scene.updateable);
+            Assert.False(PauseMenu(controller).IsEnabled());
+        }
+
+        [Fact]
+        public void MenuResumesFromPause()
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+            controller.OnButtonPressed(GameControllerButtonId.Pause);
+
+            _ = controller.MenuButtonPressed();
+
+            Assert.True(scene.updateable);
+            Assert.False(PauseMenu(controller).IsEnabled());
+        }
+
+        [Fact]
+        public void BackExitsStableResultsAndRepeatedInputRemainsGuarded()
+        {
+            (GameController controller, _) = Load();
+            controller.LevelWon(LevelResultCalculator.Calculate(elapsedTime: 20f, starsCollected: 2));
+
+            _ = controller.BackButtonPressed();
+            _ = controller.BackButtonPressed();
+
+            Assert.Equal(GameController.EXIT_CODE_FROM_PAUSE_MENU_LEVEL_SELECT, controller.exitCode);
+        }
+
+        [Fact]
+        public void MenuIsIgnoredOnStableResults()
+        {
+            (GameController controller, GameScene scene) = Load();
+            controller.LevelWon(LevelResultCalculator.Calculate(elapsedTime: 20f, starsCollected: 2));
+
+            _ = controller.MenuButtonPressed();
+
+            Assert.Equal(GameController.EXIT_CODE_FROM_PAUSE_MENU, controller.exitCode);
+            Assert.False(scene.touchable);
+            Assert.False(PauseMenu(controller).IsEnabled());
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void BackAndMenuAreIgnoredDuringOutcomeTransition(bool useBack)
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+            scene.gameplayFlow.MarkTransitionActive();
+
+            _ = useBack
+                ? controller.BackButtonPressed()
+                : controller.MenuButtonPressed();
+
+            Assert.True(scene.updateable);
+            Assert.False(PauseMenu(controller).IsEnabled());
+            Assert.Equal(GameController.EXIT_CODE_FROM_PAUSE_MENU, controller.exitCode);
         }
     }
 }

--- a/CutTheRopeDX.Tests/GameControllerInputTests.cs
+++ b/CutTheRopeDX.Tests/GameControllerInputTests.cs
@@ -21,6 +21,24 @@ namespace CutTheRopeDX.Tests
             return controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_PAUSE_MENU);
         }
 
+        private static void Press(GameController controller, int input)
+        {
+            switch ((GameControllerInputKind)input)
+            {
+                case GameControllerInputKind.Back:
+                    _ = controller.BackButtonPressed();
+                    break;
+                case GameControllerInputKind.Menu:
+                    _ = controller.MenuButtonPressed();
+                    break;
+                case GameControllerInputKind.PauseButton:
+                    controller.OnButtonPressed(GameControllerButtonId.Pause);
+                    break;
+                default:
+                    throw new System.ArgumentOutOfRangeException(nameof(input));
+            }
+        }
+
         public static IEnumerable<object[]> StableInputCases()
         {
             yield return [(int)GameControllerInputKind.Back, (int)GameControllerOverlayMode.Gameplay, (int)GameControllerInputCommand.OpenPause];
@@ -171,6 +189,41 @@ namespace CutTheRopeDX.Tests
             Assert.True(scene.updateable);
             Assert.False(PauseMenu(controller).IsEnabled());
             Assert.Equal(GameController.EXIT_CODE_FROM_PAUSE_MENU, controller.exitCode);
+        }
+
+        [Theory]
+        [InlineData((int)GameControllerInputKind.Back)]
+        [InlineData((int)GameControllerInputKind.Menu)]
+        [InlineData((int)GameControllerInputKind.PauseButton)]
+        public void EveryPauseInputEntersTheSamePausedPresentation(int input)
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+
+            Press(controller, input);
+
+            Assert.False(scene.touchable);
+            Assert.False(scene.updateable);
+            Assert.True(PauseMenu(controller).IsEnabled());
+            Assert.False(controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_PAUSE_BUTTON).IsEnabled());
+            Assert.False(controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_RESTART_BUTTON).IsEnabled());
+        }
+
+        [Theory]
+        [InlineData((int)GameControllerInputKind.Back)]
+        [InlineData((int)GameControllerInputKind.Menu)]
+        [InlineData((int)GameControllerInputKind.PauseButton)]
+        public void EveryPauseInputIsIgnoredDuringOutcomeTransition(int input)
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+            scene.gameplayFlow.MarkTransitionActive();
+
+            Press(controller, input);
+
+            Assert.True(scene.touchable);
+            Assert.True(scene.updateable);
+            Assert.False(PauseMenu(controller).IsEnabled());
         }
     }
 }

--- a/CutTheRopeDX.Tests/GameControllerInputTests.cs
+++ b/CutTheRopeDX.Tests/GameControllerInputTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 using CutTheRopeDX.GameMain;
 using CutTheRopeDX.Framework.Visual;
 
@@ -19,56 +21,63 @@ namespace CutTheRopeDX.Tests
             return controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_PAUSE_MENU);
         }
 
-        [Fact]
-        public void CanPauseFromGameplayFalseDuringOutcomeTransition()
+        public static IEnumerable<object[]> StableInputCases()
         {
-            Assert.False(GameControllerInput.CanPauseFromGameplay(
-                gameplayHudTouchable: true,
-                outcomeTransitionActive: true,
-                restartDimActive: false));
+            yield return [(int)GameControllerInputKind.Back, (int)GameControllerOverlayMode.Gameplay, (int)GameControllerInputCommand.OpenPause];
+            yield return [(int)GameControllerInputKind.Menu, (int)GameControllerOverlayMode.Gameplay, (int)GameControllerInputCommand.OpenPause];
+            yield return [(int)GameControllerInputKind.PauseButton, (int)GameControllerOverlayMode.Gameplay, (int)GameControllerInputCommand.OpenPause];
+            yield return [(int)GameControllerInputKind.Back, (int)GameControllerOverlayMode.Paused, (int)GameControllerInputCommand.Resume];
+            yield return [(int)GameControllerInputKind.Menu, (int)GameControllerOverlayMode.Paused, (int)GameControllerInputCommand.Resume];
+            yield return [(int)GameControllerInputKind.PauseButton, (int)GameControllerOverlayMode.Paused, (int)GameControllerInputCommand.Ignore];
+            yield return [(int)GameControllerInputKind.Back, (int)GameControllerOverlayMode.Results, (int)GameControllerInputCommand.ExitResults];
+            yield return [(int)GameControllerInputKind.Menu, (int)GameControllerOverlayMode.Results, (int)GameControllerInputCommand.Ignore];
+            yield return [(int)GameControllerInputKind.PauseButton, (int)GameControllerOverlayMode.Results, (int)GameControllerInputCommand.Ignore];
         }
 
-        [Fact]
-        public void CanPauseFromGameplayTrueWhenOutcomeTransitionInactive()
+        public static IEnumerable<object[]> GatedInputCases()
         {
-            Assert.True(GameControllerInput.CanPauseFromGameplay(
-                gameplayHudTouchable: true,
-                outcomeTransitionActive: false,
-                restartDimActive: false));
+            foreach (GameControllerInputKind input in System.Enum.GetValues<GameControllerInputKind>())
+            {
+                foreach (GameControllerOverlayMode overlay in System.Enum.GetValues<GameControllerOverlayMode>())
+                {
+                    yield return [(int)input, (int)overlay, (int)RestartPhase.FadingOut, false];
+                    yield return [(int)input, (int)overlay, (int)RestartPhase.FadingIn, false];
+                    yield return [(int)input, (int)overlay, (int)RestartPhase.Playing, true];
+                }
+            }
         }
 
-        [Fact]
-        public void CannotPauseWhileRestartDimIsPlaying()
+        [Theory]
+        [MemberData(nameof(StableInputCases))]
+        public void ResolveMapsStableInputByOverlayMode(
+            int input,
+            int overlay,
+            int expected)
         {
-            Assert.False(GameControllerInput.CanPauseFromGameplay(
-                gameplayHudTouchable: true,
-                outcomeTransitionActive: false,
-                restartDimActive: true));
+            Assert.Equal(
+                (GameControllerInputCommand)expected,
+                GameControllerInput.Resolve(
+                    (GameControllerInputKind)input,
+                    (GameControllerOverlayMode)overlay,
+                    RestartPhase.Playing,
+                    outcomeTransitionActive: false));
         }
 
-        [Fact]
-        public void CanPauseOnceRestartDimHasFinished()
+        [Theory]
+        [MemberData(nameof(GatedInputCases))]
+        public void ResolveIgnoresInputDuringRestartOrOutcomeTransition(
+            int input,
+            int overlay,
+            int restartPhase,
+            bool outcomeTransitionActive)
         {
-            Assert.True(GameControllerInput.CanPauseFromGameplay(
-                gameplayHudTouchable: true,
-                outcomeTransitionActive: false,
-                restartDimActive: false));
-        }
-
-        [Fact]
-        public void CanExitResultWithBackFalseDuringOutcomeTransition()
-        {
-            Assert.False(GameControllerInput.CanExitResultWithBack(
-                resultTouchable: true,
-                outcomeTransitionActive: true));
-        }
-
-        [Fact]
-        public void CanExitResultWithBackTrueAfterTransition()
-        {
-            Assert.True(GameControllerInput.CanExitResultWithBack(
-                resultTouchable: true,
-                outcomeTransitionActive: false));
+            Assert.Equal(
+                GameControllerInputCommand.Ignore,
+                GameControllerInput.Resolve(
+                    (GameControllerInputKind)input,
+                    (GameControllerOverlayMode)overlay,
+                    (RestartPhase)restartPhase,
+                    outcomeTransitionActive));
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/GameControllerInputTests.cs
+++ b/CutTheRopeDX.Tests/GameControllerInputTests.cs
@@ -155,9 +155,11 @@ namespace CutTheRopeDX.Tests
             controller.LevelWon(LevelResultCalculator.Calculate(elapsedTime: 20f, starsCollected: 2));
 
             _ = controller.BackButtonPressed();
+            Assert.Equal(GameController.EXIT_CODE_FROM_PAUSE_MENU_LEVEL_SELECT, controller.exitCode);
+            controller.exitCode = 42;
             _ = controller.BackButtonPressed();
 
-            Assert.Equal(GameController.EXIT_CODE_FROM_PAUSE_MENU_LEVEL_SELECT, controller.exitCode);
+            Assert.Equal(42, controller.exitCode);
         }
 
         [Fact]
@@ -224,6 +226,22 @@ namespace CutTheRopeDX.Tests
             Assert.True(scene.touchable);
             Assert.True(scene.updateable);
             Assert.False(PauseMenu(controller).IsEnabled());
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void BackAndMenuCannotReplaceAnExitRouteDuringLevelQuit(bool useBack)
+        {
+            (GameController controller, _) = Load();
+            controller.OnButtonPressed(GameControllerButtonId.MainMenu);
+            Assert.Equal(GameController.EXIT_CODE_FROM_PAUSE_MENU, controller.exitCode);
+
+            _ = useBack
+                ? controller.BackButtonPressed()
+                : controller.MenuButtonPressed();
+
+            Assert.Equal(GameController.EXIT_CODE_FROM_PAUSE_MENU, controller.exitCode);
         }
     }
 }

--- a/CutTheRopeDX.Tests/GameControllerInputTests.cs
+++ b/CutTheRopeDX.Tests/GameControllerInputTests.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 
-using CutTheRopeDX.GameMain;
 using CutTheRopeDX.Framework.Visual;
+using CutTheRopeDX.GameMain;
 
 using Xunit;
 

--- a/CutTheRopeDX.Tests/GameControllerOverlayModeTests.cs
+++ b/CutTheRopeDX.Tests/GameControllerOverlayModeTests.cs
@@ -4,6 +4,7 @@ using CutTheRopeDX.Framework.Core;
 using CutTheRopeDX.Framework.Media;
 using CutTheRopeDX.Framework.Visual;
 using CutTheRopeDX.GameMain;
+using CutTheRopeDX.Helpers;
 
 using Xunit;
 
@@ -75,7 +76,7 @@ namespace CutTheRopeDX.Tests
         }
 
         [Fact]
-        public void ResultsModeFreezesSceneAndHudWithoutPausingResultAudio()
+        public void ResultsModeBlocksTouchButKeepsSceneUpdatingDuringCloseAnimation()
         {
             (GameController controller, GameScene scene) = Load();
             View view = controller.GetView(0);
@@ -83,11 +84,24 @@ namespace CutTheRopeDX.Tests
             controller.LevelWon(LevelResultCalculator.Calculate(elapsedTime: 20f, starsCollected: 2));
 
             Assert.False(scene.touchable);
-            Assert.False(scene.updateable);
+            Assert.True(scene.updateable);
             Assert.False(view.GetChild(GameView.VIEW_ELEMENT_PAUSE_MENU).IsEnabled());
             Assert.False(view.GetChild(GameView.VIEW_ELEMENT_PAUSE_BUTTON).IsEnabled());
             Assert.False(view.GetChild(GameView.VIEW_ELEMENT_RESTART_BUTTON).IsEnabled());
             Assert.Equal(0, AudioPauseDepth());
+        }
+
+        [Fact]
+        public void ResultsModeFreezesSceneAfterBoxCloseDelay()
+        {
+            (GameController controller, GameScene scene) = Load();
+            BoxOpenClose box = (BoxOpenClose)controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_RESULTS);
+            controller.LevelWon(LevelResultCalculator.Calculate(elapsedTime: 20f, starsCollected: 2));
+
+            box.PostBoxClosed();
+            TimerManager.Update(0.51f);
+
+            Assert.False(scene.updateable);
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/GameControllerOverlayModeTests.cs
+++ b/CutTheRopeDX.Tests/GameControllerOverlayModeTests.cs
@@ -91,6 +91,18 @@ namespace CutTheRopeDX.Tests
         }
 
         [Fact]
+        public void EnteringResultsFromPauseReleasesTheControllerAudioPause()
+        {
+            (GameController controller, _) = Load();
+            controller.OnButtonPressed(GameControllerButtonId.Pause);
+            Assert.Equal(1, AudioPauseDepth());
+
+            controller.LevelWon(LevelResultCalculator.Calculate(elapsedTime: 20f, starsCollected: 2));
+
+            Assert.Equal(0, AudioPauseDepth());
+        }
+
+        [Fact]
         public void EnteringPausedReleasesSceneGesturesOnlyOnTheTransition()
         {
             (GameController controller, _) = Load();

--- a/CutTheRopeDX.Tests/GameControllerOverlayModeTests.cs
+++ b/CutTheRopeDX.Tests/GameControllerOverlayModeTests.cs
@@ -1,0 +1,128 @@
+using System.Reflection;
+
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.Framework.Media;
+using CutTheRopeDX.Framework.Visual;
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class GameControllerOverlayModeTests
+    {
+        private static (GameController Controller, GameScene Scene) Load()
+        {
+            _ = HeadlessGame.Boot();
+            CTRSoundMgr.StopAll();
+            GameController controller = HeadlessGame.LoadLevelWithController(pack: 1, level: 4);
+            return (controller, (GameScene)controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_GAME_SCENE));
+        }
+
+        private static int AudioPauseDepth()
+        {
+            FieldInfo field = typeof(SoundMgr).GetField("pauseDepth", BindingFlags.Instance | BindingFlags.NonPublic);
+            return Assert.IsType<int>(field?.GetValue(Application.SharedSoundMgr()));
+        }
+
+        private static Button FindButton(BaseElement root, GameControllerButtonId buttonId)
+        {
+            if (root is Button button && button.buttonID == (ButtonId)buttonId)
+            {
+                return button;
+            }
+
+            foreach (BaseElement child in root.GetChilds().Values)
+            {
+                Button match = child == null ? null : FindButton(child, buttonId);
+                if (match != null)
+                {
+                    return match;
+                }
+            }
+
+            return null;
+        }
+
+        [Fact]
+        public void GameplayModeEnablesSceneAndHudWithoutPauseAudio()
+        {
+            (GameController controller, GameScene scene) = Load();
+            View view = controller.GetView(0);
+
+            Assert.True(scene.touchable);
+            Assert.True(scene.updateable);
+            Assert.False(view.GetChild(GameView.VIEW_ELEMENT_PAUSE_MENU).IsEnabled());
+            Assert.True(view.GetChild(GameView.VIEW_ELEMENT_PAUSE_BUTTON).IsEnabled());
+            Assert.True(view.GetChild(GameView.VIEW_ELEMENT_RESTART_BUTTON).IsEnabled());
+            Assert.Equal(0, AudioPauseDepth());
+        }
+
+        [Fact]
+        public void PausedModeFreezesSceneShowsMenuDisablesHudAndPausesAudio()
+        {
+            (GameController controller, GameScene scene) = Load();
+            View view = controller.GetView(0);
+
+            controller.OnButtonPressed(GameControllerButtonId.Pause);
+
+            Assert.False(scene.touchable);
+            Assert.False(scene.updateable);
+            Assert.True(view.GetChild(GameView.VIEW_ELEMENT_PAUSE_MENU).IsEnabled());
+            Assert.False(view.GetChild(GameView.VIEW_ELEMENT_PAUSE_BUTTON).IsEnabled());
+            Assert.False(view.GetChild(GameView.VIEW_ELEMENT_RESTART_BUTTON).IsEnabled());
+            Assert.Equal(1, AudioPauseDepth());
+        }
+
+        [Fact]
+        public void ResultsModeFreezesSceneAndHudWithoutPausingResultAudio()
+        {
+            (GameController controller, GameScene scene) = Load();
+            View view = controller.GetView(0);
+
+            controller.LevelWon(LevelResultCalculator.Calculate(elapsedTime: 20f, starsCollected: 2));
+
+            Assert.False(scene.touchable);
+            Assert.False(scene.updateable);
+            Assert.False(view.GetChild(GameView.VIEW_ELEMENT_PAUSE_MENU).IsEnabled());
+            Assert.False(view.GetChild(GameView.VIEW_ELEMENT_PAUSE_BUTTON).IsEnabled());
+            Assert.False(view.GetChild(GameView.VIEW_ELEMENT_RESTART_BUTTON).IsEnabled());
+            Assert.Equal(0, AudioPauseDepth());
+        }
+
+        [Fact]
+        public void EnteringPausedReleasesSceneGesturesOnlyOnTheTransition()
+        {
+            (GameController controller, _) = Load();
+            FieldInfo field = typeof(GameController).GetField("touchAddressMap", BindingFlags.Instance | BindingFlags.NonPublic);
+            int[] touchAddressMap = Assert.IsType<int[]>(field?.GetValue(controller));
+            touchAddressMap[0] = 42;
+
+            controller.OnButtonPressed(GameControllerButtonId.Pause);
+
+            Assert.Equal(0, touchAddressMap[0]);
+            touchAddressMap[0] = 43;
+
+            controller.OnButtonPressed(GameControllerButtonId.Pause);
+
+            Assert.Equal(43, touchAddressMap[0]);
+        }
+
+        [Fact]
+        public void EnteringGameplayDeactivatesPressedMenuButtons()
+        {
+            (GameController controller, GameScene scene) = Load();
+            BaseElement pauseMenu = controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_PAUSE_MENU);
+            controller.OnButtonPressed(GameControllerButtonId.Pause);
+            Button continueButton = Assert.IsType<Button>(FindButton(pauseMenu, GameControllerButtonId.Continue));
+            continueButton.SetState(Button.BUTTON_STATE.BUTTON_DOWN);
+
+            controller.OnButtonPressed(GameControllerButtonId.Continue);
+
+            Assert.Equal(Button.BUTTON_STATE.BUTTON_UP, continueButton.state);
+            Assert.True(scene.touchable);
+            Assert.True(scene.updateable);
+            Assert.Equal(0, AudioPauseDepth());
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/MenuControllerInputTests.cs
+++ b/CutTheRopeDX.Tests/MenuControllerInputTests.cs
@@ -1,0 +1,60 @@
+using System.Reflection;
+
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class MenuControllerInputTests
+    {
+        [Fact]
+        public void RepeatedLevelClickKeepsTheFirstPendingSelection()
+        {
+            _ = HeadlessGame.Boot();
+            MenuController controller = new((CTRRootController)Application.SharedRootController());
+
+            try
+            {
+                controller.PreLevelSelect();
+                controller.ShowView(MenuController.VIEW_LEVEL_SELECT);
+
+                controller.OnButtonPressed(MenuButtonId.ForLevel(0));
+                controller.OnButtonPressed(MenuButtonId.ForLevel(1));
+
+                FieldInfo field = typeof(MenuController).GetField("level", BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.Equal(0, Assert.IsType<int>(field?.GetValue(controller)));
+            }
+            finally
+            {
+                controller.Dispose();
+            }
+        }
+
+        [Fact]
+        public void PreparingLevelSelectionAllowsANewSelection()
+        {
+            _ = HeadlessGame.Boot();
+            MenuController controller = new((CTRRootController)Application.SharedRootController());
+
+            try
+            {
+                controller.PreLevelSelect();
+                controller.ShowView(MenuController.VIEW_LEVEL_SELECT);
+                controller.OnButtonPressed(MenuButtonId.ForLevel(0));
+
+                controller.PreLevelSelect();
+                controller.ShowView(MenuController.VIEW_LEVEL_SELECT);
+                controller.OnButtonPressed(MenuButtonId.ForLevel(1));
+
+                FieldInfo field = typeof(MenuController).GetField("level", BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.Equal(1, Assert.IsType<int>(field?.GetValue(controller)));
+            }
+            finally
+            {
+                controller.Dispose();
+            }
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/PauseDuringRestartTests.cs
+++ b/CutTheRopeDX.Tests/PauseDuringRestartTests.cs
@@ -197,5 +197,34 @@ namespace CutTheRopeDX.Tests
             Assert.Equal(RestartPhase.FadingIn, scene.gameplayFlow.Phase);
             Assert.False(controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_PAUSE_MENU).IsEnabled());
         }
+
+        [Fact]
+        public void PauseButtonInputDuringRestartFadeOutIsIgnored()
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+
+            controller.OnButtonPressed(GameControllerButtonId.Restart);
+            controller.OnButtonPressed(GameControllerButtonId.Pause);
+
+            Assert.True(scene.updateable);
+            Assert.Equal(RestartPhase.FadingOut, scene.gameplayFlow.Phase);
+            Assert.False(controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_PAUSE_MENU).IsEnabled());
+        }
+
+        [Fact]
+        public void PauseButtonInputDuringRestartFadeInIsIgnored()
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+            scene.gameplayFlow.BeginRestartDim();
+            Assert.Equal(RestartStep.SwapScene, scene.gameplayFlow.Advance(1f));
+
+            controller.OnButtonPressed(GameControllerButtonId.Pause);
+
+            Assert.True(scene.updateable);
+            Assert.Equal(RestartPhase.FadingIn, scene.gameplayFlow.Phase);
+            Assert.False(controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_PAUSE_MENU).IsEnabled());
+        }
     }
 }

--- a/CutTheRopeDX.Tests/PauseDuringRestartTests.cs
+++ b/CutTheRopeDX.Tests/PauseDuringRestartTests.cs
@@ -30,7 +30,7 @@ namespace CutTheRopeDX.Tests
             {
                 CustomLevelSession.Activate("pause-name-test.xml");
 
-                controller.SetPaused(true);
+                controller.OnButtonPressed(GameControllerButtonId.Pause);
 
                 Assert.Equal("My Custom Level", PauseMapNameLabel(controller).GetString());
             }
@@ -52,7 +52,7 @@ namespace CutTheRopeDX.Tests
             {
                 CustomLevelSession.Activate("pause-name-test.xml");
 
-                controller.SetPaused(true);
+                controller.OnButtonPressed(GameControllerButtonId.Pause);
 
                 Assert.Equal(string.Empty, PauseMapNameLabel(controller).GetString());
             }
@@ -69,7 +69,7 @@ namespace CutTheRopeDX.Tests
             CTRRootController root = (CTRRootController)Application.SharedRootController();
             int score = CTRPreferences.GetScoreForPackLevel(root.GetBox(), root.GetPack(), root.GetLevel());
 
-            controller.SetPaused(true);
+            controller.OnButtonPressed(GameControllerButtonId.Pause);
 
             Assert.Equal(Application.GetString("BEST_SCORE") + ": " + score, PauseMapNameLabel(controller).GetString());
         }
@@ -82,7 +82,7 @@ namespace CutTheRopeDX.Tests
             scene.AnimateLevelRestart();
             controller.OnButtonPressed(GameControllerButtonId.Pause);
 
-            // SetPaused freezes the scene via updateable; still true means the pause was refused.
+            // Entering pause freezes the scene via updateable; still true means the pause was refused.
             Assert.True(scene.updateable);
         }
 

--- a/CutTheRopeDX.Tests/PauseDuringRestartTests.cs
+++ b/CutTheRopeDX.Tests/PauseDuringRestartTests.cs
@@ -168,5 +168,34 @@ namespace CutTheRopeDX.Tests
             Assert.Equal(RestartPhase.FadingIn, scene.gameplayFlow.Phase);
             Assert.False(controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_PAUSE_MENU).IsEnabled());
         }
+
+        [Fact]
+        public void MenuInputDuringRestartFadeOutIsIgnored()
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+
+            controller.OnButtonPressed(GameControllerButtonId.Restart);
+            _ = controller.MenuButtonPressed();
+
+            Assert.True(scene.updateable);
+            Assert.Equal(RestartPhase.FadingOut, scene.gameplayFlow.Phase);
+            Assert.False(controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_PAUSE_MENU).IsEnabled());
+        }
+
+        [Fact]
+        public void MenuInputDuringRestartFadeInIsIgnored()
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+            scene.gameplayFlow.BeginRestartDim();
+            Assert.Equal(RestartStep.SwapScene, scene.gameplayFlow.Advance(1f));
+
+            _ = controller.MenuButtonPressed();
+
+            Assert.True(scene.updateable);
+            Assert.Equal(RestartPhase.FadingIn, scene.gameplayFlow.Phase);
+            Assert.False(controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_PAUSE_MENU).IsEnabled());
+        }
     }
 }

--- a/CutTheRopeDX/GameMain/GameController.cs
+++ b/CutTheRopeDX/GameMain/GameController.cs
@@ -455,19 +455,30 @@ namespace CutTheRopeDX.GameMain
         /// <param name="n">Game controller button identifier.</param>
         public void OnButtonPressed(GameControllerButtonId n)
         {
+            if (n == GameControllerButtonId.Pause)
+            {
+                ExecuteInputCommand(ResolveInput(GameControllerInputKind.PauseButton));
+                return;
+            }
+            if (n == GameControllerButtonId.Continue)
+            {
+                ExecuteInputCommand(GameControllerInputCommand.Resume);
+                return;
+            }
+            if (n == GameControllerButtonId.ExitFromWin)
+            {
+                ExecuteInputCommand(GameControllerInputCommand.ExitResults);
+                return;
+            }
+
             CTRRootController cTRRootController = (CTRRootController)Application.SharedRootController();
             CTRSoundMgr.PlaySound(Resources.Snd.Tap);
             View view = GetView(0);
             switch (n)
             {
-                case var id when id == GameControllerButtonId.Continue:
-                    EnterOverlayMode(GameControllerOverlayMode.Gameplay);
-                    CTRRootController.LogEvent("IM_CONTINUE_PRESSED");
-                    return;
                 case var id when id == GameControllerButtonId.Restart:
                     GameScene restartScene = (GameScene)view.GetChild(GameView.VIEW_ELEMENT_GAME_SCENE);
                     if (overlayMode != GameControllerOverlayMode.Gameplay
-                        || !view.GetChild(GameView.VIEW_ELEMENT_RESTART_BUTTON).touchable
                         || restartScene.gameplayFlow.Phase != RestartPhase.Playing)
                     {
                         return;
@@ -503,31 +514,6 @@ namespace CutTheRopeDX.GameMain
                     LevelQuit();
                     CTRRootController.LogEvent("IM_MAIN_MENU");
                     return;
-                case var id when id == GameControllerButtonId.ExitFromWin:
-                    exitCode = 1;
-                    CTRSoundMgr.StopAll();
-                    if (!boxCloseHandled)
-                    {
-                        BoxClosed();
-                    }
-                    CTRRootController.LogEvent("LC_MENU_PRESSED");
-                    Deactivate();
-                    return;
-                case var id when id == GameControllerButtonId.Pause:
-                    {
-                        GameScene gameScene4 = (GameScene)view.GetChild(0);
-                        if (!GameControllerInput.CanPauseFromGameplay(
-                            view.GetChild(1).touchable,
-                            gameScene4.gameplayFlow.TransitionActive,
-                            gameScene4.gameplayFlow.IsFadingOut))
-                        {
-                            return;
-                        }
-                        EnterOverlayMode(GameControllerOverlayMode.Paused);
-                        CTRRootController.LogEvent("IG_MENU_PRESSED");
-                        CTRRootController.LogEvent("IM_SHOWN");
-                        return;
-                    }
                 case var id when id == GameControllerButtonId.WinContinue:
                     if (LastLevelInPack() && !cTRRootController.IsPicker())
                     {
@@ -590,7 +576,7 @@ namespace CutTheRopeDX.GameMain
                     return;
             }
             GameScene gameScene5 = (GameScene)view.GetChild(0);
-            if (!gameScene5.IsEnabled())
+            if (overlayMode != GameControllerOverlayMode.Gameplay)
             {
                 LevelStart();
             }
@@ -598,6 +584,54 @@ namespace CutTheRopeDX.GameMain
             gameScene5.Reload();
             EnterOverlayMode(GameControllerOverlayMode.Gameplay);
             CTRRootController.LogEvent(n != GameControllerButtonId.ExitFromLose ? "IG_REPLAY_PRESSED" : "LC_REPLAY_PRESSED");
+        }
+
+        /// <summary>Resolves an input source against the authoritative controller and level-flow state.</summary>
+        /// <param name="input">Input source to resolve.</param>
+        /// <returns>The semantic command allowed in the current state.</returns>
+        private GameControllerInputCommand ResolveInput(GameControllerInputKind input)
+        {
+            GameScene gameScene = (GameScene)GetView(0).GetChild(GameView.VIEW_ELEMENT_GAME_SCENE);
+            return GameControllerInput.Resolve(
+                input,
+                overlayMode,
+                gameScene.gameplayFlow.Phase,
+                gameScene.gameplayFlow.TransitionActive);
+        }
+
+        /// <summary>Executes one semantic controller input command.</summary>
+        /// <param name="command">Command selected by the pure input resolver.</param>
+        private void ExecuteInputCommand(GameControllerInputCommand command)
+        {
+            switch (command)
+            {
+                case GameControllerInputCommand.Ignore:
+                    return;
+                case GameControllerInputCommand.OpenPause:
+                    CTRSoundMgr.PlaySound(Resources.Snd.Tap);
+                    EnterOverlayMode(GameControllerOverlayMode.Paused);
+                    CTRRootController.LogEvent("IG_MENU_PRESSED");
+                    CTRRootController.LogEvent("IM_SHOWN");
+                    return;
+                case GameControllerInputCommand.Resume:
+                    CTRSoundMgr.PlaySound(Resources.Snd.Tap);
+                    EnterOverlayMode(GameControllerOverlayMode.Gameplay);
+                    CTRRootController.LogEvent("IM_CONTINUE_PRESSED");
+                    return;
+                case GameControllerInputCommand.ExitResults:
+                    CTRSoundMgr.PlaySound(Resources.Snd.Tap);
+                    exitCode = EXIT_CODE_FROM_PAUSE_MENU_LEVEL_SELECT;
+                    CTRSoundMgr.StopAll();
+                    if (!boxCloseHandled)
+                    {
+                        BoxClosed();
+                    }
+                    CTRRootController.LogEvent("LC_MENU_PRESSED");
+                    Deactivate();
+                    return;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(command));
+            }
         }
 
         /// <inheritdoc />
@@ -796,48 +830,14 @@ namespace CutTheRopeDX.GameMain
         /// <inheritdoc />
         public override bool BackButtonPressed()
         {
-            View view = GetView(0);
-            GameScene gameScene = (GameScene)view.GetChild(0);
-            if (gameScene.gameplayFlow.Phase != RestartPhase.Playing)
-            {
-                return true;
-            }
-            if (GameControllerInput.CanPauseFromGameplay(
-                view.GetChild(1).touchable,
-                gameScene.gameplayFlow.TransitionActive,
-                gameScene.gameplayFlow.IsFadingOut))
-            {
-                OnButtonPressed(GameControllerButtonId.Pause);
-            }
-            else if (view.GetChild(3).IsEnabled())
-            {
-                OnButtonPressed(GameControllerButtonId.Continue);
-            }
-            else if (GameControllerInput.CanExitResultWithBack(
-                view.GetChild(4).touchable,
-                gameScene.gameplayFlow.TransitionActive))
-            {
-                OnButtonPressed(GameControllerButtonId.ExitFromWin);
-            }
+            ExecuteInputCommand(ResolveInput(GameControllerInputKind.Back));
             return true;
         }
 
         /// <inheritdoc />
         public override bool MenuButtonPressed()
         {
-            View view = GetView(0);
-            GameScene gameScene = (GameScene)view.GetChild(0);
-            if (GameControllerInput.CanPauseFromGameplay(
-                view.GetChild(1).touchable,
-                gameScene.gameplayFlow.TransitionActive,
-                gameScene.gameplayFlow.IsFadingOut))
-            {
-                OnButtonPressed(GameControllerButtonId.Pause);
-            }
-            else if (view.GetChild(3).IsEnabled())
-            {
-                OnButtonPressed(GameControllerButtonId.Continue);
-            }
+            ExecuteInputCommand(ResolveInput(GameControllerInputKind.Menu));
             return true;
         }
 

--- a/CutTheRopeDX/GameMain/GameController.cs
+++ b/CutTheRopeDX/GameMain/GameController.cs
@@ -693,7 +693,7 @@ namespace CutTheRopeDX.GameMain
             view.GetChild(GameView.VIEW_ELEMENT_RESTART_BUTTON).SetEnabled(gameplay);
             view.GetChild(GameView.VIEW_ELEMENT_RESULTS).touchable = mode == GameControllerOverlayMode.Results;
             gameScene.touchable = gameplay;
-            gameScene.updateable = gameplay;
+            gameScene.updateable = !paused;
 
             if (previousMode == GameControllerOverlayMode.Paused && mode != GameControllerOverlayMode.Paused)
             {

--- a/CutTheRopeDX/GameMain/GameController.cs
+++ b/CutTheRopeDX/GameMain/GameController.cs
@@ -22,7 +22,7 @@ namespace CutTheRopeDX.GameMain
         public override void Update(float t)
         {
             // XnaGame is the desktop host and is absent headless, where there is no keyboard.
-            if (!isGamePaused && Global.XnaGame?.IsKeyPressed(Keys.F5) == true)
+            if (overlayMode == GameControllerOverlayMode.Gameplay && Global.XnaGame?.IsKeyPressed(Keys.F5) == true)
             {
                 OnButtonPressed(GameControllerButtonId.Restart);
             }
@@ -60,7 +60,7 @@ namespace CutTheRopeDX.GameMain
                 // external edit reads as a deliberate restart rather than a glitch.
                 scene.animateRestartDim = true;
                 scene.Reload();
-                SetPaused(false);
+                EnterOverlayMode(GameControllerOverlayMode.Gameplay);
                 return;
             }
 
@@ -202,7 +202,6 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         public void InitGameView()
         {
-            SetPaused(false);
             LevelFirstStart();
         }
 
@@ -213,11 +212,7 @@ namespace CutTheRopeDX.GameMain
         {
             View view = GetView(0);
             ((BoxOpenClose)view.GetChild(4)).LevelFirstStart();
-            isGamePaused = false;
-            view.GetChild(0).touchable = true;
-            view.GetChild(0).updateable = true;
-            view.GetChild(1).touchable = true;
-            view.GetChild(2).touchable = true;
+            EnterOverlayMode(GameControllerOverlayMode.Gameplay);
         }
 
         /// <summary>
@@ -227,12 +222,7 @@ namespace CutTheRopeDX.GameMain
         {
             View view = GetView(0);
             ((BoxOpenClose)view.GetChild(4)).LevelStart();
-            isGamePaused = false;
-            view.GetChild(0).touchable = true;
-            view.GetChild(0).updateable = true;
-            view.GetChild(1).touchable = true;
-            view.GetChild(2).touchable = true;
-            view.GetChild(4).touchable = false;
+            EnterOverlayMode(GameControllerOverlayMode.Gameplay);
         }
 
         /// <summary>
@@ -241,8 +231,8 @@ namespace CutTheRopeDX.GameMain
         public void LevelQuit()
         {
             View view = GetView(0);
+            EnterOverlayMode(GameControllerOverlayMode.Results);
             ((BoxOpenClose)view.GetChild(4)).LevelQuit();
-            view.GetChild(0).touchable = false;
         }
 
         /// <summary>
@@ -333,7 +323,6 @@ namespace CutTheRopeDX.GameMain
             //}
             CTRSoundMgr.PlaySound(Resources.Snd.Win);
             View view = GetView(0);
-            view.GetChild(4).touchable = true;
             GameScene gameScene = (GameScene)view.GetChild(0);
             BoxOpenClose boxOpenClose = (BoxOpenClose)view.GetChild(4);
             Image image = (Image)boxOpenClose.result.GetChildWithName("star1");
@@ -350,10 +339,7 @@ namespace CutTheRopeDX.GameMain
                 _ => "LEVEL_CLEARED1"
             };
             ((Text)boxOpenClose.result.GetChildWithName("passText")).SetString(Application.GetString(clearText));
-            isGamePaused = true;
-            gameScene.touchable = false;
-            view.GetChild(2).touchable = false;
-            view.GetChild(1).touchable = false;
+            EnterOverlayMode(GameControllerOverlayMode.Results);
             int box = cTRRootController.GetBox();
             int pack = cTRRootController.GetPack();
             int level = cTRRootController.GetLevel();
@@ -384,7 +370,7 @@ namespace CutTheRopeDX.GameMain
                     (_) =>
                     {
                         // Only freeze if still in result screen (not when replaying/moving to next level)
-                        if (isGamePaused)
+                        if (overlayMode == GameControllerOverlayMode.Results)
                         {
                             gameScene.updateable = false;
                         }
@@ -410,6 +396,7 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         public void LevelLost()
         {
+            EnterOverlayMode(GameControllerOverlayMode.Results);
             ((BoxOpenClose)GetView(0).GetChild(4)).LevelLost();
         }
 
@@ -474,12 +461,12 @@ namespace CutTheRopeDX.GameMain
             switch (n)
             {
                 case var id when id == GameControllerButtonId.Continue:
-                    SetPaused(false);
+                    EnterOverlayMode(GameControllerOverlayMode.Gameplay);
                     CTRRootController.LogEvent("IM_CONTINUE_PRESSED");
                     return;
                 case var id when id == GameControllerButtonId.Restart:
                     GameScene restartScene = (GameScene)view.GetChild(GameView.VIEW_ELEMENT_GAME_SCENE);
-                    if (isGamePaused
+                    if (overlayMode != GameControllerOverlayMode.Gameplay
                         || !view.GetChild(GameView.VIEW_ELEMENT_RESTART_BUTTON).touchable
                         || restartScene.gameplayFlow.Phase != RestartPhase.Playing)
                     {
@@ -494,7 +481,7 @@ namespace CutTheRopeDX.GameMain
                         return;
                     }
                     UnlockNextLevel();
-                    SetPaused(false);
+                    EnterOverlayMode(GameControllerOverlayMode.Gameplay);
                     ((GameScene)view.GetChild(0)).LoadNextMap();
                     CTRRootController.LogEvent("IM_SKIP_PRESSED");
                     return;
@@ -536,7 +523,7 @@ namespace CutTheRopeDX.GameMain
                         {
                             return;
                         }
-                        SetPaused(true);
+                        EnterOverlayMode(GameControllerOverlayMode.Paused);
                         CTRRootController.LogEvent("IG_MENU_PRESSED");
                         CTRRootController.LogEvent("IM_SHOWN");
                         return;
@@ -549,7 +536,6 @@ namespace CutTheRopeDX.GameMain
                     }
                     ((GameScene)view.GetChild(0)).LoadNextMap();
                     LevelStart();
-                    SetPaused(false);
                     return;
                 case var id when id == GameControllerButtonId.ExitFromLose:
                     if (!boxCloseHandled)
@@ -571,7 +557,6 @@ namespace CutTheRopeDX.GameMain
                     }
                     ((GameScene)view.GetChild(0)).LoadNextMap();
                     LevelStart();
-                    SetPaused(false);
                     return;
                 case var id when id == GameControllerButtonId.ToggleMusic:
                     {
@@ -611,7 +596,7 @@ namespace CutTheRopeDX.GameMain
             }
             gameScene5.animateRestartDim = n == GameControllerButtonId.Restart;
             gameScene5.Reload();
-            SetPaused(false);
+            EnterOverlayMode(GameControllerOverlayMode.Gameplay);
             CTRRootController.LogEvent(n != GameControllerButtonId.ExitFromLose ? "IG_REPLAY_PRESSED" : "LC_REPLAY_PRESSED");
         }
 
@@ -622,35 +607,57 @@ namespace CutTheRopeDX.GameMain
         }
 
         /// <summary>
-        /// Sets pause state, toggles HUD/menu visibility, and updates audio pause state.
+        /// Applies the complete scene, HUD, menu, gesture, and audio policy for an overlay mode.
         /// </summary>
-        /// <param name="p"><see langword="true"/> to pause the game; <see langword="false"/> to resume it.</param>
-        public void SetPaused(bool p)
+        /// <param name="mode">Overlay mode to enter.</param>
+        private void EnterOverlayMode(GameControllerOverlayMode mode)
         {
+            if (overlayModeApplied && overlayMode == mode)
+            {
+                return;
+            }
+
             View view = GetView(0);
-            if (!p)
+            GameScene gameScene = (GameScene)view.GetChild(GameView.VIEW_ELEMENT_GAME_SCENE);
+            GameControllerOverlayMode previousMode = overlayMode;
+            overlayMode = mode;
+            overlayModeApplied = true;
+
+            if (mode == GameControllerOverlayMode.Gameplay)
             {
                 DeactivateAllButtons();
             }
-            else
+            else if (mode == GameControllerOverlayMode.Paused)
             {
                 // Cancel any in-progress game-scene gesture
                 // before the scene stops receiving input. Otherwise the matching touch-up is
                 // dropped while paused, stranding the button in its pressed state until restart.
-                ReleaseAllTouches((GameScene)view.GetChild(0));
+                ReleaseAllTouches(gameScene);
             }
-            isGamePaused = p;
-            view.GetChild(3).SetEnabled(p);
-            view.GetChild(1).SetEnabled(!p);
-            view.GetChild(2).SetEnabled(!p);
-            view.GetChild(0).touchable = !p;
-            view.GetChild(0).updateable = !p;
-            if (!isGamePaused)
+
+            bool gameplay = mode == GameControllerOverlayMode.Gameplay;
+            bool paused = mode == GameControllerOverlayMode.Paused;
+            view.GetChild(GameView.VIEW_ELEMENT_PAUSE_MENU).SetEnabled(paused);
+            view.GetChild(GameView.VIEW_ELEMENT_PAUSE_BUTTON).SetEnabled(gameplay);
+            view.GetChild(GameView.VIEW_ELEMENT_RESTART_BUTTON).SetEnabled(gameplay);
+            view.GetChild(GameView.VIEW_ELEMENT_RESULTS).touchable = mode == GameControllerOverlayMode.Results;
+            gameScene.touchable = gameplay;
+            gameScene.updateable = gameplay;
+
+            if (previousMode == GameControllerOverlayMode.Paused && mode != GameControllerOverlayMode.Paused)
             {
                 CTRSoundMgr.Unpause();
+            }
+            else if (previousMode != GameControllerOverlayMode.Paused && mode == GameControllerOverlayMode.Paused)
+            {
+                CTRSoundMgr.Pause();
+            }
+
+            if (!paused)
+            {
                 return;
             }
-            CTRSoundMgr.Pause();
+
             CTRRootController cTRRootController = (CTRRootController)Application.SharedRootController();
             if (cTRRootController.IsPicker())
             {
@@ -659,7 +666,6 @@ namespace CutTheRopeDX.GameMain
             }
             if (CustomLevelSession.IsActive)
             {
-                GameScene gameScene = (GameScene)view.GetChild(0);
                 mapNameLabel.SetString(gameScene.ResolveLevelDisplayName() ?? string.Empty);
                 return;
             }
@@ -850,7 +856,6 @@ namespace CutTheRopeDX.GameMain
             }
             ((GameScene)view.GetChild(0)).LoadNextMap();
             LevelStart();
-            SetPaused(false);
         }
 
         /// <summary>
@@ -967,8 +972,11 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Watches the custom level file for external edits, or <see langword="null"/> in normal play.</summary>
         private CustomLevelWatcher levelWatcher;
 
-        /// <summary>Whether gameplay is currently paused.</summary>
-        private bool isGamePaused;
+        /// <summary>Authoritative controller overlay mode.</summary>
+        private GameControllerOverlayMode overlayMode = GameControllerOverlayMode.Gameplay;
+
+        /// <summary>Whether the initial overlay presentation has been applied to the created view.</summary>
+        private bool overlayModeApplied;
 
         /// <summary>Exit code describing the selected controller deactivation route.</summary>
         public int exitCode;

--- a/CutTheRopeDX/GameMain/GameController.cs
+++ b/CutTheRopeDX/GameMain/GameController.cs
@@ -100,6 +100,13 @@ namespace CutTheRopeDX.GameMain
         }
 
         /// <inheritdoc />
+        public override void Deactivate()
+        {
+            navigationExitActive = true;
+            base.Deactivate();
+        }
+
+        /// <inheritdoc />
         protected override void Dispose(bool disposing)
         {
             if (disposing)
@@ -211,6 +218,7 @@ namespace CutTheRopeDX.GameMain
         public void LevelFirstStart()
         {
             View view = GetView(0);
+            navigationExitActive = false;
             ((BoxOpenClose)view.GetChild(4)).LevelFirstStart();
             EnterOverlayMode(GameControllerOverlayMode.Gameplay);
         }
@@ -221,6 +229,7 @@ namespace CutTheRopeDX.GameMain
         public void LevelStart()
         {
             View view = GetView(0);
+            navigationExitActive = false;
             ((BoxOpenClose)view.GetChild(4)).LevelStart();
             EnterOverlayMode(GameControllerOverlayMode.Gameplay);
         }
@@ -231,6 +240,7 @@ namespace CutTheRopeDX.GameMain
         public void LevelQuit()
         {
             View view = GetView(0);
+            navigationExitActive = true;
             EnterOverlayMode(GameControllerOverlayMode.Results);
             ((BoxOpenClose)view.GetChild(4)).LevelQuit();
         }
@@ -591,6 +601,11 @@ namespace CutTheRopeDX.GameMain
         /// <returns>The semantic command allowed in the current state.</returns>
         private GameControllerInputCommand ResolveInput(GameControllerInputKind input)
         {
+            if (navigationExitActive)
+            {
+                return GameControllerInputCommand.Ignore;
+            }
+
             GameScene gameScene = (GameScene)GetView(0).GetChild(GameView.VIEW_ELEMENT_GAME_SCENE);
             return GameControllerInput.Resolve(
                 input,
@@ -619,6 +634,7 @@ namespace CutTheRopeDX.GameMain
                     CTRRootController.LogEvent("IM_CONTINUE_PRESSED");
                     return;
                 case GameControllerInputCommand.ExitResults:
+                    navigationExitActive = true;
                     CTRSoundMgr.PlaySound(Resources.Snd.Tap);
                     exitCode = EXIT_CODE_FROM_PAUSE_MENU_LEVEL_SELECT;
                     CTRSoundMgr.StopAll();
@@ -977,6 +993,9 @@ namespace CutTheRopeDX.GameMain
 
         /// <summary>Whether the initial overlay presentation has been applied to the created view.</summary>
         private bool overlayModeApplied;
+
+        /// <summary>Whether controller navigation has begun and further Back/Menu input must be ignored.</summary>
+        private bool navigationExitActive;
 
         /// <summary>Exit code describing the selected controller deactivation route.</summary>
         public int exitCode;

--- a/CutTheRopeDX/GameMain/GameController.cs
+++ b/CutTheRopeDX/GameMain/GameController.cs
@@ -611,7 +611,8 @@ namespace CutTheRopeDX.GameMain
                 input,
                 overlayMode,
                 gameScene.gameplayFlow.Phase,
-                gameScene.gameplayFlow.TransitionActive);
+                gameScene.gameplayFlow.TransitionActive,
+                resultExitAllowed: !CustomLevelSession.IsActive);
         }
 
         /// <summary>Executes one semantic controller input command.</summary>

--- a/CutTheRopeDX/GameMain/GameController.cs
+++ b/CutTheRopeDX/GameMain/GameController.cs
@@ -52,7 +52,7 @@ namespace CutTheRopeDX.GameMain
             if (kind == CustomLevelReloadKind.Instant)
             {
                 GameScene scene = (GameScene)GetView(0).GetChild(0);
-                if (!scene.IsEnabled())
+                if (overlayMode != GameControllerOverlayMode.Gameplay)
                 {
                     LevelStart();
                 }

--- a/CutTheRopeDX/GameMain/GameControllerInput.cs
+++ b/CutTheRopeDX/GameMain/GameControllerInput.cs
@@ -39,12 +39,14 @@ namespace CutTheRopeDX.GameMain
         /// <param name="overlay">Current controller overlay.</param>
         /// <param name="restartPhase">Authoritative restart phase.</param>
         /// <param name="outcomeTransitionActive">Whether a win/loss transition is active.</param>
+        /// <param name="resultExitAllowed">Whether Back may leave a stable result screen.</param>
         /// <returns>The semantic command allowed by the current state.</returns>
         public static GameControllerInputCommand Resolve(
             GameControllerInputKind input,
             GameControllerOverlayMode overlay,
             RestartPhase restartPhase,
-            bool outcomeTransitionActive)
+            bool outcomeTransitionActive,
+            bool resultExitAllowed)
         {
             return restartPhase != RestartPhase.Playing || outcomeTransitionActive
                 ? GameControllerInputCommand.Ignore
@@ -52,7 +54,7 @@ namespace CutTheRopeDX.GameMain
                 {
                     (GameControllerOverlayMode.Gameplay, _) => GameControllerInputCommand.OpenPause,
                     (GameControllerOverlayMode.Paused, GameControllerInputKind.Back or GameControllerInputKind.Menu) => GameControllerInputCommand.Resume,
-                    (GameControllerOverlayMode.Results, GameControllerInputKind.Back) => GameControllerInputCommand.ExitResults,
+                    (GameControllerOverlayMode.Results, GameControllerInputKind.Back) when resultExitAllowed => GameControllerInputCommand.ExitResults,
                     _ => GameControllerInputCommand.Ignore,
                 };
         }

--- a/CutTheRopeDX/GameMain/GameControllerInput.cs
+++ b/CutTheRopeDX/GameMain/GameControllerInput.cs
@@ -1,10 +1,62 @@
 namespace CutTheRopeDX.GameMain
 {
+    /// <summary>Platform or HUD input that may affect the controller overlay.</summary>
+    internal enum GameControllerInputKind
+    {
+        /// <summary>Back or Escape input.</summary>
+        Back,
+
+        /// <summary>Platform Menu input.</summary>
+        Menu,
+
+        /// <summary>Gameplay HUD pause button.</summary>
+        PauseButton,
+    }
+
+    /// <summary>Semantic action selected by the controller input policy.</summary>
+    internal enum GameControllerInputCommand
+    {
+        /// <summary>Leave controller state unchanged.</summary>
+        Ignore,
+
+        /// <summary>Open the pause overlay.</summary>
+        OpenPause,
+
+        /// <summary>Resume gameplay from pause.</summary>
+        Resume,
+
+        /// <summary>Leave a stable result screen.</summary>
+        ExitResults,
+    }
+
     /// <summary>
     /// Pure input routing decisions for the game controller.
     /// </summary>
     internal static class GameControllerInput
     {
+        /// <summary>Resolves controller input into a semantic command.</summary>
+        /// <param name="input">Input source.</param>
+        /// <param name="overlay">Current controller overlay.</param>
+        /// <param name="restartPhase">Authoritative restart phase.</param>
+        /// <param name="outcomeTransitionActive">Whether a win/loss transition is active.</param>
+        /// <returns>The semantic command allowed by the current state.</returns>
+        public static GameControllerInputCommand Resolve(
+            GameControllerInputKind input,
+            GameControllerOverlayMode overlay,
+            RestartPhase restartPhase,
+            bool outcomeTransitionActive)
+        {
+            return restartPhase != RestartPhase.Playing || outcomeTransitionActive
+                ? GameControllerInputCommand.Ignore
+                : (overlay, input) switch
+                {
+                    (GameControllerOverlayMode.Gameplay, _) => GameControllerInputCommand.OpenPause,
+                    (GameControllerOverlayMode.Paused, GameControllerInputKind.Back or GameControllerInputKind.Menu) => GameControllerInputCommand.Resume,
+                    (GameControllerOverlayMode.Results, GameControllerInputKind.Back) => GameControllerInputCommand.ExitResults,
+                    _ => GameControllerInputCommand.Ignore,
+                };
+        }
+
         /// <summary>
         /// Returns whether the pause menu may be opened from gameplay.
         /// </summary>

--- a/CutTheRopeDX/GameMain/GameControllerInput.cs
+++ b/CutTheRopeDX/GameMain/GameControllerInput.cs
@@ -57,32 +57,5 @@ namespace CutTheRopeDX.GameMain
                 };
         }
 
-        /// <summary>
-        /// Returns whether the pause menu may be opened from gameplay.
-        /// </summary>
-        /// <param name="gameplayHudTouchable">Whether the gameplay HUD is accepting input.</param>
-        /// <param name="outcomeTransitionActive">Whether a game win/loss transition is currently active.</param>
-        /// <param name="restartDimActive">Whether a restart dim is playing.</param>
-        /// <returns><see langword="true"/> when the pause menu may open.</returns>
-        /// <remarks>
-        /// Pausing mid-dim would have to suspend and resume a partly-finished restart. Refusing
-        /// for the ~0.15s the dim lasts avoids that state entirely, and matches the loss-triggered
-        /// restart, which is already unpausable via <paramref name="outcomeTransitionActive"/>.
-        /// </remarks>
-        public static bool CanPauseFromGameplay(bool gameplayHudTouchable, bool outcomeTransitionActive, bool restartDimActive)
-        {
-            return gameplayHudTouchable && !outcomeTransitionActive && !restartDimActive;
-        }
-
-        /// <summary>
-        /// Returns whether Back/Escape may leave the result screen.
-        /// </summary>
-        /// <param name="resultTouchable">Whether the result screen is accepting input.</param>
-        /// <param name="outcomeTransitionActive">Whether a game win/loss transition is currently active.</param>
-        /// <returns><see langword="true"/> when the result screen is stable enough to handle Back/Escape.</returns>
-        public static bool CanExitResultWithBack(bool resultTouchable, bool outcomeTransitionActive)
-        {
-            return resultTouchable && !outcomeTransitionActive;
-        }
     }
 }

--- a/CutTheRopeDX/GameMain/GameControllerOverlayMode.cs
+++ b/CutTheRopeDX/GameMain/GameControllerOverlayMode.cs
@@ -1,0 +1,15 @@
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>Controller-owned presentation mode for gameplay overlays.</summary>
+    internal enum GameControllerOverlayMode
+    {
+        /// <summary>The level accepts gameplay input and updates normally.</summary>
+        Gameplay,
+
+        /// <summary>The pause menu is visible and gameplay is suspended.</summary>
+        Paused,
+
+        /// <summary>The result flow owns the screen and gameplay is frozen.</summary>
+        Results,
+    }
+}

--- a/CutTheRopeDX/GameMain/MenuController.cs
+++ b/CutTheRopeDX/GameMain/MenuController.cs
@@ -1620,6 +1620,7 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         public void PreLevelSelect()
         {
+            levelLaunchPending = false;
             CTRResourceMgr cTRResourceMgr = Application.SharedResourceMgr();
             string[] array = PackConfig.GetBoxCovers(pack);
             cTRResourceMgr.InitLoading();
@@ -1669,6 +1670,11 @@ namespace CutTheRopeDX.GameMain
         /// <param name="n">Menu button identifier that was pressed.</param>
         public void OnButtonPressed(MenuButtonId n)
         {
+            if (n.IsLevelButton() && levelLaunchPending)
+            {
+                return;
+            }
+
             if (n.Value != -1)
             {
                 CTRSoundMgr.PlaySound(Resources.Snd.Tap);
@@ -1676,6 +1682,7 @@ namespace CutTheRopeDX.GameMain
 
             if (n.IsLevelButton())
             {
+                levelLaunchPending = true;
                 level = n.GetLevelIndex();
                 ActiveView().GetChildWithName("levelsBox").PlayTimeline(0);
                 ActiveView().GetChildWithName("shadow").PlayTimeline(0);
@@ -2366,6 +2373,9 @@ namespace CutTheRopeDX.GameMain
 
         /// <summary>Current level index used for gameplay launch.</summary>
         private int level;
+
+        /// <summary>Whether a level selection is already transitioning into its launch flow.</summary>
+        private bool levelLaunchPending;
 
         /// <summary>View identifier to show when the menu controller is activated.</summary>
         public int viewToShow;


### PR DESCRIPTION
## Description

- Add explicit Gameplay, Paused, and Results overlay modes to `GameController`
- Centralize Back, Menu, and pause-button routing through semantic input commands
- Ignore controller input during restart, outcome, and navigation-exit transitions
- Ignore Escape/Back on custom-level result screens
- Prevent repeated level-selection clicks from restarting the launch transition
- Remove legacy pause-state and UI-driven navigation authorities