### PR TITLE
refactor: Refactor LightBulb to use authoritative candy lifecycle state

### DIFF
--- a/CutTheRopeDX.Tests/LightBulbPresentationTests.cs
+++ b/CutTheRopeDX.Tests/LightBulbPresentationTests.cs
@@ -1,0 +1,104 @@
+using System.Linq;
+using System.Reflection;
+
+using CutTheRopeDX.Framework.Visual;
+using CutTheRopeDX.GameMain;
+using CutTheRopeDX.Tests.Interactions;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class LightBulbPresentationTests
+    {
+        [Fact]
+        public void UpdateReadsVisibilityFromTheOwningLifecycle()
+        {
+            GameScene scene = Scenario.New()
+                .LightBulb(240, 200)
+                .OmNom(20, 460)
+                .Build();
+            CandyContext context = scene.Candies().Single(candy => candy.emitsLight);
+
+            Assert.True(context.Lifecycle.TryRemove(CandyRemovalReason.OffScreen));
+
+            context.LightBulb.Update(0.016f);
+
+            Assert.False(context.LightBulb.visible);
+        }
+
+        [Fact]
+        public void PrepareToDrawReadsSameFrameBubbleTransitions()
+        {
+            GameScene scene = Scenario.New()
+                .LightBulb(240, 200)
+                .Bubble(240, 200)
+                .OmNom(20, 460)
+                .Build();
+            CandyContext context = scene.Candies().Single(candy => candy.emitsLight);
+            Interaction.Hover(context);
+
+            _ = Act.CaptureInBubble(scene, context);
+
+            context.LightBulb.PrepareToDraw();
+
+            Assert.True(BubbleAnimation(context.LightBulb).visible);
+            Assert.False(GhostBubbleAnimation(context.LightBulb).visible);
+
+            context.WholeBody.BubbleHasGhost = true;
+
+            context.LightBulb.PrepareToDraw();
+
+            Assert.False(BubbleAnimation(context.LightBulb).visible);
+            Assert.True(GhostBubbleAnimation(context.LightBulb).visible);
+
+            context.WholeBody.Bubble = null;
+            context.WholeBody.BubbleHasGhost = false;
+
+            context.LightBulb.PrepareToDraw();
+
+            Assert.False(BubbleAnimation(context.LightBulb).visible);
+            Assert.False(GhostBubbleAnimation(context.LightBulb).visible);
+        }
+
+        [Fact]
+        public void PrepareToDrawReadsTransportVisibilityFromTheOwningLifecycle()
+        {
+            GameScene scene = Scenario.New()
+                .LightBulb(160, 200)
+                .Hat(20, 40, group: 1)
+                .Hat(300, 40, group: 1)
+                .OmNom(20, 460)
+                .Build();
+            CandyContext context = scene.Candies().Single(candy => candy.emitsLight);
+            Interaction.Hover(context);
+
+            Act.EnterHat(scene, context);
+            context.LightBulb.PrepareToDraw();
+
+            Assert.Equal(CandyPresence.Hidden, context.Lifecycle.Presence);
+            Assert.False(context.LightBulb.visible);
+
+            Assert.True(
+                Interaction.StepUntil(scene, () => context.Lifecycle.Presence == CandyPresence.Present),
+                "the hat never released the light bulb");
+            context.LightBulb.PrepareToDraw();
+
+            Assert.True(context.LightBulb.visible);
+        }
+
+        private static Animation BubbleAnimation(LightBulb bulb)
+        {
+            return (Animation)typeof(LightBulb)
+                .GetField("bubbleAnimation", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(bulb);
+        }
+
+        private static CandyInGhostBubbleAnimation GhostBubbleAnimation(LightBulb bulb)
+        {
+            return (CandyInGhostBubbleAnimation)typeof(LightBulb)
+                .GetField("ghostBubbleAnimation", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(bulb);
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/CandyContext.cs
+++ b/CutTheRopeDX/GameMain/CandyContext.cs
@@ -98,8 +98,8 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Optional light-bulb identifier from XML.</summary>
         public string lightBulbNumber;
 
-        /// <summary>Transitional light-bulb visual root while bulb visuals migrate into candy contexts.</summary>
-        public LightBulb lightBulb;
+        /// <summary>Gets the light-bulb visual root when this context owns one.</summary>
+        public LightBulb LightBulb => WholeBody.Visual as LightBulb;
 
         /// <summary>Optional axe identifier from XML.</summary>
         public string axeNumber;
@@ -208,6 +208,11 @@ namespace CutTheRopeDX.GameMain
             WholeBody = wholeBody;
             wholeBody.AttachTo(this);
             Lifecycle = CandyLifecycle.CreatePresent(wholeBody);
+
+            if (wholeBody.Visual is LightBulb bulb)
+            {
+                bulb.AttachTo(this);
+            }
         }
 
         /// <summary>

--- a/CutTheRopeDX/GameMain/GameScene.CandyRemoval.cs
+++ b/CutTheRopeDX/GameMain/GameScene.CandyRemoval.cs
@@ -140,7 +140,6 @@ namespace CutTheRopeDX.GameMain
 
             body.Bubble = null;
             body.BubbleHasGhost = false;
-            body.Owner.lightBulb?.SyncFromContext(body.Owner);
             _ = (body.BubbleAnimation?.visible = false);
             _ = (body.GhostBubbleAnimation?.visible = false);
         }

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -135,9 +135,9 @@ namespace CutTheRopeDX.GameMain
         {
             foreach (CandyContext ctx in LightEmitters())
             {
-                if (ctx.lightBulb != null)
+                if (ctx.LightBulb != null)
                 {
-                    yield return ctx.lightBulb;
+                    yield return ctx.LightBulb;
                 }
             }
         }
@@ -148,7 +148,7 @@ namespace CutTheRopeDX.GameMain
             for (int i = 0; i < candies.Count; i++)
             {
                 CandyContext ctx = candies[i];
-                if (!ctx.emitsLight || ctx.lightBulb == null)
+                if (!ctx.emitsLight || ctx.LightBulb == null)
                 {
                     continue;
                 }
@@ -242,8 +242,6 @@ namespace CutTheRopeDX.GameMain
                     ctx.activeRocket.additionalAngle = 0f;
                     ctx.activeRocket.UpdateRotation();
                 }
-
-                ctx.lightBulb?.SyncFromContext(ctx);
             }
         }
 
@@ -648,7 +646,6 @@ namespace CutTheRopeDX.GameMain
 
             body.Bubble = null;
             body.BubbleHasGhost = false;
-            body.Owner.lightBulb?.SyncFromContext(body.Owner);
             _ = (body.BubbleAnimation?.visible = false);
             _ = (body.GhostBubbleAnimation?.visible = false);
             PopBubbleAtXY(effectPosition.X, effectPosition.Y);

--- a/CutTheRopeDX/GameMain/GameScene.NightLevel.cs
+++ b/CutTheRopeDX/GameMain/GameScene.NightLevel.cs
@@ -57,7 +57,6 @@ namespace CutTheRopeDX.GameMain
         /// shared candy path (main candy loop + <see cref="ResolveCandyCollisions"/>). This method
         /// only handles:
         /// <list type="bullet">
-        ///   <item><description>Syncing capture/sock state from the context onto the bulb visual</description></item>
         ///   <item><description>Collision between light emitters and the legacy split-candy halves</description></item>
         ///   <item><description>Removal of light emitters that fall off screen</description></item>
         ///   <item><description>Game over trigger when all light emitters are lost (night levels only)</description></item>
@@ -65,17 +64,6 @@ namespace CutTheRopeDX.GameMain
         /// </remarks>
         private void UpdateLightEmitterPhysics()
         {
-            // Integration, whole-body collision, and the bulb visual's own Update() are all owned by
-            // the shared candy path now: the main candy loop integrates the point and calls
-            // ctx.candy.Update(delta) (ctx.candy IS the bulb), and ResolveCandyCollisions() handles
-            // collision. Re-stepping the point here double-integrated it (erratic swing); calling
-            // Update() here too double-advanced the bulb's animations (bubble/firefly ran ~2x fast).
-            // This loop only syncs capture/sock state from the context onto the bulb visual.
-            foreach (CandyContext ctx in LightEmitters())
-            {
-                ctx.lightBulb?.SyncFromContext(ctx);
-            }
-
             // ResolveCandyCollisions pairs logical candies, so it never sees a split half. Each
             // surviving half still has to collide with every light emitter.
             foreach (CandyContext ctx in LightEmitters())
@@ -99,10 +87,7 @@ namespace CutTheRopeDX.GameMain
                 }
                 if (!ctx.HasNoWholeBodyInPlay && PointOutOfScreen(ctx.WholeBody.Point))
                 {
-                    if (TryRetireCandyBody(ctx.WholeBody, CandyRemovalReason.OffScreen))
-                    {
-                        ctx.lightBulb?.SyncFromContext(ctx);
-                    }
+                    _ = TryRetireCandyBody(ctx.WholeBody, CandyRemovalReason.OffScreen);
                 }
                 // A bulb mid-teleport is Hidden for the brief transport window but is not lost: count
                 // it as active so a lone emitter in a bamboo tube or hat does not trip the lights-out

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -609,10 +609,9 @@ namespace CutTheRopeDX.GameMain
                     bool hasGhost = DisableGhostCycleForBubble(bubble3);
                     body.Bubble = bubble3;
                     body.BubbleHasGhost = hasGhost;
-                    if (ctx.lightBulb != null)
+                    if (ctx.LightBulb != null)
                     {
                         bubble3.capturedByBulb = !hasGhost;
-                        ctx.lightBulb.SyncFromContext(ctx);
                     }
                     else
                     {
@@ -934,7 +933,6 @@ namespace CutTheRopeDX.GameMain
                             {
                                 ctx.activeRocket.visible = false;
                             }
-                            ctx.lightBulb?.SyncFromContext(ctx);
                             sock3.light.PlayTimeline(0);
                             sock3.light.visible = true;
 

--- a/CutTheRopeDX/GameMain/LightBulb.cs
+++ b/CutTheRopeDX/GameMain/LightBulb.cs
@@ -64,28 +64,8 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         public readonly string bulbNumber;
 
-        /// <summary>
-        /// Reference to a hat/sock that has captured this light bulb.
-        /// When not <see langword="null"/>, the light bulb becomes invisible.
-        /// </summary>
-        public Sock attachedSock;
-
-        /// <summary>
-        /// Reference to a bubble that is currently capturing or carrying the light bulb.
-        /// </summary>
-        public Bubble capturingBubble;
-
-        /// <summary>
-        /// Indicates whether the capturing bubble is a ghost bubble variant,
-        /// which uses a different visual animation.
-        /// </summary>
-        public bool capturingGhostBubble;
-
-        /// <summary>
-        /// Speed at which the attached hat/sock moves, used for physics calculations.
-        /// </summary>
-        public float sockSpeed;
-
+        /// <summary>The logical candy whose authoritative body and lifecycle this visual presents.</summary>
+        private CandyContext owner;
 
         /// <summary>The additive-blended light glow halo effect.</summary>
         private readonly GameObject lightGlow;
@@ -117,10 +97,6 @@ namespace CutTheRopeDX.GameMain
             this.lightRadius = lightRadius;
             this.constraint = constraint;
             this.bulbNumber = bulbNumber ?? string.Empty;
-            attachedSock = null;
-            capturingBubble = null;
-            capturingGhostBubble = false;
-            sockSpeed = 0f;
             scaleX = scaleY = LightBulbRootScale;
 
             // Create light glow with additive blending for a soft halo effect
@@ -213,22 +189,17 @@ namespace CutTheRopeDX.GameMain
             CalculateTopLeft(this);
         }
 
-        /// <summary>Mirrors one candy context's carrier and presence state onto this bulb's visuals.</summary>
-        /// <param name="ctx">The logical candy context whose whole body this bulb represents.</param>
-        public void SyncFromContext(CandyContext ctx)
+        /// <summary>Connects this visual to the logical candy that owns it.</summary>
+        /// <param name="context">The owning logical candy.</param>
+        internal void AttachTo(CandyContext context)
         {
-            CandyTransportSession transport = ctx.Lifecycle.Transport;
-            visible = !ctx.HasNoWholeBodyInPlay && transport?.Sock == null;
-            capturingBubble = ctx.WholeBody.Bubble as Bubble;
-            capturingGhostBubble = ctx.WholeBody.BubbleHasGhost;
-            sockSpeed = transport?.SavedExitSpeed ?? 0f;
-            attachedSock = transport?.Sock;
-            SyncToConstraint();
+            owner = context;
         }
 
         /// <inheritdoc />
         public override void Draw()
         {
+            PrepareToDraw();
             if (!visible)
             {
                 return;
@@ -248,6 +219,7 @@ namespace CutTheRopeDX.GameMain
         /// </remarks>
         public void DrawLight()
         {
+            PrepareToDraw();
             if (!visible)
             {
                 return;
@@ -271,6 +243,7 @@ namespace CutTheRopeDX.GameMain
         /// </remarks>
         public void DrawBottleAndFirefly()
         {
+            PrepareToDraw();
             if (!visible)
             {
                 return;
@@ -347,15 +320,24 @@ namespace CutTheRopeDX.GameMain
         /// <inheritdoc />
         public override void Update(float delta)
         {
+            RefreshPresentation();
             base.Update(delta);
+        }
 
-            // Hide when attached to a hat/sock (hat/sock draws the captured object)
-            visible = attachedSock == null;
+        /// <summary>Refreshes the view from authoritative state immediately before rendering.</summary>
+        internal void PrepareToDraw()
+        {
+            RefreshPresentation();
+        }
 
-            // Show appropriate bubble animation based on capture state
-            bool hasBubble = capturingBubble != null && attachedSock == null;
-            bubbleAnimation.visible = hasBubble && !capturingGhostBubble;
-            ghostBubbleAnimation.visible = hasBubble && capturingGhostBubble;
+        private void RefreshPresentation()
+        {
+            CandyTransportSession transport = owner.Lifecycle.Transport;
+            visible = !owner.HasNoWholeBodyInPlay && transport?.Sock == null;
+
+            bool hasBubble = visible && owner.WholeBody.Bubble != null;
+            bubbleAnimation.visible = hasBubble && !owner.WholeBody.BubbleHasGhost;
+            ghostBubbleAnimation.visible = hasBubble && owner.WholeBody.BubbleHasGhost;
         }
     }
 }

--- a/CutTheRopeDX/GameMain/LightBulbVisualFactory.cs
+++ b/CutTheRopeDX/GameMain/LightBulbVisualFactory.cs
@@ -23,7 +23,6 @@ namespace CutTheRopeDX.GameMain
             {
                 candyNumber = null,
                 lightBulbNumber = bulb.bulbNumber,
-                lightBulb = bulb,
                 Capabilities = LightBulbDefinition.Capabilities,
                 lightRadius = lightRadius,
                 emitsLight = LightBulbDefinition.EmitsLight,


### PR DESCRIPTION
## Description

- Make `LightBulb` derive visibility, bubble presentation, and transport state directly from its owning `CandyContext`
- Remove the mirrored `attachedSock`, `capturingBubble`, `capturingGhostBubble`, and `sockSpeed` fields
- Remove all seven `SyncFromContext` call sites
- Derive `CandyContext.LightBulb` from `WholeBody.Visual`
- Refresh presentation at update and draw boundaries so same-frame transitions cannot render stale state
