### PR TITLE
refactor: Refactor candy removal into an atomic retirement transaction

### DIFF
--- a/CutTheRopeDX.Tests/Interactions/EatenRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/EatenRowTests.cs
@@ -63,12 +63,15 @@ namespace CutTheRopeDX.Tests.Interactions
         }
 
         [Fact]
-        public void EatenLeavesTheEatenCandyRidingTheAntLane()
+        public void EatenDetachesTheCandyFromTheAntLane()
         {
             (GameScene scene, CandyContext candy) = Rig(s => s.Ants(120, 200, path: "80,0"));
             Act.CarryByAnts(scene, candy);
             Act.Eat(scene, candy);
-            Assert.NotNull(candy.antSegment);
+            Assert.Null(candy.antSegment);
+            Assert.Null(candy.lastAntSegment);
+            Assert.False(candy.antWaitForFly);
+            Assert.Equal(0f, candy.antCooldown);
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/Interactions/LostRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/LostRowTests.cs
@@ -9,10 +9,7 @@ namespace CutTheRopeDX.Tests.Interactions
 {
     /// <summary>
     /// Interaction matrix, "Lost" row: a candy destroyed on spikes takes its attachments down with
-    /// it, partly through the break itself and partly through the GameLost that follows. The row
-    /// names a second trigger - leaving the screen - which runs a thinner path of its own: it cuts
-    /// the ropes and exhausts the rocket like the break does, but leaves the snail riding, exactly
-    /// as iOS does (breakCandy: detaches snails and hands; the off-screen block does neither).
+    /// it. Both spikes and leaving the screen must retire every attachment owned by that candy.
     /// </summary>
     public sealed class LostRowTests
     {
@@ -79,14 +76,17 @@ namespace CutTheRopeDX.Tests.Interactions
         }
 
         [Fact]
-        public void LostLeavesTheBrokenCandyRidingTheAntLane()
+        public void LostDetachesTheBrokenCandyFromTheAntLane()
         {
             (GameScene scene, CandyContext candy) = Rig(s => s.Ants(120, 200, path: "80,0"));
             Act.CarryByAnts(scene, candy);
 
             Act.BreakOnSpikes(scene, candy);
 
-            Assert.NotNull(candy.antSegment);
+            Assert.Null(candy.antSegment);
+            Assert.Null(candy.lastAntSegment);
+            Assert.False(candy.antWaitForFly);
+            Assert.Equal(0f, candy.antCooldown);
         }
 
         [Fact]
@@ -126,16 +126,14 @@ namespace CutTheRopeDX.Tests.Interactions
         }
 
         [Fact]
-        public void LostOffScreenLeavesItsSnailAttached()
+        public void LostOffScreenDetachesItsSnail()
         {
             (GameScene scene, CandyContext candy) = Rig(s => s.Snail(160, 200));
             _ = Act.RideSnail(scene, candy);
 
             Act.LoseOffScreen(scene, candy);
 
-            // Same split as the rope: the off-screen path never calls DetachSnailsForPoint, and
-            // GameLost only tears down hands and mice.
-            Assert.Equal(1, scene.SnailCount(candy));
+            Assert.Equal(0, scene.SnailCount(candy));
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/Interactions/LostRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/LostRowTests.cs
@@ -102,6 +102,28 @@ namespace CutTheRopeDX.Tests.Interactions
         }
 
         [Fact]
+        public void RepeatedHazardOverlapRetiresAndPresentsTheCandyOnlyOnce()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Ants(120, 200, path: "80,0"));
+            Act.CarryByAnts(scene, candy);
+
+            // Two hazards may discover the same body before the next active-body enumeration. Drive
+            // the real hazard entry point twice to require its lifecycle transition to be the gate
+            // for cleanup, break presentation, and delayed loss scheduling.
+            scene.BreakCandyBody(candy.WholeBody);
+            scene.BreakCandyBody(candy.WholeBody);
+
+            Assert.Equal(CandyRemovalReason.Hazard, candy.Lifecycle.RemovalReason);
+            Assert.Equal(1, scene.CandyBreakEffectCount());
+            scene.AssertNoLiveAttachments(candy);
+            Assert.True(
+                Interaction.StepUntil(scene, () => scene.Outcomes().LostCount > 0),
+                "the broken candy never lost the level");
+            HeadlessGame.StepFrames(scene, 60);
+            Assert.Equal(1, scene.Outcomes().LostCount);
+        }
+
+        [Fact]
         public void LostOffScreenExhaustsItsRocket()
         {
             (GameScene scene, CandyContext candy) = Rig(s => s.Rocket(160, 200, impulse: 0f));

--- a/CutTheRopeDX.Tests/Interactions/LostRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/LostRowTests.cs
@@ -124,6 +124,70 @@ namespace CutTheRopeDX.Tests.Interactions
         }
 
         [Fact]
+        public void HazardRetirementClearsAntCooldownStateAfterTheCarrierLetsGo()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Ants(150, 200, path: "20,0", moveSpeed: 600f));
+            Act.CarryByAnts(scene, candy);
+            Assert.True(
+                Interaction.StepUntil(scene, () => candy.antSegment == null && candy.lastAntSegment != null),
+                "the candy never entered the ant reattachment-cooldown state");
+
+            scene.BreakCandyBody(candy.WholeBody);
+
+            Assert.Null(candy.antSegment);
+            Assert.Null(candy.lastAntSegment);
+            Assert.False(candy.antWaitForFly);
+            Assert.Equal(0f, candy.antCooldown);
+        }
+
+        [Fact]
+        public void HazardRetirementClearsMouseContextOwnershipImmediately()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Mouse(160, 200));
+            _ = Act.CarryByMouse(scene, candy);
+
+            scene.BreakCandyBody(candy.WholeBody);
+
+            Assert.False(scene.MouseCarries(candy));
+            Assert.False(candy.carriedByMouse);
+        }
+
+        [Fact]
+        public void HazardRetirementCancelsPendingLanternCapture()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Lantern(20, 40));
+            Lantern lantern = Lantern.GetAllLanterns()[0];
+            Assert.True(
+                Interaction.StepUntil(
+                    scene,
+                    () => Act.MoveTo(lantern, candy.WholeBody.Point.pos),
+                    () => candy.inLantern),
+                "the lantern never began capturing the candy");
+
+            scene.BreakCandyBody(candy.WholeBody);
+
+            Assert.False(candy.inLantern);
+            Assert.False(candy.WholeBody.Point.disableGravity);
+            HeadlessGame.StepFrames(scene, 10);
+            Assert.False(candy.inLantern);
+            Assert.False(candy.WholeBody.Point.disableGravity);
+        }
+
+        [Fact]
+        public void HazardRetirementCancelsCompletedLanternCapture()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Lantern(20, 40));
+            Act.CaptureInLantern(scene, candy);
+
+            scene.BreakCandyBody(candy.WholeBody);
+
+            Assert.False(candy.inLantern);
+            Assert.False(candy.WholeBody.Point.disableGravity);
+            HeadlessGame.StepFrames(scene, 10);
+            Assert.False(candy.WholeBody.Point.disableGravity);
+        }
+
+        [Fact]
         public void LostOffScreenExhaustsItsRocket()
         {
             (GameScene scene, CandyContext candy) = Rig(s => s.Rocket(160, 200, impulse: 0f));

--- a/CutTheRopeDX.Tests/Interactions/LostRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/LostRowTests.cs
@@ -148,6 +148,18 @@ namespace CutTheRopeDX.Tests.Interactions
         }
 
         [Fact]
+        public void LostOffScreenClearsItsBubbleOwnership()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s.Bubble(160, 200));
+            _ = Act.CaptureInBubble(scene, candy);
+
+            Act.LoseOffScreen(scene, candy);
+
+            Assert.Null(candy.WholeBody.Bubble);
+            Assert.False(candy.WholeBody.Point.disableGravity);
+        }
+
+        [Fact]
         public void LostOffScreenDetachesItsSnail()
         {
             (GameScene scene, CandyContext candy) = Rig(s => s.Snail(160, 200));
@@ -156,6 +168,30 @@ namespace CutTheRopeDX.Tests.Interactions
             Act.LoseOffScreen(scene, candy);
 
             Assert.Equal(0, scene.SnailCount(candy));
+        }
+
+        [Fact]
+        public void LosingOneCandyOffScreenDoesNotAlterAnotherCandysBubble()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(60, 200, number: "1")
+                .Candy(260, 200, number: "2")
+                .Snail(60, 200)
+                .Bubble(260, 200)
+                .OmNom(20, 460)
+                .Build();
+            CandyContext lost = scene.Candies()[0];
+            CandyContext kept = scene.Candies()[1];
+            Interaction.Hover(lost);
+            Interaction.Hover(kept);
+            _ = Act.RideSnail(scene, lost);
+            Bubble bubble = Act.CaptureInBubble(scene, kept);
+
+            Act.LoseOffScreen(scene, lost);
+
+            Assert.Equal(0, scene.SnailCount(lost));
+            Assert.Same(bubble, kept.WholeBody.Bubble);
+            Assert.Equal(CandyPresence.Present, kept.Lifecycle.Presence);
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/Interactions/PerCandyIsolationTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/PerCandyIsolationTests.cs
@@ -37,6 +37,30 @@ namespace CutTheRopeDX.Tests.Interactions
         }
 
         [Fact]
+        public void EatingOneOfTwoCandiesImmediatelyDetachesItsAntCarrier()
+        {
+            AssertPreWinEatenCleanup(
+                s => s.Ants(20, 200, path: "80,0"),
+                Act.CarryByAnts);
+        }
+
+        [Fact]
+        public void EatingOneOfTwoCandiesImmediatelyDetachesItsHand()
+        {
+            AssertPreWinEatenCleanup(
+                s => s.Hand(60, 120, segmentLength: 20, segmentAngle: 90f),
+                (scene, candy) => _ = Act.GrabWithHand(scene, candy));
+        }
+
+        [Fact]
+        public void EatingOneOfTwoCandiesImmediatelyDropsItsMouseCarrier()
+        {
+            AssertPreWinEatenCleanup(
+                s => s.Mouse(60, 200),
+                (scene, candy) => _ = Act.CarryByMouse(scene, candy));
+        }
+
+        [Fact]
         public void LanternCapturingOneCandyLeavesTheOtherCandysBubble()
         {
             (GameScene scene, CandyContext captured, CandyContext kept) = TwoCandies(s => s
@@ -109,6 +133,30 @@ namespace CutTheRopeDX.Tests.Interactions
             Interaction.Hover(first);
             Interaction.Hover(second);
             return (scene, first, second);
+        }
+
+        private static void AssertPreWinEatenCleanup(
+            System.Func<Scenario, Scenario> extras,
+            System.Action<GameScene, CandyContext> attach)
+        {
+            GameScene scene = extras(
+                    Scenario.New()
+                        .Candy(60, 200, number: "1")
+                        .Candy(260, 200, number: "2")
+                        .OmNom(20, 460)
+                        .OmNom(300, 460))
+                .Build();
+            CandyContext eaten = scene.Candies()[0];
+            CandyContext remaining = scene.Candies()[1];
+            Interaction.Hover(eaten);
+            Interaction.Hover(remaining);
+            attach(scene, eaten);
+
+            Act.Eat(scene, eaten);
+
+            Assert.Equal(0, scene.Outcomes().WonCount);
+            Assert.Equal(CandyPresence.Present, remaining.Lifecycle.Presence);
+            scene.AssertNoLiveAttachments(eaten);
         }
     }
 }

--- a/CutTheRopeDX.Tests/Interactions/PerCandyIsolationTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/PerCandyIsolationTests.cs
@@ -37,6 +37,21 @@ namespace CutTheRopeDX.Tests.Interactions
         }
 
         [Fact]
+        public void RetiringAnotherCandyDoesNotReleaseThePrimarysParkedGhostBubble()
+        {
+            (GameScene scene, CandyContext primary, CandyContext removed) = TwoCandies(s => s
+                .Bubble(260, 200)
+                .Bubble(20, 40));
+            _ = Act.CaptureInBubble(scene, removed, bubbleIndex: 0);
+            Bubble parked = scene.Bubbles()[1];
+            scene.ParkSecondGhostBubble(primary.WholeBody, parked);
+
+            scene.BreakCandyBody(removed.WholeBody);
+
+            Assert.Same(parked, scene.PendingSecondGhostBubble());
+        }
+
+        [Fact]
         public void EatingOneOfTwoCandiesImmediatelyDetachesItsAntCarrier()
         {
             AssertPreWinEatenCleanup(

--- a/CutTheRopeDX.Tests/Interactions/Scenario.cs
+++ b/CutTheRopeDX.Tests/Interactions/Scenario.cs
@@ -78,6 +78,20 @@ namespace CutTheRopeDX.Tests.Interactions
             return Add(candy);
         }
 
+        /// <summary>Adds a numbered light-emitting candy body.</summary>
+        /// <param name="x">Level-space X.</param>
+        /// <param name="y">Level-space Y.</param>
+        /// <param name="number">Bulb key used by authored ropes.</param>
+        /// <param name="litRadius">Illumination radius in level units.</param>
+        /// <returns>This scenario.</returns>
+        public Scenario LightBulb(int x, int y, string number = "first", int litRadius = 100)
+        {
+            XElement bulb = Node("lightBulb", x, y);
+            bulb.SetAttributeValue("bulbNumber", number);
+            bulb.SetAttributeValue("litRadius", Num(litRadius));
+            return Add(bulb);
+        }
+
         /// <summary>
         /// Makes the primary candy a split candy: turns on the level's <c>twoParts</c> design flag
         /// and emits the <c>&lt;candyL&gt;</c>/<c>&lt;candyR&gt;</c> halves that the loader hands to
@@ -138,6 +152,8 @@ namespace CutTheRopeDX.Tests.Interactions
         /// <param name="path">Mover path string (makes it a bee), e.g. "L,60,0".</param>
         /// <param name="moveSpeed">Mover speed for <paramref name="path"/>.</param>
         /// <param name="candyNumber">Optional candy key to bind the rope to.</param>
+        /// <param name="bindBulb">Whether this rope binds a numbered light emitter.</param>
+        /// <param name="bulbNumber">Light-emitter key when <paramref name="bindBulb"/> is true.</param>
         /// <param name="breakable">Whether the rope can be cut by an ordinary swipe.</param>
         /// <returns>This scenario.</returns>
         public Scenario Grab(
@@ -155,6 +171,8 @@ namespace CutTheRopeDX.Tests.Interactions
             string path = null,
             float moveSpeed = 0f,
             string candyNumber = null,
+            bool bindBulb = false,
+            string bulbNumber = null,
             bool breakable = true)
         {
             XElement grab = Node("grab", x, y);
@@ -171,6 +189,11 @@ namespace CutTheRopeDX.Tests.Interactions
             grab.SetAttributeValue("moveOffset", Num(0));
             grab.SetAttributeValue("part", "L");
             grab.SetAttributeValue("breakable", Flag(breakable));
+            grab.SetAttributeValue("bindBulb", Flag(bindBulb));
+            if (bulbNumber != null)
+            {
+                grab.SetAttributeValue("bulbNumber", bulbNumber);
+            }
             if (kickable)
             {
                 grab.SetAttributeValue("kickable", Flag(true));

--- a/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
+++ b/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 using CutTheRopeDX.Framework.Core;
 using CutTheRopeDX.Framework.Physics;
+using CutTheRopeDX.Framework.Visual;
 using CutTheRopeDX.GameMain;
 
 using Xunit;
@@ -291,6 +293,25 @@ namespace CutTheRopeDX.Tests.Interactions
             Assert.Equal(0, scene.SnailCount(candy));
             Assert.False(candy.inLantern);
             Assert.False(candy.WholeBody.Point.disableGravity);
+        }
+
+        /// <summary>Invokes the scene's hazard entry point to model repeated overlap in one update.</summary>
+        /// <param name="scene">Scene whose hazard path is invoked.</param>
+        /// <param name="body">Body intersecting the hazard.</param>
+        public static void BreakCandyBody(this GameScene scene, CandyBody body)
+        {
+            MethodInfo method = typeof(GameScene).GetMethod("BreakCandyBody", Instance)
+                ?? throw new MissingMethodException(nameof(GameScene), "BreakCandyBody");
+            _ = method.Invoke(scene, [body]);
+        }
+
+        /// <summary>Number of live candy-break particle systems in the scene animation pool.</summary>
+        /// <param name="scene">Scene to inspect.</param>
+        /// <returns>The live candy-break effect count.</returns>
+        public static int CandyBreakEffectCount(this GameScene scene)
+        {
+            AnimationsPool pool = Field<AnimationsPool>(scene, "aniPool");
+            return pool.GetChilds().Values.OfType<CandyBreak>().Count();
         }
 
         /// <summary>Whether any conveyor belt has bound the given grab.</summary>

--- a/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
+++ b/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
@@ -335,6 +335,18 @@ namespace CutTheRopeDX.Tests.Interactions
                 .Count(animation => ReferenceEquals(animation.texture, bubbleTexture));
         }
 
+        /// <summary>Number of live spider victory images in the scene animation pool.</summary>
+        /// <param name="scene">Scene to inspect.</param>
+        /// <returns>The live spider victory-image count.</returns>
+        public static int SpiderVictoryEffectCount(this GameScene scene)
+        {
+            AnimationsPool pool = Field<AnimationsPool>(scene, "aniPool");
+            CTRTexture2D spiderTexture = Application.GetTexture(Resources.Img.ObjSpider);
+            return pool.GetChilds().Values
+                .OfType<Image>()
+                .Count(effect => ReferenceEquals(effect.texture, spiderTexture) && effect.GetChilds().Count > 0);
+        }
+
         /// <summary>Whether any conveyor belt has bound the given grab.</summary>
         /// <param name="scene">Scene to read.</param>
         /// <param name="grab">Grab to inspect.</param>

--- a/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
+++ b/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 
 using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.Framework.Helpers;
 using CutTheRopeDX.Framework.Physics;
 using CutTheRopeDX.Framework.Visual;
 using CutTheRopeDX.GameMain;
@@ -345,6 +346,28 @@ namespace CutTheRopeDX.Tests.Interactions
             return pool.GetChilds().Values
                 .OfType<Image>()
                 .Count(effect => ReferenceEquals(effect.texture, spiderTexture) && effect.GetChilds().Count > 0);
+        }
+
+        /// <summary>
+        /// Parks a second merged ghost bubble for an owner. Scenario XML cannot directly author the
+        /// transient two-ghost post-merge state, so this probe establishes only that private state.
+        /// </summary>
+        public static void ParkSecondGhostBubble(this GameScene scene, CandyBody owner, GameObject bubble)
+        {
+            FieldInfo bubbleField = typeof(GameScene).GetField("pendingSecondGhostBubble", Instance)
+                ?? throw new MissingFieldException(nameof(GameScene), "pendingSecondGhostBubble");
+            bubbleField.SetValue(scene, bubble);
+
+            // The owner field is introduced by the invariant fix. Keeping this setup compatible
+            // with the pre-fix shape lets the isolation test first demonstrate the failure.
+            FieldInfo ownerField = typeof(GameScene).GetField("pendingSecondGhostBubbleOwner", Instance);
+            ownerField?.SetValue(scene, owner);
+        }
+
+        /// <summary>Gets the ghost bubble parked behind a merged candy's active ghost bubble.</summary>
+        public static GameObject PendingSecondGhostBubble(this GameScene scene)
+        {
+            return Field<GameObject>(scene, "pendingSecondGhostBubble");
         }
 
         /// <summary>Whether any conveyor belt has bound the given grab.</summary>

--- a/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
+++ b/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
@@ -6,6 +6,8 @@ using CutTheRopeDX.Framework.Core;
 using CutTheRopeDX.Framework.Physics;
 using CutTheRopeDX.GameMain;
 
+using Xunit;
+
 namespace CutTheRopeDX.Tests.Interactions
 {
     /// <summary>
@@ -271,6 +273,24 @@ namespace CutTheRopeDX.Tests.Interactions
             MiceObject mice = Field<MiceObject>(scene, "miceManager");
             ConstraintedPoint carried = mice?.ActiveMouseCarriedStar();
             return carried != null && carried == candy.WholeBody.Point;
+        }
+
+        /// <summary>Asserts that a retired whole candy has no observable live attachment owner.</summary>
+        /// <param name="scene">Scene that owned the candy.</param>
+        /// <param name="candy">Retired candy to inspect.</param>
+        public static void AssertNoLiveAttachments(this GameScene scene, CandyContext candy)
+        {
+            Assert.Equal(0, scene.AttachedRopeCount(candy));
+            Assert.Null(candy.WholeBody.Bubble);
+            Assert.Null(candy.activeRocket);
+            Assert.Null(candy.capturingHand);
+            Assert.False(scene.MouseCarries(candy));
+            Assert.False(candy.carriedByMouse);
+            Assert.Null(candy.antSegment);
+            Assert.Null(candy.lastAntSegment);
+            Assert.Equal(0, scene.SnailCount(candy));
+            Assert.False(candy.inLantern);
+            Assert.False(candy.WholeBody.Point.disableGravity);
         }
 
         /// <summary>Whether any conveyor belt has bound the given grab.</summary>

--- a/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
+++ b/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
@@ -245,10 +245,19 @@ namespace CutTheRopeDX.Tests.Interactions
         /// <returns>The number of uncut ropes whose tail is this candy.</returns>
         public static int AttachedRopeCount(this GameScene scene, CandyContext candy)
         {
+            return scene.AttachedRopeCount(candy.WholeBody);
+        }
+
+        /// <summary>Ropes still attached (uncut) to the exact candy body.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <param name="body">Body to inspect.</param>
+        /// <returns>The number of uncut ropes whose tail is this body's point.</returns>
+        public static int AttachedRopeCount(this GameScene scene, CandyBody body)
+        {
             int count = 0;
             foreach (Grab grab in scene.Grabs())
             {
-                if (grab.Rope != null && grab.Rope.tail == candy.WholeBody.Point && grab.Rope.cut == -1)
+                if (grab.Rope != null && grab.Rope.tail == body.Point && grab.Rope.cut == -1)
                 {
                     count++;
                 }
@@ -312,6 +321,18 @@ namespace CutTheRopeDX.Tests.Interactions
         {
             AnimationsPool pool = Field<AnimationsPool>(scene, "aniPool");
             return pool.GetChilds().Values.OfType<CandyBreak>().Count();
+        }
+
+        /// <summary>Number of live bubble-pop animations in the scene animation pool.</summary>
+        /// <param name="scene">Scene to inspect.</param>
+        /// <returns>The live bubble-pop effect count.</returns>
+        public static int BubblePopEffectCount(this GameScene scene)
+        {
+            AnimationsPool pool = Field<AnimationsPool>(scene, "aniPool");
+            CTRTexture2D bubbleTexture = Application.GetTexture(Resources.Img.ObjBubble);
+            return pool.GetChilds().Values
+                .OfType<Animation>()
+                .Count(animation => ReferenceEquals(animation.texture, bubbleTexture));
         }
 
         /// <summary>Whether any conveyor belt has bound the given grab.</summary>

--- a/CutTheRopeDX.Tests/Interactions/SpiderRemovalInvariantTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/SpiderRemovalInvariantTests.cs
@@ -1,0 +1,139 @@
+using System;
+
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>Spider capture must retire the exact candy and all of its live attachment owners.</summary>
+    public sealed class SpiderRemovalInvariantTests
+    {
+        [Fact]
+        public void SpiderCaptureClearsBubbleOwnership()
+        {
+            AssertSpiderRetires(s => s.Bubble(160, 200), (scene, candy) => _ = Act.CaptureInBubble(scene, candy));
+        }
+
+        [Fact]
+        public void SpiderCaptureClearsRocketOwnership()
+        {
+            AssertSpiderRetires(s => s.Rocket(160, 200, impulse: 0f), (scene, candy) => _ = Act.BindRocket(scene, candy));
+        }
+
+        [Fact]
+        public void SpiderCaptureClearsSnailOwnership()
+        {
+            AssertSpiderRetires(s => s.Snail(160, 200), (scene, candy) => _ = Act.RideSnail(scene, candy));
+        }
+
+        [Fact]
+        public void SpiderCaptureClearsAntOwnership()
+        {
+            // A pre-attached fixed rope pulls the candy off the narrow ant lane before pickup. Use
+            // the real radius-hook path instead: let the ants acquire it first, then move the
+            // spider hook into range so the reachable ant-plus-spider-rope composition is formed.
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .Grab(20, 20, radius: 100f, spider: true, moveLength: -1f)
+                .Ants(120, 200, path: "80,0")
+                .OmNom(20, 460)
+                .Build();
+            CandyContext candy = scene.Candy();
+            Grab spiderGrab = scene.Grabs()[0];
+            Interaction.Hover(candy);
+            Act.CarryByAnts(scene, candy);
+            Act.MoveTo(spiderGrab, candy.WholeBody.Point.pos);
+            Assert.True(
+                Interaction.StepUntil(scene, () => spiderGrab.Rope != null),
+                "the radius spider hook never attached to the ant-carried candy");
+
+            scene.SpiderWon(spiderGrab);
+
+            Assert.Equal(SpiderRiderState.Won, spiderGrab.Spider.State);
+            scene.AssertNoLiveAttachments(candy);
+        }
+
+        [Fact]
+        public void SpiderCaptureClearsHandOwnership()
+        {
+            AssertSpiderRetires(
+                s => s.Hand(160, 120, segmentLength: 20, segmentAngle: 90f),
+                (scene, candy) => _ = Act.GrabWithHand(scene, candy));
+        }
+
+        [Fact]
+        public void SpiderCaptureClearsMouseOwnership()
+        {
+            // Mouse pickup always severs every rope on the candy, including the spider's, so a
+            // same-body mouse-plus-spider capture is not reachable through the update loop. The
+            // nearest reachable composition proves that retiring the spidered candy leaves the
+            // mouse's exact-point ownership of another candy intact.
+            GameScene scene = Scenario.New()
+                .Candy(80, 200, number: "1")
+                .Candy(240, 200, number: "2")
+                .Grab(80, 120, length: 100, spider: true, candyNumber: "1")
+                .Mouse(240, 200)
+                .OmNom(20, 460)
+                .Build();
+            CandyContext captured = scene.Candies()[0];
+            CandyContext mouseCandy = scene.Candies()[1];
+            Interaction.Hover(mouseCandy);
+            _ = Act.CarryByMouse(scene, mouseCandy);
+
+            scene.SpiderWon(scene.Grabs()[0]);
+
+            scene.AssertNoLiveAttachments(captured);
+            Assert.True(mouseCandy.carriedByMouse);
+            Assert.True(scene.MouseCarries(mouseCandy));
+        }
+
+        [Fact]
+        public void SpiderCaptureDoesNotAlterAnotherCandysAttachments()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(80, 200, number: "1")
+                .Candy(240, 200, number: "2")
+                .Grab(80, 120, length: 100, spider: true, candyNumber: "1")
+                .Rope(240, 120, length: 100, candyNumber: "2")
+                .Bubble(240, 200)
+                .OmNom(20, 460)
+                .Build();
+            CandyContext captured = scene.Candies()[0];
+            CandyContext other = scene.Candies()[1];
+            Interaction.Hover(other);
+            Bubble bubble = Act.CaptureInBubble(scene, other);
+            Assert.Equal(1, scene.AttachedRopeCount(other));
+
+            scene.SpiderWon(scene.Grabs()[0]);
+
+            scene.AssertNoLiveAttachments(captured);
+            Assert.Equal(CandyPresence.Present, other.Lifecycle.Presence);
+            Assert.Same(bubble, other.WholeBody.Bubble);
+            Assert.Equal(1, scene.AttachedRopeCount(other));
+        }
+
+        private static void AssertSpiderRetires(
+            Func<Scenario, Scenario> addAttachment,
+            Action<GameScene, CandyContext> attach)
+        {
+            GameScene scene = addAttachment(
+                    Scenario.New()
+                        .Candy(160, 200)
+                        .Grab(160, 120, length: 100, spider: true)
+                        .OmNom(20, 460))
+                .Build();
+            CandyContext candy = scene.Candy();
+            Grab spiderGrab = scene.Grabs()[0];
+            Interaction.Hover(candy);
+            attach(scene, candy);
+            Assert.Equal(1, scene.AttachedRopeCount(candy));
+
+            scene.SpiderWon(spiderGrab);
+
+            Assert.Equal(CandyRemovalReason.Spider, candy.Lifecycle.RemovalReason);
+            Assert.Equal(SpiderRiderState.Won, spiderGrab.Spider.State);
+            scene.AssertNoLiveAttachments(candy);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/SpiderRemovalInvariantTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/SpiderRemovalInvariantTests.cs
@@ -113,6 +113,53 @@ namespace CutTheRopeDX.Tests.Interactions
             Assert.Equal(1, scene.AttachedRopeCount(other));
         }
 
+        [Fact]
+        public void WinningSpiderSurvivesRopeRetirementWhileOtherSpidersBust()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .Grab(120, 120, length: 100, spider: true)
+                .Grab(200, 120, length: 100, spider: true)
+                .OmNom(20, 460)
+                .Build();
+            Grab winner = scene.Grabs()[0];
+            Grab other = scene.Grabs()[1];
+            HeadlessGame.StepFrames(scene, 1);
+            Assert.True(winner.Spider.ShouldBustOnRopeCut);
+            Assert.True(other.Spider.ShouldBustOnRopeCut);
+
+            scene.SpiderWon(winner);
+
+            Assert.Equal(SpiderRiderState.Won, winner.Spider.State);
+            Assert.Equal(SpiderRiderState.Busted, other.Spider.State);
+        }
+
+        [Fact]
+        public void SpiderOnAnAlreadyRemovedBodyCreatesNoVictoryOrCrossCandyDamage()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(60, 200, number: "1")
+                .Candy(260, 200, number: "2")
+                .Rope(60, 120, length: 100, candyNumber: "1")
+                .Grab(260, 120, length: 100, spider: true, candyNumber: "2")
+                .OmNom(20, 460)
+                .Build();
+            CandyContext kept = scene.Candies()[0];
+            CandyContext removed = scene.Candies()[1];
+            Grab staleSpider = scene.Grabs()[1];
+            Interaction.Hover(removed);
+            Act.LoseOffScreen(scene, removed);
+            int victoryEffects = scene.SpiderVictoryEffectCount();
+            Assert.Equal(1, scene.AttachedRopeCount(kept));
+
+            scene.SpiderWon(staleSpider);
+
+            Assert.Equal(victoryEffects, scene.SpiderVictoryEffectCount());
+            Assert.Equal(CandyRemovalReason.OffScreen, removed.Lifecycle.RemovalReason);
+            Assert.Equal(CandyPresence.Present, kept.Lifecycle.Presence);
+            Assert.Equal(1, scene.AttachedRopeCount(kept));
+        }
+
         private static void AssertSpiderRetires(
             Func<Scenario, Scenario> addAttachment,
             Action<GameScene, CandyContext> attach)

--- a/CutTheRopeDX.Tests/LightEmitterRemovalTests.cs
+++ b/CutTheRopeDX.Tests/LightEmitterRemovalTests.cs
@@ -1,0 +1,59 @@
+using System.Linq;
+
+using CutTheRopeDX.GameMain;
+using CutTheRopeDX.Tests.Interactions;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    /// <summary>Off-screen light emitters use the same retirement invariant as edible candy.</summary>
+    public sealed class LightEmitterRemovalTests
+    {
+        [Fact]
+        public void OffScreenLightEmitterReleasesItsRopeAndRocketBeforeLightsOut()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(60, 200)
+                .LightBulb(240, 200)
+                .Grab(240, 120, length: 100, bindBulb: true, bulbNumber: "first")
+                .Rocket(240, 200, impulse: 0f)
+                .OmNom(20, 460)
+                .Design("nightLevel", "true")
+                .Build();
+            CandyContext bulb = scene.Candies().Single(candy => candy.emitsLight);
+            Interaction.Hover(bulb);
+            _ = Act.BindRocket(scene, bulb);
+            Assert.Equal(1, scene.AttachedRopeCount(bulb));
+
+            Act.LoseOffScreen(scene, bulb);
+
+            Assert.Equal(CandyRemovalReason.OffScreen, bulb.Lifecycle.RemovalReason);
+            scene.AssertNoLiveAttachments(bulb);
+            Assert.Equal(1, scene.Outcomes().LostCount);
+        }
+
+        [Fact]
+        public void OffScreenLightEmitterSilentlyClearsItsBubbleBeforeLightsOut()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(60, 200)
+                .LightBulb(240, 200)
+                .Bubble(240, 200)
+                .OmNom(20, 460)
+                .Design("nightLevel", "true")
+                .Build();
+            CandyContext bulb = scene.Candies().Single(candy => candy.emitsLight);
+            Interaction.Hover(bulb);
+            _ = Act.CaptureInBubble(scene, bulb);
+            int bubblePopEffects = scene.BubblePopEffectCount();
+
+            Act.LoseOffScreen(scene, bulb);
+
+            Assert.Equal(CandyRemovalReason.OffScreen, bulb.Lifecycle.RemovalReason);
+            Assert.Null(bulb.WholeBody.Bubble);
+            Assert.Equal(bubblePopEffects, scene.BubblePopEffectCount());
+            Assert.Equal(1, scene.Outcomes().LostCount);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/SplitCandyLifecycleIntegrationTests.cs
+++ b/CutTheRopeDX.Tests/SplitCandyLifecycleIntegrationTests.cs
@@ -103,6 +103,30 @@ namespace CutTheRopeDX.Tests
         }
 
         [Fact]
+        public void AHalfLostOffScreenReleasesOnlyItsOwnBubbleAndRopes()
+        {
+            (GameScene scene, CandyContext primary) = SplitLevel();
+            SplitCandyState split = primary.Lifecycle.Split;
+            Assert.True(
+                Interaction.StepUntil(
+                    scene,
+                    () => split.Left.Body.Bubble != null || split.Right.Body.Bubble != null),
+                "no half ever picked up one of the level's bubbles");
+            CandyHalf removed = split.Left.Body.Bubble != null ? split.Left : split.Right;
+            CandyHalf surviving = removed == split.Left ? split.Right : split.Left;
+            int survivingRopes = scene.AttachedRopeCount(surviving.Body);
+            Assert.True(scene.AttachedRopeCount(removed.Body) > 0);
+            Assert.True(survivingRopes > 0);
+
+            DropHalfOffScreen(scene, removed);
+
+            Assert.Null(removed.Body.Bubble);
+            Assert.Equal(0, scene.AttachedRopeCount(removed.Body));
+            Assert.Null(surviving.RemovalReason);
+            Assert.Equal(survivingRopes, scene.AttachedRopeCount(surviving.Body));
+        }
+
+        [Fact]
         public void ALostHalfBlocksTheMerge()
         {
             (GameScene scene, CandyContext primary) = SplitLevel();

--- a/CutTheRopeDX/GameMain/GameScene.Ants.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Ants.cs
@@ -222,20 +222,25 @@ namespace CutTheRopeDX.GameMain
         /// <param name="ctx">The candy to detach from the conveyor.</param>
         private static void DetachCandyFromConveyor(CandyContext ctx)
         {
-            if (ctx?.antSegment == null)
+            if (ctx == null)
             {
                 return;
             }
 
-            PlayAntConveyorDetachSound();
+            if (ctx.antSegment != null)
+            {
+                PlayAntConveyorDetachSound();
 
-            // A candy can only hold a segment if it had a point when it attached.
-            ctx.WholeBody.Point.disableGravity = ctx.HasActiveRocket;
+                // A candy can only hold a segment if it had a point when it attached.
+                ctx.WholeBody.Point.disableGravity = ctx.HasActiveRocket;
+            }
 
             ctx.antWaitForFly = false;
             ctx.antSegment = null;
             ctx.lastAntSegment = null;
             ctx.antCooldown = 0f;
+            ctx.antInteractionPoint = default;
+            ctx.antInteractionTime = 0f;
         }
 
         /// <summary>

--- a/CutTheRopeDX/GameMain/GameScene.CandyRemoval.cs
+++ b/CutTheRopeDX/GameMain/GameScene.CandyRemoval.cs
@@ -1,3 +1,4 @@
+using CutTheRopeDX.Framework;
 using CutTheRopeDX.Framework.Helpers;
 using CutTheRopeDX.Framework.Physics;
 
@@ -51,17 +52,43 @@ namespace CutTheRopeDX.GameMain
                 DetachHandsForPoint(body.Point);
                 DetachSnailsForPoint(body.Point);
                 DropMouseCandyForPoint(body.Point);
+                ctx.carriedByMouse = false;
                 DetachCandyFromConveyor(ctx);
                 ExhaustRocketForCandy(ctx);
-                if (Lantern.CancelCandyCaptureForRemoval(body.Point))
-                {
-                    ctx.inLantern = false;
-                }
+                CancelPendingLanternCaptureForRemoval(body.Point);
+                _ = Lantern.CancelCandyCaptureForRemoval(body.Point);
+                ctx.inLantern = false;
             }
 
             // Carrier release ordering is deliberately closed here: no owner may leave a retired
             // point gravity-suppressed. Authored/device-specific weight is preserved.
             body.Point.disableGravity = false;
+        }
+
+        private void CancelPendingLanternCaptureForRemoval(ConstraintedPoint point)
+        {
+            if (pendingLanternCapturePoint == point)
+            {
+                pendingLanternCapturePoint = null;
+                pendingLanternCapture = null;
+            }
+        }
+
+        private void CompletePendingLanternCapture(FrameworkTypes value)
+        {
+            if (value is not ConstraintedPoint point || pendingLanternCapturePoint != point)
+            {
+                return;
+            }
+
+            Lantern lantern = pendingLanternCapture;
+            pendingLanternCapturePoint = null;
+            pendingLanternCapture = null;
+            CandyContext ctx = CandyForPointOrNull(point);
+            if (lantern != null && ctx?.inLantern == true)
+            {
+                lantern.CaptureCandy(point);
+            }
         }
 
         private void DetachRopeConstraintsForPoint(ConstraintedPoint point)
@@ -90,7 +117,13 @@ namespace CutTheRopeDX.GameMain
                 return;
             }
 
-            if (reason is CandyRemovalReason.Eaten or CandyRemovalReason.Hazard)
+            if (reason == CandyRemovalReason.Hazard)
+            {
+                PopCandyBubbleAt(body, body.Point.pos);
+                return;
+            }
+
+            if (reason == CandyRemovalReason.Eaten)
             {
                 PopCandyBubble(body);
                 return;
@@ -98,11 +131,7 @@ namespace CutTheRopeDX.GameMain
 
             GameObject released = body.Bubble;
             EnableGhostCycleForBubble(released);
-            if (pendingSecondGhostBubble != null && body.Role == CandyBodyRole.Whole)
-            {
-                EnableGhostCycleForBubble(pendingSecondGhostBubble);
-                pendingSecondGhostBubble = null;
-            }
+            ReleasePendingSecondGhostBubbleForBody(body);
 
             if (released is Bubble bubble)
             {
@@ -114,6 +143,18 @@ namespace CutTheRopeDX.GameMain
             body.Owner.lightBulb?.SyncFromContext(body.Owner);
             _ = (body.BubbleAnimation?.visible = false);
             _ = (body.GhostBubbleAnimation?.visible = false);
+        }
+
+        private void ReleasePendingSecondGhostBubbleForBody(CandyBody body)
+        {
+            if (pendingSecondGhostBubble == null || pendingSecondGhostBubbleOwner != body)
+            {
+                return;
+            }
+
+            EnableGhostCycleForBubble(pendingSecondGhostBubble);
+            pendingSecondGhostBubble = null;
+            pendingSecondGhostBubbleOwner = null;
         }
     }
 }

--- a/CutTheRopeDX/GameMain/GameScene.CandyRemoval.cs
+++ b/CutTheRopeDX/GameMain/GameScene.CandyRemoval.cs
@@ -1,4 +1,5 @@
 using CutTheRopeDX.Framework.Helpers;
+using CutTheRopeDX.Framework.Physics;
 
 namespace CutTheRopeDX.GameMain
 {
@@ -34,15 +35,14 @@ namespace CutTheRopeDX.GameMain
             };
         }
 
-        // Temporary low-level compatibility for removal callers migrated by the later plan tasks.
-        private static bool TryRemoveBody(CandyBody body, CandyRemovalReason reason)
-        {
-            return body?.Owner != null && TryCommitCandyRemoval(body, reason);
-        }
-
         private void ReleaseRemovalOwnership(CandyBody body, CandyRemovalReason reason)
         {
             ReleaseRopesForBody(body);
+            DetachRopeConstraintsForPoint(body.Point);
+            if (body.Role != CandyBodyRole.Whole)
+            {
+                DetachRopeConstraintsForPoint(body.Owner.WholeBody.Point);
+            }
             ReleaseBubbleForRemoval(body, reason);
 
             if (body.Role == CandyBodyRole.Whole)
@@ -62,6 +62,25 @@ namespace CutTheRopeDX.GameMain
             // Carrier release ordering is deliberately closed here: no owner may leave a retired
             // point gravity-suppressed. Authored/device-specific weight is preserved.
             body.Point.disableGravity = false;
+        }
+
+        private void DetachRopeConstraintsForPoint(ConstraintedPoint point)
+        {
+            foreach (RopeEntry entry in ropes.All)
+            {
+                int? cutPart = entry.CutPartForCandy(point);
+                if (cutPart == null)
+                {
+                    continue;
+                }
+
+                ConstraintedPoint ropeEnd = entry.Rope.parts[cutPart.Value];
+                ConstraintedPoint attachedPoint = entry.Rope.parts[cutPart.Value + 1];
+                if (attachedPoint.HasConstraintTo(ropeEnd))
+                {
+                    entry.Rope.RemovePart(cutPart.Value);
+                }
+            }
         }
 
         private void ReleaseBubbleForRemoval(CandyBody body, CandyRemovalReason reason)

--- a/CutTheRopeDX/GameMain/GameScene.CandyRemoval.cs
+++ b/CutTheRopeDX/GameMain/GameScene.CandyRemoval.cs
@@ -1,0 +1,100 @@
+using CutTheRopeDX.Framework.Helpers;
+
+namespace CutTheRopeDX.GameMain
+{
+    internal sealed partial class GameScene
+    {
+        /// <summary>
+        /// Atomically records one body's permanent removal and releases every live owner attached
+        /// to that body. A failed lifecycle transition has no cleanup or presentation side effects.
+        /// </summary>
+        /// <param name="body">Body being permanently retired.</param>
+        /// <param name="reason">Permanent removal reason.</param>
+        /// <returns><see langword="true"/> only when the body transitioned to removed.</returns>
+        private bool TryRetireCandyBody(CandyBody body, CandyRemovalReason reason)
+        {
+            if (body?.Owner == null || !TryCommitCandyRemoval(body, reason))
+            {
+                return false;
+            }
+
+            ReleaseRemovalOwnership(body, reason);
+            return true;
+        }
+
+        private static bool TryCommitCandyRemoval(CandyBody body, CandyRemovalReason reason)
+        {
+            SplitCandyState split = body.Owner.Lifecycle.Split;
+            return body.Role switch
+            {
+                CandyBodyRole.LeftHalf => split?.Left.TryRemove(reason) == true,
+                CandyBodyRole.RightHalf => split?.Right.TryRemove(reason) == true,
+                CandyBodyRole.Whole => body.Owner.Lifecycle.TryRemove(reason),
+                _ => false,
+            };
+        }
+
+        // Temporary low-level compatibility for removal callers migrated by the later plan tasks.
+        private static bool TryRemoveBody(CandyBody body, CandyRemovalReason reason)
+        {
+            return body?.Owner != null && TryCommitCandyRemoval(body, reason);
+        }
+
+        private void ReleaseRemovalOwnership(CandyBody body, CandyRemovalReason reason)
+        {
+            ReleaseRopesForBody(body);
+            ReleaseBubbleForRemoval(body, reason);
+
+            if (body.Role == CandyBodyRole.Whole)
+            {
+                CandyContext ctx = body.Owner;
+                DetachHandsForPoint(body.Point);
+                DetachSnailsForPoint(body.Point);
+                DropMouseCandyForPoint(body.Point);
+                DetachCandyFromConveyor(ctx);
+                ExhaustRocketForCandy(ctx);
+                if (Lantern.CancelCandyCaptureForRemoval(body.Point))
+                {
+                    ctx.inLantern = false;
+                }
+            }
+
+            // Carrier release ordering is deliberately closed here: no owner may leave a retired
+            // point gravity-suppressed. Authored/device-specific weight is preserved.
+            body.Point.disableGravity = false;
+        }
+
+        private void ReleaseBubbleForRemoval(CandyBody body, CandyRemovalReason reason)
+        {
+            if (body.Bubble == null)
+            {
+                return;
+            }
+
+            if (reason is CandyRemovalReason.Eaten or CandyRemovalReason.Hazard)
+            {
+                PopCandyBubble(body);
+                return;
+            }
+
+            GameObject released = body.Bubble;
+            EnableGhostCycleForBubble(released);
+            if (pendingSecondGhostBubble != null && body.Role == CandyBodyRole.Whole)
+            {
+                EnableGhostCycleForBubble(pendingSecondGhostBubble);
+                pendingSecondGhostBubble = null;
+            }
+
+            if (released is Bubble bubble)
+            {
+                bubble.capturedByBulb = false;
+            }
+
+            body.Bubble = null;
+            body.BubbleHasGhost = false;
+            body.Owner.lightBulb?.SyncFromContext(body.Owner);
+            _ = (body.BubbleAnimation?.visible = false);
+            _ = (body.GhostBubbleAnimation?.visible = false);
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -854,29 +854,6 @@ namespace CutTheRopeDX.GameMain
         }
 
         /// <summary>
-        /// Permanently removes one active body for the given reason, routing the removal to whichever
-        /// owner actually holds that body's state: a whole body's own lifecycle, or the matching half
-        /// of its logical candy's split state.
-        /// </summary>
-        /// <param name="body">The body being removed.</param>
-        /// <param name="reason">The reason the body is removed.</param>
-        /// <returns>
-        /// <see langword="true"/> when the body transitioned to removed; otherwise,
-        /// <see langword="false"/> when it was already removed or the transition is illegal.
-        /// </returns>
-        private static bool TryRemoveBody(CandyBody body, CandyRemovalReason reason)
-        {
-            SplitCandyState split = body.Owner.Lifecycle.Split;
-            return body.Role switch
-            {
-                CandyBodyRole.LeftHalf => split?.Left.TryRemove(reason) == true,
-                CandyBodyRole.RightHalf => split?.Right.TryRemove(reason) == true,
-                CandyBodyRole.Whole => body.Owner.Lifecycle.TryRemove(reason),
-                _ => false,
-            };
-        }
-
-        /// <summary>
         /// Destroys one candy body that touched a hazard (spike, axe, ...): pops its bubble, removes
         /// it as a hazard loss, releases its ropes, detaches its carriers, schedules the loss, and
         /// flags ghosts. A split half loses only itself; its sibling keeps playing until the
@@ -885,20 +862,15 @@ namespace CutTheRopeDX.GameMain
         /// <param name="body">The body being destroyed.</param>
         private void BreakCandyBody(CandyBody body)
         {
-            CandyContext ctx = body.Owner;
-            PopCandyBubble(body);
-            body.Visual.x = body.Point.pos.X;
-            body.Visual.y = body.Point.pos.Y;
-            _ = TryRemoveBody(body, CandyRemovalReason.Hazard);
-            ExhaustRocketForCandy(ctx);
-            SpawnCandyBreakParticles(body.Visual.x, body.Visual.y);
-            ReleaseRopesForBody(body);
-            // Carriers only ever hold a whole body, so they are always detached from the logical
-            // candy's whole point - which for a whole body is this body's own point.
-            ConstraintedPoint carrierPoint = ctx.WholeBody.Point;
-            DetachHandsForPoint(carrierPoint);
-            DetachSnailsForPoint(carrierPoint);
-            DropMouseCandyForPoint(carrierPoint);
+            Vector breakPosition = body.Point.pos;
+            body.Visual.x = breakPosition.X;
+            body.Visual.y = breakPosition.Y;
+            if (!TryRetireCandyBody(body, CandyRemovalReason.Hazard))
+            {
+                return;
+            }
+
+            SpawnCandyBreakParticles(breakPosition.X, breakPosition.Y);
             if (gameplayFlow.CanTriggerOutcome)
             {
                 ScheduleGameLost(0.3f);

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -639,11 +639,7 @@ namespace CutTheRopeDX.GameMain
 
             // A merge can fold both halves' ghost bubbles onto the merged candy, parking the second
             // one behind the first. Popping the survivor releases the ghost that was parked with it.
-            if (pendingSecondGhostBubble != null && body.Role == CandyBodyRole.Whole)
-            {
-                EnableGhostCycleForBubble(pendingSecondGhostBubble);
-                pendingSecondGhostBubble = null;
-            }
+            ReleasePendingSecondGhostBubbleForBody(body);
 
             if (popped is Bubble bubble)
             {
@@ -863,13 +859,13 @@ namespace CutTheRopeDX.GameMain
         private void BreakCandyBody(CandyBody body)
         {
             Vector breakPosition = body.Point.pos;
-            body.Visual.x = breakPosition.X;
-            body.Visual.y = breakPosition.Y;
             if (!TryRetireCandyBody(body, CandyRemovalReason.Hazard))
             {
                 return;
             }
 
+            body.Visual.x = breakPosition.X;
+            body.Visual.y = breakPosition.Y;
             SpawnCandyBreakParticles(breakPosition.X, breakPosition.Y);
             if (gameplayFlow.CanTriggerOutcome)
             {

--- a/CutTheRopeDX/GameMain/GameScene.Initialize.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Initialize.cs
@@ -77,6 +77,9 @@ namespace CutTheRopeDX.GameMain
             earthAnims = null;
             pollenDrawer = new PollenDrawer();
             pendingSecondGhostBubble = null;
+            pendingSecondGhostBubbleOwner = null;
+            pendingLanternCapturePoint = null;
+            pendingLanternCapture = null;
             targets.Clear();
             targetBaseScaleX = 1f;
             targetBaseScaleY = 1f;

--- a/CutTheRopeDX/GameMain/GameScene.NightLevel.cs
+++ b/CutTheRopeDX/GameMain/GameScene.NightLevel.cs
@@ -99,12 +99,10 @@ namespace CutTheRopeDX.GameMain
                 }
                 if (!ctx.HasNoWholeBodyInPlay && PointOutOfScreen(ctx.WholeBody.Point))
                 {
-                    _ = ctx.Lifecycle.TryRemove(CandyRemovalReason.OffScreen);
-                    // A light emitter leaving the screen is a non-candy object escaping: release its
-                    // rope and exhaust its bound rocket, matching C's generic-object off-screen loop.
-                    ExhaustRocketForCandy(ctx);
-                    ReleaseRopesForPoint(ctx.WholeBody.Point);
-                    ctx.lightBulb?.SyncFromContext(ctx);
+                    if (TryRetireCandyBody(ctx.WholeBody, CandyRemovalReason.OffScreen))
+                    {
+                        ctx.lightBulb?.SyncFromContext(ctx);
+                    }
                 }
                 // A bulb mid-teleport is Hidden for the brief transport window but is not lost: count
                 // it as active so a lone emitter in a bamboo tube or hat does not trip the lights-out

--- a/CutTheRopeDX/GameMain/GameScene.Systems.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Systems.cs
@@ -488,32 +488,7 @@ namespace CutTheRopeDX.GameMain
         /// <param name="sg">Grab whose spider captured the candy.</param>
         public void SpiderWon(Grab sg)
         {
-            CTRSoundMgr.PlaySound(Resources.Snd.SpiderWin);
             ConstraintedPoint capturedStar = sg.Rope?.tail;
-            int grabCount = bungees.Count;
-            for (int i = 0; i < grabCount; i++)
-            {
-                Grab grab = bungees[i];
-                Bungee rope = grab.Rope;
-                if (rope != null && rope.tail == capturedStar)
-                {
-                    if (rope.cut == -1)
-                    {
-                        rope.SetCut(rope.parts.Count - 2);
-                    }
-                    int tailPart = rope.parts.Count - 2;
-                    if (rope.tail.HasConstraintTo(rope.parts[tailPart]))
-                    {
-                        rope.RemovePart(tailPart);
-                    }
-                    if (grab.Spider?.ShouldBustOnRopeCut == true && sg != grab)
-                    {
-                        SpiderBusted(grab);
-                    }
-                    grab.OnRopeCut(RopeCutReason.Severed);
-                }
-            }
-            sg.Spider.Win();
             // spiderTookCandy = true;
             // The spider takes whichever body its rope ends on - a whole candy or one split half. A
             // rope that ends on no live body has nothing to steal; it used to steal the primary candy.
@@ -523,7 +498,15 @@ namespace CutTheRopeDX.GameMain
                 return;
             }
 
-            _ = TryRemoveBody(capturedBody, CandyRemovalReason.Spider);
+            // Generic rope retirement busts every rider whose rope is cut. Mark this rider first so
+            // it is recognized as the winner while the other riders on this body are busted.
+            sg.Spider.Win();
+            if (!TryRetireCandyBody(capturedBody, CandyRemovalReason.Spider))
+            {
+                return;
+            }
+
+            CTRSoundMgr.PlaySound(Resources.Snd.SpiderWin);
             GameObject capturedCandy = capturedBody.Visual;
             Image image = Image.Image_createWithResIDQuad(Resources.Img.ObjSpider, 12);
             image.DoRestoreCutTransparency();
@@ -551,8 +534,6 @@ namespace CutTheRopeDX.GameMain
             image.anchor = 18;
             timeline.delegateTimelineDelegate = aniPool;
             _ = aniPool.AddChild(image);
-            ExhaustRocketForCandy(capturedBody.Owner);
-            DetachSnailsForPoint(capturedStar);
             if (gameplayFlow.CanTriggerOutcome)
             {
                 ScheduleGameLost(2);

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -379,6 +379,7 @@ namespace CutTheRopeDX.GameMain
                         GameObject leftBubble = leftBody.Bubble;
                         GameObject rightBubble = rightBody.Bubble;
                         pendingSecondGhostBubble = null;
+                        pendingSecondGhostBubbleOwner = null;
                         if (leftBubble != null || rightBubble != null)
                         {
                             bool leftHasGhost = leftBubble != null && DisableGhostCycleForBubble(leftBubble);
@@ -387,6 +388,7 @@ namespace CutTheRopeDX.GameMain
                             {
                                 mergedBody.Bubble = leftBubble;
                                 pendingSecondGhostBubble = rightBubble;
+                                pendingSecondGhostBubbleOwner = mergedBody;
                             }
                             else if (leftHasGhost)
                             {
@@ -601,11 +603,7 @@ namespace CutTheRopeDX.GameMain
                     {
                         PopBubbleAtXY(bubble3.x, bubble3.y);
                         EnableGhostCycleForBubble(body.Bubble);
-                        if (pendingSecondGhostBubble != null && body.Role == CandyBodyRole.Whole)
-                        {
-                            EnableGhostCycleForBubble(pendingSecondGhostBubble);
-                            pendingSecondGhostBubble = null;
-                        }
+                        ReleasePendingSecondGhostBubbleForBody(body);
                     }
 
                     bool hasGhost = DisableGhostCycleForBubble(bubble3);
@@ -777,7 +775,9 @@ namespace CutTheRopeDX.GameMain
                     }
                     DetachCandyFromConveyor(ctx);
                     PopCandyBubble(body);
-                    dd.CallObjectSelectorParamafterDelay(new DelayedDispatcher.DispatchFunc(lantern.CaptureCandyFromDispatcher), body.Point, 0.05f);
+                    pendingLanternCapturePoint = body.Point;
+                    pendingLanternCapture = lantern;
+                    dd.CallObjectSelectorParamafterDelay(new DelayedDispatcher.DispatchFunc(CompletePendingLanternCapture), body.Point, 0.05f);
 
                     // Trigger special tutorial for lantern
                     TriggerSpecialTutorial(3);

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1464,15 +1464,11 @@ namespace CutTheRopeDX.GameMain
                         body.Visual.y = body.Point.pos.Y;
                         if (GameObject.ObjectsIntersect(body.Visual, t.targetObject))
                         {
-                            _ = ctx.Lifecycle.TryRemove(CandyRemovalReason.Eaten);
-                            ExhaustRocketForCandy(ctx);
-                            ReleaseRopesForPoint(body.Point);
-                            // Drop this candy's riders here, not at GameWon(). With one candy the
-                            // reference engine went straight from "eaten" to gameWon(), which tore
-                            // them down; now the other candies keep the level running, so a snail
-                            // would stay riding an eaten candy's invisible point until the last one
-                            // is eaten.
-                            DetachSnailsForPoint(body.Point);
+                            if (!TryRetireCandyBody(body, CandyRemovalReason.Eaten))
+                            {
+                                continue;
+                            }
+
                             body.Visual.visible = false;
                             t.asleep = true;
                             t.mouthOpen = false;

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1505,17 +1505,14 @@ namespace CutTheRopeDX.GameMain
                     continue;
                 }
                 CandyContext ctx = body.Owner;
-                _ = TryRemoveBody(body, CandyRemovalReason.OffScreen);
-                ExhaustRocketForCandy(ctx);
-                if (body.Role == CandyBodyRole.Whole)
+                if (!TryRetireCandyBody(body, CandyRemovalReason.OffScreen))
                 {
-                    ReleaseRopesForBody(body);
-                    anyLeft = anyLeft || ctx.Capabilities.CanLoseLevelWhenOffScreen;
+                    continue;
                 }
-                else
-                {
-                    anyLeft = true;
-                }
+
+                anyLeft = anyLeft
+                    || body.Role != CandyBodyRole.Whole
+                    || ctx.Capabilities.CanLoseLevelWhenOffScreen;
             }
             if (anyLeft)
             {

--- a/CutTheRopeDX/GameMain/GameScene.cs
+++ b/CutTheRopeDX/GameMain/GameScene.cs
@@ -1021,6 +1021,15 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         private GameObject pendingSecondGhostBubble;
 
+        /// <summary>The whole body that owns <see cref="pendingSecondGhostBubble"/>.</summary>
+        private CandyBody pendingSecondGhostBubbleOwner;
+
+        /// <summary>Candy point waiting for the lantern's delayed capture callback.</summary>
+        private ConstraintedPoint pendingLanternCapturePoint;
+
+        /// <summary>Lantern assigned to <see cref="pendingLanternCapturePoint"/>.</summary>
+        private Lantern pendingLanternCapture;
+
         /// <summary>
         /// The number of ropes cut within the active combo window.
         /// </summary>

--- a/CutTheRopeDX/GameMain/Lantern.cs
+++ b/CutTheRopeDX/GameMain/Lantern.cs
@@ -191,6 +191,33 @@ namespace CutTheRopeDX.GameMain
             GetAllLanterns().Clear();
         }
 
+        /// <summary>
+        /// Cancels lantern ownership when the exact captured candy point is permanently removed.
+        /// Pending release callbacks are discarded and every lantern returns to its inactive visual.
+        /// </summary>
+        /// <param name="point">Point being permanently removed.</param>
+        /// <returns><see langword="true"/> when this was the captured lantern point.</returns>
+        public static bool CancelCandyCaptureForRemoval(ConstraintedPoint point)
+        {
+            if (point == null || SharedCandyPoint != point)
+            {
+                return false;
+            }
+
+            SharedCandyPoint = null;
+            foreach (Lantern lantern in GetAllLanterns())
+            {
+                lantern.delayedDispatcher.CancelAllDispatches();
+                lantern.lanternState = LanternStateInactive;
+                lantern.idleForm.color = RGBAColor.solidOpaqueRGBA;
+                lantern.activeForm.color = RGBAColor.transparentRGBA;
+                lantern.innerCandy.color = RGBAColor.transparentRGBA;
+                lantern.fire.color = RGBAColor.transparentRGBA;
+            }
+
+            return true;
+        }
+
         /// <inheritdoc />
         public override void Update(float delta)
         {


### PR DESCRIPTION
## Description

- Centralize permanent candy-body removal in `TryRetireCandyBody`.
- Atomically clear ropes, bubbles, rockets, hands, snails, mice, ants, lantern capture, and gravity suppression.
- Route hazard, eaten, off-screen, light-emitter, and spider removal through the transaction.
- Preserve exact per-candy and split-half ownership isolation.
- Add interaction coverage for idempotency, transient carrier state, spider ordering, light emitters, and multi-candy scenarios.
