### PR TITLE
fix: Prevent gameplay lifecycle leaks during level exit

### DIFF
--- a/CutTheRopeDX.Tests/GameControllerOverlayModeTests.cs
+++ b/CutTheRopeDX.Tests/GameControllerOverlayModeTests.cs
@@ -76,7 +76,7 @@ namespace CutTheRopeDX.Tests
         }
 
         [Fact]
-        public void ResultsModeBlocksTouchButKeepsSceneUpdatingDuringCloseAnimation()
+        public void ResultsModeKeepsSceneUpdatingDuringCloseAnimation()
         {
             (GameController controller, GameScene scene) = Load();
             View view = controller.GetView(0);
@@ -85,6 +85,10 @@ namespace CutTheRopeDX.Tests
 
             Assert.False(scene.touchable);
             Assert.True(scene.updateable);
+            BoxOpenClose results = Assert.IsType<BoxOpenClose>(view.GetChild(GameView.VIEW_ELEMENT_RESULTS));
+            Assert.True(results.updateable);
+            controller.Update(0.1f);
+            Assert.Equal(1, results.raState);
             Assert.False(view.GetChild(GameView.VIEW_ELEMENT_PAUSE_MENU).IsEnabled());
             Assert.False(view.GetChild(GameView.VIEW_ELEMENT_PAUSE_BUTTON).IsEnabled());
             Assert.False(view.GetChild(GameView.VIEW_ELEMENT_RESTART_BUTTON).IsEnabled());
@@ -105,14 +109,69 @@ namespace CutTheRopeDX.Tests
         }
 
         [Fact]
-        public void EnteringResultsFromPauseReleasesTheControllerAudioPause()
+        public void DelayedResultFreezeDoesNotRefreezeReplayedLevel()
         {
-            (GameController controller, _) = Load();
+            (GameController controller, GameScene scene) = Load();
+            BoxOpenClose box = (BoxOpenClose)controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_RESULTS);
+            controller.LevelWon(LevelResultCalculator.Calculate(elapsedTime: 20f, starsCollected: 2));
+
+            box.PostBoxClosed();
+            controller.OnButtonPressed(GameControllerButtonId.ExitFromLose);
+            Assert.True(scene.updateable);
+            TimerManager.Update(0.51f);
+
+            Assert.True(scene.updateable);
+        }
+
+        [Fact]
+        public void EnteringResultsFromPauseKeepsGameplaySuspended()
+        {
+            (GameController controller, GameScene scene) = Load();
             controller.OnButtonPressed(GameControllerButtonId.Pause);
             Assert.Equal(1, AudioPauseDepth());
 
             controller.LevelWon(LevelResultCalculator.Calculate(elapsedTime: 20f, starsCollected: 2));
 
+            Assert.False(scene.updateable);
+            Assert.Equal(1, AudioPauseDepth());
+        }
+
+        [Fact]
+        public void LeavingPausedGameplayForMenuDoesNotRestartSceneDuringCloseAnimation()
+        {
+            (GameController controller, GameScene scene) = Load();
+            controller.OnButtonPressed(GameControllerButtonId.Pause);
+
+            controller.OnButtonPressed(GameControllerButtonId.MainMenu);
+
+            Assert.False(scene.touchable);
+            Assert.False(scene.updateable);
+            Assert.Equal(0, AudioPauseDepth());
+        }
+
+        [Fact]
+        public void LeavingActiveGameplayForMenuDoesNotCreateANewAudioPause()
+        {
+            (GameController controller, GameScene scene) = Load();
+
+            controller.OnButtonPressed(GameControllerButtonId.MainMenu);
+
+            Assert.False(scene.touchable);
+            Assert.False(scene.updateable);
+            Assert.Equal(0, AudioPauseDepth());
+        }
+
+        [Fact]
+        public void ExitingResultsDirectlyFreezesSceneAndClearsAudioPauseOwnership()
+        {
+            (GameController controller, GameScene scene) = Load();
+            controller.LevelWon(LevelResultCalculator.Calculate(elapsedTime: 20f, starsCollected: 2));
+            Assert.True(scene.updateable);
+
+            controller.OnButtonPressed(GameControllerButtonId.ExitFromWin);
+
+            Assert.False(scene.touchable);
+            Assert.False(scene.updateable);
             Assert.Equal(0, AudioPauseDepth());
         }
 

--- a/CutTheRopeDX/GameMain/GameController.cs
+++ b/CutTheRopeDX/GameMain/GameController.cs
@@ -103,6 +103,12 @@ namespace CutTheRopeDX.GameMain
         public override void Deactivate()
         {
             navigationExitActive = true;
+            gameplayAudioPaused = false;
+            if (GetView(0)?.GetChild(GameView.VIEW_ELEMENT_GAME_SCENE) is GameScene gameScene)
+            {
+                gameScene.touchable = false;
+                gameScene.updateable = false;
+            }
             base.Deactivate();
         }
 
@@ -688,20 +694,31 @@ namespace CutTheRopeDX.GameMain
 
             bool gameplay = mode == GameControllerOverlayMode.Gameplay;
             bool paused = mode == GameControllerOverlayMode.Paused;
+            bool resultCloseAnimation = mode == GameControllerOverlayMode.Results
+                && previousMode == GameControllerOverlayMode.Gameplay
+                && !navigationExitActive;
             view.GetChild(GameView.VIEW_ELEMENT_PAUSE_MENU).SetEnabled(paused);
             view.GetChild(GameView.VIEW_ELEMENT_PAUSE_BUTTON).SetEnabled(gameplay);
             view.GetChild(GameView.VIEW_ELEMENT_RESTART_BUTTON).SetEnabled(gameplay);
             view.GetChild(GameView.VIEW_ELEMENT_RESULTS).touchable = mode == GameControllerOverlayMode.Results;
             gameScene.touchable = gameplay;
-            gameScene.updateable = !paused;
+            gameScene.updateable = gameplay || resultCloseAnimation;
 
-            if (previousMode == GameControllerOverlayMode.Paused && mode != GameControllerOverlayMode.Paused)
+            if (mode == GameControllerOverlayMode.Results && navigationExitActive)
             {
-                CTRSoundMgr.Unpause();
+                // Navigation callers stop all audio before starting the quit animation, which
+                // also resets the global pause depth. Do not leave stale controller ownership.
+                gameplayAudioPaused = false;
             }
-            else if (previousMode != GameControllerOverlayMode.Paused && mode == GameControllerOverlayMode.Paused)
+            else if (paused && !gameplayAudioPaused)
             {
                 CTRSoundMgr.Pause();
+                gameplayAudioPaused = true;
+            }
+            else if (gameplay && gameplayAudioPaused)
+            {
+                CTRSoundMgr.Unpause();
+                gameplayAudioPaused = false;
             }
 
             if (!paused)
@@ -997,6 +1014,9 @@ namespace CutTheRopeDX.GameMain
 
         /// <summary>Whether controller navigation has begun and further Back/Menu input must be ignored.</summary>
         private bool navigationExitActive;
+
+        /// <summary>Whether this controller currently owns one pause on the shared audio manager.</summary>
+        private bool gameplayAudioPaused;
 
         /// <summary>Exit code describing the selected controller deactivation route.</summary>
         public int exitCode;


### PR DESCRIPTION
## Description

Fix a regression introduced by PR #291 where gameplay updates and audio could leak into result, loading, or menu screens.

## Changes

- Preserve the original two-phase level-win behavior:
  - Keep gameplay updating during the box-close animation
  - Freeze gameplay after the existing post-close delay
- Freeze gameplay immediately when navigating away from a level
- Apply the same shutdown behavior to direct result and end-of-pack exits
- Track controller-owned audio pause state explicitly
- Prevent navigation after `StopAll()` from leaving stale audio pause ownership
- Ensure delayed result callbacks cannot freeze a replayed or newly loaded level
- Add regression coverage for result, replay, pause, and navigation transitions
