### PR TITLE
refactor: Refactor candy attachment state into a single source of truth

### DIFF
--- a/CutTheRopeDX.Tests/CandyAttachmentsTests.cs
+++ b/CutTheRopeDX.Tests/CandyAttachmentsTests.cs
@@ -1,0 +1,137 @@
+using System.Runtime.CompilerServices;
+
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class CandyAttachmentsTests
+    {
+        private static T Uninitialized<T>() where T : class
+        {
+            return (T)RuntimeHelpers.GetUninitializedObject(typeof(T));
+        }
+
+        [Fact]
+        public void OwnerCheckedReleasesCannotClearAnotherDevicesAttachment()
+        {
+            CandyAttachments attachments = new();
+            Rocket firstRocket = Uninitialized<Rocket>();
+            Rocket otherRocket = Uninitialized<Rocket>();
+            MechanicalHand firstHand = Uninitialized<MechanicalHand>();
+            MechanicalHand otherHand = Uninitialized<MechanicalHand>();
+
+            Assert.True(attachments.BindRocket(firstRocket));
+            Assert.True(attachments.CaptureByHand(firstHand));
+
+            Assert.False(attachments.TryReleaseRocket(otherRocket));
+            Assert.False(attachments.TryReleaseHand(otherHand));
+            Assert.Same(firstRocket, attachments.Rocket);
+            Assert.Same(firstHand, attachments.Hand);
+
+            Assert.True(attachments.TryReleaseRocket(firstRocket));
+            Assert.True(attachments.TryReleaseHand(firstHand));
+            Assert.Null(attachments.Rocket);
+            Assert.Null(attachments.Hand);
+        }
+
+        [Fact]
+        public void ResetAntsClearsTheWholeAntInteractionTogether()
+        {
+            CandyAttachments attachments = new();
+            AntsPathSegment segment = new(new Vector(0f, 0f), new Vector(100f, 0f), 20f, 1f);
+
+            Assert.True(attachments.BeginAntCarry(segment, new Vector(25f, 5f), 0.3f, 0.01f));
+            attachments.SetAntWaitingForExit(true);
+            attachments.AdvanceAntCarry(0.5f);
+
+            attachments.ResetAnts();
+
+            Assert.Null(attachments.AntSegment);
+            Assert.Null(attachments.LastAntSegment);
+            Assert.Equal(0f, attachments.AntCooldown);
+            Assert.False(attachments.AntWaitingForExit);
+            Assert.Equal(default, attachments.AntInteractionPoint);
+            Assert.Equal(0f, attachments.AntInteractionTime);
+        }
+
+        [Fact]
+        public void DetachAllReturnsFormerOwnersAndLeavesNoAttachmentState()
+        {
+            CandyAttachments attachments = new();
+            Rocket rocket = Uninitialized<Rocket>();
+            MechanicalHand hand = Uninitialized<MechanicalHand>();
+            AntsPathSegment segment = new(new Vector(0f, 0f), new Vector(100f, 0f), 20f, 1f);
+            _ = attachments.CaptureInLantern();
+            _ = attachments.BindRocket(rocket);
+            _ = attachments.CaptureByHand(hand);
+            _ = attachments.BeginAntCarry(segment, new Vector(25f, 5f), 0.3f, 0.01f);
+            attachments.SetCarriedByMouse(true);
+
+            CandyAttachmentSnapshot detached = attachments.DetachAll();
+
+            Assert.Same(rocket, detached.Rocket);
+            Assert.Same(hand, detached.Hand);
+            Assert.Same(segment, detached.AntSegment);
+            Assert.True(detached.CarriedByMouse);
+            Assert.True(detached.InLantern);
+            Assert.False(attachments.HasAny);
+            Assert.False(attachments.IsGravitySuppressed);
+            Assert.Null(attachments.LastAntSegment);
+            Assert.Equal(0f, attachments.AntCooldown);
+        }
+
+        [Fact]
+        public void DetachForTransportKeepsRocketButReleasesConflictingCarriers()
+        {
+            CandyAttachments attachments = new();
+            Rocket rocket = Uninitialized<Rocket>();
+            MechanicalHand hand = Uninitialized<MechanicalHand>();
+            AntsPathSegment segment = new(new Vector(0f, 0f), new Vector(100f, 0f), 20f, 1f);
+            _ = attachments.BindRocket(rocket);
+            _ = attachments.CaptureByHand(hand);
+            _ = attachments.BeginAntCarry(segment, new Vector(25f, 5f), 0.3f, 0.01f);
+            attachments.SetCarriedByMouse(true);
+
+            CandyAttachmentSnapshot detached = attachments.DetachForTransport();
+
+            Assert.Same(hand, detached.Hand);
+            Assert.Same(segment, detached.AntSegment);
+            Assert.True(detached.CarriedByMouse);
+            Assert.Null(detached.Rocket);
+            Assert.Same(rocket, attachments.Rocket);
+            Assert.Null(attachments.Hand);
+            Assert.Null(attachments.AntSegment);
+            Assert.False(attachments.CarriedByMouse);
+        }
+
+        [Fact]
+        public void CaptureInLanternAtomicallyReleasesEveryConflictingCarrier()
+        {
+            CandyAttachments attachments = new();
+            Rocket rocket = Uninitialized<Rocket>();
+            MechanicalHand hand = Uninitialized<MechanicalHand>();
+            AntsPathSegment segment = new(new Vector(0f, 0f), new Vector(100f, 0f), 20f, 1f);
+            _ = attachments.BindRocket(rocket);
+            _ = attachments.CaptureByHand(hand);
+            _ = attachments.BeginAntCarry(segment, new Vector(25f, 5f), 0.3f, 0.01f);
+            attachments.SetCarriedByMouse(true);
+
+            CandyAttachmentSnapshot detached = attachments.CaptureInLantern();
+
+            Assert.Same(rocket, detached.Rocket);
+            Assert.Same(hand, detached.Hand);
+            Assert.Same(segment, detached.AntSegment);
+            Assert.True(detached.CarriedByMouse);
+            Assert.False(detached.InLantern);
+            Assert.True(attachments.InLantern);
+            Assert.Null(attachments.Rocket);
+            Assert.Null(attachments.Hand);
+            Assert.Null(attachments.AntSegment);
+            Assert.False(attachments.CarriedByMouse);
+            Assert.True(attachments.IsGravitySuppressed);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/CandyAttachmentsTests.cs
+++ b/CutTheRopeDX.Tests/CandyAttachmentsTests.cs
@@ -78,7 +78,7 @@ namespace CutTheRopeDX.Tests
             Assert.True(detached.CarriedByMouse);
             Assert.True(detached.InLantern);
             Assert.False(attachments.HasAny);
-            Assert.False(attachments.IsGravitySuppressed);
+            Assert.False(attachments.SuppressGravity);
             Assert.Null(attachments.LastAntSegment);
             Assert.Equal(0f, attachments.AntCooldown);
         }
@@ -131,7 +131,7 @@ namespace CutTheRopeDX.Tests
             Assert.Null(attachments.Hand);
             Assert.Null(attachments.AntSegment);
             Assert.False(attachments.CarriedByMouse);
-            Assert.True(attachments.IsGravitySuppressed);
+            Assert.True(attachments.SuppressGravity);
         }
     }
 }

--- a/CutTheRopeDX.Tests/CandyLifecycleTests.cs
+++ b/CutTheRopeDX.Tests/CandyLifecycleTests.cs
@@ -22,7 +22,7 @@ namespace CutTheRopeDX.Tests
         {
             CandyLifecycle lifecycle = PresentLifecycle();
 
-            Assert.True(lifecycle.TryRemove(CandyRemovalReason.Eaten));
+            Assert.True(lifecycle.TryRemove(CandyRemovalReason.Eaten, out _));
             Assert.Equal(CandyPresence.Removed, lifecycle.Presence);
             Assert.Equal(CandyRemovalReason.Eaten, lifecycle.RemovalReason);
             Assert.True(lifecycle.WasEaten);
@@ -38,7 +38,7 @@ namespace CutTheRopeDX.Tests
             CandyRemovalReason reason = (CandyRemovalReason)reasonValue;
             CandyLifecycle lifecycle = PresentLifecycle();
 
-            Assert.True(lifecycle.TryRemove(reason));
+            Assert.True(lifecycle.TryRemove(reason, out _));
             Assert.False(lifecycle.WasEaten);
             Assert.True(lifecycle.HasFailedRemoval);
         }
@@ -47,10 +47,25 @@ namespace CutTheRopeDX.Tests
         public void RemovedCandyIsTerminal()
         {
             CandyLifecycle lifecycle = PresentLifecycle();
-            Assert.True(lifecycle.TryRemove(CandyRemovalReason.Hazard));
+            Assert.True(lifecycle.TryRemove(CandyRemovalReason.Hazard, out _));
 
-            Assert.False(lifecycle.TryRemove(CandyRemovalReason.Eaten));
+            Assert.False(lifecycle.TryRemove(CandyRemovalReason.Eaten, out _));
             Assert.Equal(CandyRemovalReason.Hazard, lifecycle.RemovalReason);
+        }
+
+        [Fact]
+        public void RemovingAWholeCandyAtomicallyClearsItsAttachmentState()
+        {
+            CandyLifecycle lifecycle = PresentLifecycle();
+            _ = lifecycle.Attachments.CaptureInLantern();
+            lifecycle.Attachments.SetCarriedByMouse(true);
+
+            Assert.True(lifecycle.TryRemove(CandyRemovalReason.Hazard, out CandyAttachmentSnapshot detached));
+
+            Assert.True(detached.CarriedByMouse);
+            Assert.True(detached.InLantern);
+            Assert.False(lifecycle.Attachments.HasAny);
+            Assert.False(lifecycle.IsGravitySuppressed);
         }
 
         [Fact]
@@ -94,7 +109,7 @@ namespace CutTheRopeDX.Tests
             CandyLifecycle lifecycle = PresentLifecycle();
             CandyTransportSession session = CandyTransportSession.ForBamboo(candy: null, tube: null);
 
-            Assert.True(lifecycle.TryHide(session));
+            Assert.True(lifecycle.TryHide(session, out _));
             Assert.Equal(CandyPresence.Hidden, lifecycle.Presence);
             Assert.Empty(lifecycle.ActiveBodies);
             Assert.False(lifecycle.WasEaten);
@@ -105,7 +120,7 @@ namespace CutTheRopeDX.Tests
         {
             CandyLifecycle lifecycle = PresentLifecycle();
             CandyTransportSession session = CandyTransportSession.ForSock(null, null, 123f);
-            Assert.True(lifecycle.TryHide(session));
+            Assert.True(lifecycle.TryHide(session, out _));
 
             Assert.True(lifecycle.TryCompleteTransport(session));
             Assert.Equal(CandyPresence.Present, lifecycle.Presence);
@@ -124,13 +139,33 @@ namespace CutTheRopeDX.Tests
             Assert.Same(whole, ctx.Lifecycle.WholeBody);
             Assert.Equal(CandyPresence.Present, ctx.Lifecycle.Presence);
             Assert.Equal([whole], ctx.Lifecycle.ActiveBodies);
+            Assert.NotNull(ctx.Lifecycle.Attachments);
+            Assert.True(ctx.Lifecycle.CanEnterTransport);
+            Assert.False(ctx.Lifecycle.IsGravitySuppressed);
+        }
+
+        [Fact]
+        public void LanternAndTransportStateAuthoritativelyAnswerInteractionQuestions()
+        {
+            CandyLifecycle lifecycle = PresentLifecycle();
+
+            _ = lifecycle.Attachments.CaptureInLantern();
+
+            Assert.False(lifecycle.CanEnterTransport);
+            Assert.True(lifecycle.IsGravitySuppressed);
+
+            lifecycle.Attachments.ReleaseFromLantern();
+            CandyTransportSession session = CandyTransportSession.ForBamboo(null, null);
+            Assert.True(lifecycle.TryHide(session, out _));
+            Assert.False(lifecycle.CanEnterTransport);
+            Assert.True(lifecycle.IsGravitySuppressed);
         }
 
         [Fact]
         public void ContextOutcomePreservesCapabilitiesAndRemovalReason()
         {
             CandyContext ctx = new(Body(CandyBodyRole.Whole)) { Capabilities = CandyCapabilities.LightBulb };
-            Assert.True(ctx.Lifecycle.TryRemove(CandyRemovalReason.Hazard));
+            Assert.True(ctx.Lifecycle.TryRemove(CandyRemovalReason.Hazard, out _));
 
             CandyOutcomeView outcome = ctx.ToOutcomeView();
 
@@ -175,9 +210,9 @@ namespace CutTheRopeDX.Tests
             CandyLifecycle lifecycle = PresentLifecycle();
             CandyTransportSession oldSession = CandyTransportSession.ForBamboo(null, null);
             CandyTransportSession newSession = CandyTransportSession.ForSock(null, null, 123f);
-            _ = lifecycle.TryHide(oldSession);
+            _ = lifecycle.TryHide(oldSession, out _);
             Assert.True(lifecycle.TryCompleteTransport(oldSession));
-            _ = lifecycle.TryHide(newSession);
+            _ = lifecycle.TryHide(newSession, out _);
 
             Assert.False(lifecycle.TryCompleteTransport(oldSession));
             Assert.Same(newSession, lifecycle.Transport);

--- a/CutTheRopeDX.Tests/HeadlessGame.cs
+++ b/CutTheRopeDX.Tests/HeadlessGame.cs
@@ -40,6 +40,7 @@ namespace CutTheRopeDX.Tests
         public static GameScene LoadLevel(int pack, int level)
         {
             CTRRootController root = (CTRRootController)Application.SharedRootController();
+            root.SetPicker(false);
             root.SetPack(pack);
             root.SetLevel(level);
             string mapPath = Path.Combine(ContentPaths.MapsDirectory, LevelsList.LEVEL_NAMES[pack, level]);
@@ -61,6 +62,7 @@ namespace CutTheRopeDX.Tests
         public static GameController LoadLevelWithController(int pack, int level)
         {
             CTRRootController root = (CTRRootController)Application.SharedRootController();
+            root.SetPicker(false);
             root.SetPack(pack);
             root.SetLevel(level);
             string mapPath = Path.Combine(ContentPaths.MapsDirectory, LevelsList.LEVEL_NAMES[pack, level]);

--- a/CutTheRopeDX.Tests/Interactions/Act.cs
+++ b/CutTheRopeDX.Tests/Interactions/Act.cs
@@ -41,7 +41,7 @@ namespace CutTheRopeDX.Tests.Interactions
                     rocket.point.pos = position;
                     rocket.point.prevPos = position;
                 },
-                () => candy.activeRocket == rocket,
+                () => candy.Lifecycle.Attachments.Rocket == rocket,
                 "the rocket never bound to the candy");
             return rocket;
         }
@@ -96,7 +96,7 @@ namespace CutTheRopeDX.Tests.Interactions
         public static MechanicalHand GrabWithHand(GameScene scene, CandyContext candy, int handIndex = 0)
         {
             MechanicalHand hand = scene.Hands()[handIndex];
-            Chase(scene, candy, position => MoveClawTo(hand, position), () => candy.capturingHand == hand, "the hand never grabbed the candy");
+            Chase(scene, candy, position => MoveClawTo(hand, position), () => candy.Lifecycle.Attachments.Hand == hand, "the hand never grabbed the candy");
             return hand;
         }
 
@@ -107,7 +107,7 @@ namespace CutTheRopeDX.Tests.Interactions
         public static Mouse CarryByMouse(GameScene scene, CandyContext candy)
         {
             Mouse mouse = scene.Mice()[0];
-            Chase(scene, candy, position => MoveTo(mouse, position), () => candy.carriedByMouse, "the mouse never took the candy");
+            Chase(scene, candy, position => MoveTo(mouse, position), () => candy.Lifecycle.Attachments.CarriedByMouse, "the mouse never took the candy");
             return mouse;
         }
 
@@ -122,7 +122,7 @@ namespace CutTheRopeDX.Tests.Interactions
         public static Mouse CarryByMouseWithoutMovingIt(GameScene scene, CandyContext candy)
         {
             Assert.True(
-                Interaction.StepUntil(scene, () => candy.carriedByMouse),
+                Interaction.StepUntil(scene, () => candy.Lifecycle.Attachments.CarriedByMouse),
                 "the mouse never took the candy");
             HeadlessGame.StepFrames(scene, SettleFrames);
             return scene.Mice()[0];
@@ -137,7 +137,7 @@ namespace CutTheRopeDX.Tests.Interactions
         public static void CarryByAnts(GameScene scene, CandyContext candy)
         {
             Assert.True(
-                Interaction.StepUntil(scene, () => candy.antSegment != null),
+                Interaction.StepUntil(scene, () => candy.Lifecycle.Attachments.AntSegment != null),
                 "the ants never picked up the candy");
         }
 
@@ -246,7 +246,7 @@ namespace CutTheRopeDX.Tests.Interactions
         public static void CaptureInLantern(GameScene scene, CandyContext candy)
         {
             Lantern lantern = Lantern.GetAllLanterns()[0];
-            Chase(scene, candy, position => MoveTo(lantern, position), () => candy.inLantern, "the lantern never captured the candy");
+            Chase(scene, candy, position => MoveTo(lantern, position), () => candy.Lifecycle.Attachments.InLantern, "the lantern never captured the candy");
         }
 
         /// <summary>

--- a/CutTheRopeDX.Tests/Interactions/AttachmentSetupTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/AttachmentSetupTests.cs
@@ -24,7 +24,7 @@ namespace CutTheRopeDX.Tests.Interactions
             Interaction.Hover(candy);
             Interaction.PlaceCandyAt(candy, Interaction.At(rocket.x, rocket.y));
 
-            Assert.True(Interaction.StepUntil(scene, () => candy.HasActiveRocket));
+            Assert.True(Interaction.StepUntil(scene, () => candy.Lifecycle.Attachments.HasActiveRocket));
         }
 
         [Fact]
@@ -75,7 +75,7 @@ namespace CutTheRopeDX.Tests.Interactions
             Interaction.Hover(candy);
             Interaction.PlaceCandyAt(candy, hand.ClawPosition());
 
-            Assert.True(Interaction.StepUntil(scene, () => candy.capturingHand == hand));
+            Assert.True(Interaction.StepUntil(scene, () => candy.Lifecycle.Attachments.Hand == hand));
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace CutTheRopeDX.Tests.Interactions
             Interaction.Hover(candy);
             Interaction.PlaceCandyAt(candy, Interaction.At(Scenario.New().WorldX(160), Scenario.WorldY(200)));
 
-            Assert.True(Interaction.StepUntil(scene, () => candy.carriedByMouse));
+            Assert.True(Interaction.StepUntil(scene, () => candy.Lifecycle.Attachments.CarriedByMouse));
         }
 
         [Fact]
@@ -106,7 +106,7 @@ namespace CutTheRopeDX.Tests.Interactions
             CandyContext candy = scene.Candy();
             Interaction.Hover(candy);
 
-            Assert.True(Interaction.StepUntil(scene, () => candy.antSegment != null));
+            Assert.True(Interaction.StepUntil(scene, () => candy.Lifecycle.Attachments.AntSegment != null));
         }
 
         [Fact]
@@ -121,7 +121,7 @@ namespace CutTheRopeDX.Tests.Interactions
             CandyContext candy = scene.Candy();
             Interaction.Hover(candy);
 
-            Assert.True(Interaction.StepUntil(scene, () => candy.inLantern));
+            Assert.True(Interaction.StepUntil(scene, () => candy.Lifecycle.Attachments.InLantern));
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/Interactions/BambooTubeEntryRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/BambooTubeEntryRowTests.cs
@@ -32,7 +32,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Act.EnterBambooTube(scene, candy, TubeMouth.CatchesFalling);
 
-            Assert.Null(candy.capturingHand);
+            Assert.Null(candy.Lifecycle.Attachments.Hand);
             Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, hand.state);
         }
 
@@ -44,8 +44,8 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Act.EnterBambooTube(scene, candy, TubeMouth.CatchesFalling);
 
-            Assert.True(candy.HasActiveRocket);
-            Assert.Same(rocket, candy.activeRocket);
+            Assert.True(candy.Lifecycle.Attachments.HasActiveRocket);
+            Assert.Same(rocket, candy.Lifecycle.Attachments.Rocket);
             Assert.False(rocket.visible);
         }
 
@@ -82,7 +82,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Act.EnterBambooTube(scene, candy, TubeMouth.CatchesRightward);
 
-            Assert.Null(candy.antSegment);
+            Assert.Null(candy.Lifecycle.Attachments.AntSegment);
         }
 
         [Fact]
@@ -94,7 +94,7 @@ namespace CutTheRopeDX.Tests.Interactions
             Act.EnterBambooTube(scene, candy, TubeMouth.CatchesFalling);
 
             Assert.False(scene.MouseCarries(candy));
-            Assert.False(candy.carriedByMouse);
+            Assert.False(candy.Lifecycle.Attachments.CarriedByMouse);
         }
 
         private static (GameScene Scene, CandyContext Candy) Rig(TubeMouth mouth, Func<Scenario, Scenario> attachment)

--- a/CutTheRopeDX.Tests/Interactions/BubbleCaptureRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/BubbleCaptureRowTests.cs
@@ -33,7 +33,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Assert.True(bubble.popped);
             Assert.Null(candy.WholeBody.Bubble);
-            Assert.Same(rocket, candy.activeRocket);
+            Assert.Same(rocket, candy.Lifecycle.Attachments.Rocket);
         }
 
         [Fact]
@@ -74,7 +74,7 @@ namespace CutTheRopeDX.Tests.Interactions
             // overwriting the candy's position, but the bubble's lift eventually pulls it clear of
             // the segment and the lane lets go.
             Assert.Same(bubble, candy.WholeBody.Bubble);
-            Assert.Null(candy.antSegment);
+            Assert.Null(candy.Lifecycle.Attachments.AntSegment);
         }
 
         [Fact]
@@ -86,7 +86,7 @@ namespace CutTheRopeDX.Tests.Interactions
             Bubble bubble = Act.CaptureInBubble(scene, candy);
 
             Assert.Same(bubble, candy.WholeBody.Bubble);
-            Assert.True(candy.carriedByMouse);
+            Assert.True(candy.Lifecycle.Attachments.CarriedByMouse);
         }
 
         private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment)

--- a/CutTheRopeDX.Tests/Interactions/CandyTopologyMatrixTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/CandyTopologyMatrixTests.cs
@@ -54,7 +54,7 @@ namespace CutTheRopeDX.Tests.Interactions
             Rocket rocket = scene.Rockets()[0];
 
             Assert.True(
-                Interaction.StepUntil(scene, () => candy.HasActiveRocket),
+                Interaction.StepUntil(scene, () => candy.Lifecycle.Attachments.HasActiveRocket),
                 "the rocket never bound the candy");
 
             AssertReachIsToItsOwnCandy(rocket, candy);
@@ -156,7 +156,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Assert.Empty(scene.ActiveBodies(CandyInteraction.Rocket));
             HeadlessGame.StepFrames(scene, 120);
-            Assert.False(scene.Candies()[0].HasActiveRocket);
+            Assert.False(scene.Candies()[0].Lifecycle.Attachments.HasActiveRocket);
             Assert.Equal([split.Left.Body, split.Right.Body], scene.ActiveBodies());
         }
 
@@ -188,11 +188,11 @@ namespace CutTheRopeDX.Tests.Interactions
             (GameScene scene, CandyContext left, CandyContext right) = TwoRocketScene();
 
             Assert.True(
-                Interaction.StepUntil(scene, () => left.HasActiveRocket && right.HasActiveRocket),
+                Interaction.StepUntil(scene, () => left.Lifecycle.Attachments.HasActiveRocket && right.Lifecycle.Attachments.HasActiveRocket),
                 "both rockets never bound");
 
-            Assert.Same(scene.Rockets()[0], right.activeRocket);
-            Assert.Same(scene.Rockets()[1], left.activeRocket);
+            Assert.Same(scene.Rockets()[0], right.Lifecycle.Attachments.Rocket);
+            Assert.Same(scene.Rockets()[1], left.Lifecycle.Attachments.Rocket);
         }
 
         /// <summary>
@@ -205,11 +205,11 @@ namespace CutTheRopeDX.Tests.Interactions
         {
             (GameScene scene, CandyContext left, CandyContext right) = TwoRocketScene();
             Assert.True(
-                Interaction.StepUntil(scene, () => left.HasActiveRocket && right.HasActiveRocket),
+                Interaction.StepUntil(scene, () => left.Lifecycle.Attachments.HasActiveRocket && right.Lifecycle.Attachments.HasActiveRocket),
                 "both rockets never bound");
 
-            AssertReachIsToItsOwnCandy(right.activeRocket, right);
-            AssertReachIsToItsOwnCandy(left.activeRocket, left);
+            AssertReachIsToItsOwnCandy(right.Lifecycle.Attachments.Rocket, right);
+            AssertReachIsToItsOwnCandy(left.Lifecycle.Attachments.Rocket, left);
         }
 
         [Fact]
@@ -217,11 +217,11 @@ namespace CutTheRopeDX.Tests.Interactions
         {
             (GameScene scene, CandyContext left, CandyContext right) = TwoRocketScene();
             Assert.True(
-                Interaction.StepUntil(scene, () => left.HasActiveRocket && right.HasActiveRocket),
+                Interaction.StepUntil(scene, () => left.Lifecycle.Attachments.HasActiveRocket && right.Lifecycle.Attachments.HasActiveRocket),
                 "both rockets never bound");
 
-            Assert.Null(right.activeRocket.BindReach(left));
-            Assert.Null(left.activeRocket.BindReach(right));
+            Assert.Null(right.Lifecycle.Attachments.Rocket.BindReach(left));
+            Assert.Null(left.Lifecycle.Attachments.Rocket.BindReach(right));
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/Interactions/CandyTransportLifecycleTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/CandyTransportLifecycleTests.cs
@@ -116,7 +116,7 @@ namespace CutTheRopeDX.Tests.Interactions
             Assert.Equal(CandyPresence.Hidden, swallowed.Lifecycle.Presence);
             Assert.Equal(CandyPresence.Present, kept.Lifecycle.Presence);
             Assert.Null(kept.Lifecycle.Transport);
-            Assert.Same(rocket, kept.activeRocket);
+            Assert.Same(rocket, kept.Lifecycle.Attachments.Rocket);
             Assert.True(rocket.visible);
         }
 

--- a/CutTheRopeDX.Tests/Interactions/EatenRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/EatenRowTests.cs
@@ -28,7 +28,7 @@ namespace CutTheRopeDX.Tests.Interactions
             (GameScene scene, CandyContext candy) = Rig(s => s.Hand(160, 120, segmentLength: 20, segmentAngle: 90f));
             MechanicalHand hand = Act.GrabWithHand(scene, candy);
             Act.Eat(scene, candy);
-            Assert.Null(candy.capturingHand);
+            Assert.Null(candy.Lifecycle.Attachments.Hand);
             Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, hand.state);
         }
 
@@ -38,7 +38,7 @@ namespace CutTheRopeDX.Tests.Interactions
             (GameScene scene, CandyContext candy) = Rig(s => s.Rocket(160, 200, impulse: 0f));
             Rocket rocket = Act.BindRocket(scene, candy);
             Act.Eat(scene, candy);
-            Assert.False(candy.HasActiveRocket);
+            Assert.False(candy.Lifecycle.Attachments.HasActiveRocket);
             Assert.Equal(Rocket.STATE_ROCKET_EXAUST, rocket.state);
         }
 
@@ -68,10 +68,10 @@ namespace CutTheRopeDX.Tests.Interactions
             (GameScene scene, CandyContext candy) = Rig(s => s.Ants(120, 200, path: "80,0"));
             Act.CarryByAnts(scene, candy);
             Act.Eat(scene, candy);
-            Assert.Null(candy.antSegment);
-            Assert.Null(candy.lastAntSegment);
-            Assert.False(candy.antWaitForFly);
-            Assert.Equal(0f, candy.antCooldown);
+            Assert.Null(candy.Lifecycle.Attachments.AntSegment);
+            Assert.Null(candy.Lifecycle.Attachments.LastAntSegment);
+            Assert.False(candy.Lifecycle.Attachments.AntWaitingForExit);
+            Assert.Equal(0f, candy.Lifecycle.Attachments.AntCooldown);
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace CutTheRopeDX.Tests.Interactions
             (GameScene scene, CandyContext candy) = Rig(s => s.Mouse(160, 200));
             _ = Act.CarryByMouse(scene, candy);
             Act.Eat(scene, candy);
-            Assert.False(candy.carriedByMouse);
+            Assert.False(candy.Lifecycle.Attachments.CarriedByMouse);
             Assert.False(scene.MouseCarries(candy));
         }
 

--- a/CutTheRopeDX.Tests/Interactions/HandGrabRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/HandGrabRowTests.cs
@@ -31,7 +31,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             MechanicalHand claimant = Act.GrabWithHand(scene, candy, handIndex: 0);
 
-            Assert.Same(claimant, candy.capturingHand);
+            Assert.Same(claimant, candy.Lifecycle.Attachments.Hand);
             Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, rival.state);
         }
 
@@ -43,8 +43,8 @@ namespace CutTheRopeDX.Tests.Interactions
 
             _ = Act.GrabWithHand(scene, candy);
 
-            Assert.True(candy.HasActiveRocket);
-            Assert.Same(rocket, candy.activeRocket);
+            Assert.True(candy.Lifecycle.Attachments.HasActiveRocket);
+            Assert.Same(rocket, candy.Lifecycle.Attachments.Rocket);
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             _ = Act.GrabWithHand(scene, candy);
 
-            Assert.Null(candy.antSegment);
+            Assert.Null(candy.Lifecycle.Attachments.AntSegment);
         }
 
         [Fact]
@@ -92,7 +92,7 @@ namespace CutTheRopeDX.Tests.Interactions
             _ = Act.GrabWithHand(scene, candy);
 
             Assert.False(scene.MouseCarries(candy));
-            Assert.False(candy.carriedByMouse);
+            Assert.False(candy.Lifecycle.Attachments.CarriedByMouse);
         }
 
         private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment)

--- a/CutTheRopeDX.Tests/Interactions/LanternCaptureRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/LanternCaptureRowTests.cs
@@ -31,7 +31,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Act.CaptureInLantern(scene, candy);
 
-            Assert.Null(candy.capturingHand);
+            Assert.Null(candy.Lifecycle.Attachments.Hand);
             Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, hand.state);
         }
 
@@ -43,7 +43,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Act.CaptureInLantern(scene, candy);
 
-            Assert.False(candy.HasActiveRocket);
+            Assert.False(candy.Lifecycle.Attachments.HasActiveRocket);
             Assert.Equal(Rocket.STATE_ROCKET_EXAUST, rocket.state);
         }
 
@@ -79,7 +79,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Act.CaptureInLantern(scene, candy);
 
-            Assert.Null(candy.antSegment);
+            Assert.Null(candy.Lifecycle.Attachments.AntSegment);
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace CutTheRopeDX.Tests.Interactions
             Act.CaptureInLantern(scene, candy);
 
             Assert.False(scene.MouseCarries(candy));
-            Assert.False(candy.carriedByMouse);
+            Assert.False(candy.Lifecycle.Attachments.CarriedByMouse);
         }
 
         private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment)

--- a/CutTheRopeDX.Tests/Interactions/LostRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/LostRowTests.cs
@@ -35,7 +35,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Act.BreakOnSpikes(scene, candy);
 
-            Assert.Null(candy.capturingHand);
+            Assert.Null(candy.Lifecycle.Attachments.Hand);
             Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, hand.state);
         }
 
@@ -47,7 +47,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Act.BreakOnSpikes(scene, candy);
 
-            Assert.False(candy.HasActiveRocket);
+            Assert.False(candy.Lifecycle.Attachments.HasActiveRocket);
             Assert.Equal(Rocket.STATE_ROCKET_EXAUST, rocket.state);
         }
 
@@ -83,10 +83,10 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Act.BreakOnSpikes(scene, candy);
 
-            Assert.Null(candy.antSegment);
-            Assert.Null(candy.lastAntSegment);
-            Assert.False(candy.antWaitForFly);
-            Assert.Equal(0f, candy.antCooldown);
+            Assert.Null(candy.Lifecycle.Attachments.AntSegment);
+            Assert.Null(candy.Lifecycle.Attachments.LastAntSegment);
+            Assert.False(candy.Lifecycle.Attachments.AntWaitingForExit);
+            Assert.Equal(0f, candy.Lifecycle.Attachments.AntCooldown);
         }
 
         [Fact]
@@ -98,7 +98,27 @@ namespace CutTheRopeDX.Tests.Interactions
             Act.BreakOnSpikes(scene, candy);
 
             Assert.False(scene.MouseCarries(candy));
-            Assert.False(candy.carriedByMouse);
+            Assert.False(candy.Lifecycle.Attachments.CarriedByMouse);
+        }
+
+        [Fact]
+        public void LevelLossClearsMouseOwnershipFromASurvivingCandy()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(240, 200)
+                .Mouse(240, 200)
+                .OmNom(20, 460)
+                .Build();
+            CandyContext surviving = scene.Candy();
+            Interaction.Hover(surviving);
+            _ = Act.CarryByMouse(scene, surviving);
+
+            scene.GameLost();
+
+            Assert.False(scene.MouseCarries(surviving));
+            Assert.False(surviving.Lifecycle.Attachments.CarriedByMouse);
+            Assert.False(surviving.Lifecycle.IsGravitySuppressed);
+            Assert.False(surviving.WholeBody.Point.disableGravity);
         }
 
         [Fact]
@@ -129,15 +149,15 @@ namespace CutTheRopeDX.Tests.Interactions
             (GameScene scene, CandyContext candy) = Rig(s => s.Ants(150, 200, path: "20,0", moveSpeed: 600f));
             Act.CarryByAnts(scene, candy);
             Assert.True(
-                Interaction.StepUntil(scene, () => candy.antSegment == null && candy.lastAntSegment != null),
+                Interaction.StepUntil(scene, () => candy.Lifecycle.Attachments.AntSegment == null && candy.Lifecycle.Attachments.LastAntSegment != null),
                 "the candy never entered the ant reattachment-cooldown state");
 
             scene.BreakCandyBody(candy.WholeBody);
 
-            Assert.Null(candy.antSegment);
-            Assert.Null(candy.lastAntSegment);
-            Assert.False(candy.antWaitForFly);
-            Assert.Equal(0f, candy.antCooldown);
+            Assert.Null(candy.Lifecycle.Attachments.AntSegment);
+            Assert.Null(candy.Lifecycle.Attachments.LastAntSegment);
+            Assert.False(candy.Lifecycle.Attachments.AntWaitingForExit);
+            Assert.Equal(0f, candy.Lifecycle.Attachments.AntCooldown);
         }
 
         [Fact]
@@ -149,7 +169,7 @@ namespace CutTheRopeDX.Tests.Interactions
             scene.BreakCandyBody(candy.WholeBody);
 
             Assert.False(scene.MouseCarries(candy));
-            Assert.False(candy.carriedByMouse);
+            Assert.False(candy.Lifecycle.Attachments.CarriedByMouse);
         }
 
         [Fact]
@@ -161,15 +181,15 @@ namespace CutTheRopeDX.Tests.Interactions
                 Interaction.StepUntil(
                     scene,
                     () => Act.MoveTo(lantern, candy.WholeBody.Point.pos),
-                    () => candy.inLantern),
+                    () => candy.Lifecycle.Attachments.InLantern),
                 "the lantern never began capturing the candy");
 
             scene.BreakCandyBody(candy.WholeBody);
 
-            Assert.False(candy.inLantern);
+            Assert.False(candy.Lifecycle.Attachments.InLantern);
             Assert.False(candy.WholeBody.Point.disableGravity);
             HeadlessGame.StepFrames(scene, 10);
-            Assert.False(candy.inLantern);
+            Assert.False(candy.Lifecycle.Attachments.InLantern);
             Assert.False(candy.WholeBody.Point.disableGravity);
         }
 
@@ -181,7 +201,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             scene.BreakCandyBody(candy.WholeBody);
 
-            Assert.False(candy.inLantern);
+            Assert.False(candy.Lifecycle.Attachments.InLantern);
             Assert.False(candy.WholeBody.Point.disableGravity);
             HeadlessGame.StepFrames(scene, 10);
             Assert.False(candy.WholeBody.Point.disableGravity);
@@ -195,7 +215,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Act.LoseOffScreen(scene, candy);
 
-            Assert.False(candy.HasActiveRocket);
+            Assert.False(candy.Lifecycle.Attachments.HasActiveRocket);
             Assert.Equal(Rocket.STATE_ROCKET_EXAUST, rocket.state);
         }
 
@@ -271,7 +291,7 @@ namespace CutTheRopeDX.Tests.Interactions
             // The claw pins the candy back every frame, ahead of the off-screen check, so a held
             // candy never reaches the kill line - the hand has to let go first.
             Assert.Equal(0, scene.Outcomes().LostCount);
-            Assert.Same(hand, candy.capturingHand);
+            Assert.Same(hand, candy.Lifecycle.Attachments.Hand);
         }
 
         [Fact]
@@ -285,7 +305,7 @@ namespace CutTheRopeDX.Tests.Interactions
             HeadlessGame.StepFrames(scene, 60);
 
             Assert.Equal(0, scene.Outcomes().LostCount);
-            Assert.True(candy.carriedByMouse);
+            Assert.True(candy.Lifecycle.Attachments.CarriedByMouse);
         }
 
         private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment)

--- a/CutTheRopeDX.Tests/Interactions/MagicHatEntryRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/MagicHatEntryRowTests.cs
@@ -32,7 +32,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Act.EnterHat(scene, candy);
 
-            Assert.Null(candy.capturingHand);
+            Assert.Null(candy.Lifecycle.Attachments.Hand);
             Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, hand.state);
         }
 
@@ -44,8 +44,8 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Act.EnterHat(scene, candy);
 
-            Assert.True(candy.HasActiveRocket);
-            Assert.Same(rocket, candy.activeRocket);
+            Assert.True(candy.Lifecycle.Attachments.HasActiveRocket);
+            Assert.Same(rocket, candy.Lifecycle.Attachments.Rocket);
             Assert.False(rocket.visible);
         }
 
@@ -79,7 +79,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Act.EnterHat(scene, candy);
 
-            Assert.Null(candy.antSegment);
+            Assert.Null(candy.Lifecycle.Attachments.AntSegment);
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace CutTheRopeDX.Tests.Interactions
             Act.EnterHat(scene, candy);
 
             Assert.False(scene.MouseCarries(candy));
-            Assert.False(candy.carriedByMouse);
+            Assert.False(candy.Lifecycle.Attachments.CarriedByMouse);
         }
 
         private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment)

--- a/CutTheRopeDX.Tests/Interactions/MouseGrabRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/MouseGrabRowTests.cs
@@ -32,9 +32,9 @@ namespace CutTheRopeDX.Tests.Interactions
 
             _ = Act.CarryByMouse(scene, candy);
 
-            Assert.Null(candy.capturingHand);
+            Assert.Null(candy.Lifecycle.Attachments.Hand);
             Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, hand.state);
-            Assert.True(candy.carriedByMouse);
+            Assert.True(candy.Lifecycle.Attachments.CarriedByMouse);
         }
 
         [Fact]
@@ -45,8 +45,8 @@ namespace CutTheRopeDX.Tests.Interactions
 
             _ = Act.CarryByMouse(scene, candy);
 
-            Assert.True(candy.HasActiveRocket);
-            Assert.Same(rocket, candy.activeRocket);
+            Assert.True(candy.Lifecycle.Attachments.HasActiveRocket);
+            Assert.Same(rocket, candy.Lifecycle.Attachments.Rocket);
         }
 
         [Fact]
@@ -82,8 +82,21 @@ namespace CutTheRopeDX.Tests.Interactions
             _ = Act.CarryByMouseWithoutMovingIt(scene, candy);
             HeadlessGame.StepFrames(scene, 30);
 
-            Assert.True(candy.carriedByMouse);
-            Assert.Null(candy.antSegment);
+            Assert.True(candy.Lifecycle.Attachments.CarriedByMouse);
+            Assert.Null(candy.Lifecycle.Attachments.AntSegment);
+        }
+
+        [Fact]
+        public void ClickingTheCarryingMouseImmediatelyClearsCandyOwnership()
+        {
+            (GameScene scene, CandyContext candy) = Rig(s => s);
+            Mouse mouse = Act.CarryByMouse(scene, candy);
+
+            Assert.True(scene.TouchDownXYIndex((int)mouse.x, (int)mouse.y, 0));
+
+            Assert.False(scene.MouseCarries(candy));
+            Assert.False(candy.Lifecycle.Attachments.CarriedByMouse);
+            Assert.Equal(candy.Lifecycle.IsGravitySuppressed, candy.WholeBody.Point.disableGravity);
         }
 
         private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment, int mouseY = 40)

--- a/CutTheRopeDX.Tests/Interactions/PerCandyIsolationTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/PerCandyIsolationTests.cs
@@ -85,7 +85,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Act.CaptureInLantern(scene, captured);
 
-            Assert.True(captured.inLantern);
+            Assert.True(captured.Lifecycle.Attachments.InLantern);
             Assert.Same(bubble, kept.WholeBody.Bubble);
         }
 
@@ -113,8 +113,8 @@ namespace CutTheRopeDX.Tests.Interactions
 
             _ = Act.CarryByMouse(scene, stolen);
 
-            Assert.True(stolen.carriedByMouse);
-            Assert.Same(hand, kept.capturingHand);
+            Assert.True(stolen.Lifecycle.Attachments.CarriedByMouse);
+            Assert.Same(hand, kept.Lifecycle.Attachments.Hand);
         }
 
         [Fact]
@@ -128,7 +128,7 @@ namespace CutTheRopeDX.Tests.Interactions
             Act.EnterBambooTube(scene, swallowed, TubeMouth.CatchesFalling);
 
             Assert.NotNull(swallowed.Lifecycle.Transport?.BambooTube);
-            Assert.Same(rocket, kept.activeRocket);
+            Assert.Same(rocket, kept.Lifecycle.Attachments.Rocket);
             Assert.True(rocket.visible);
         }
 

--- a/CutTheRopeDX.Tests/Interactions/RocketBindRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/RocketBindRowTests.cs
@@ -31,8 +31,8 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Rocket rocket = Act.BindRocket(scene, candy);
 
-            Assert.Same(hand, candy.capturingHand);
-            Assert.Same(rocket, candy.activeRocket);
+            Assert.Same(hand, candy.Lifecycle.Attachments.Hand);
+            Assert.Same(rocket, candy.Lifecycle.Attachments.Rocket);
 
             // A holder's rocket skips the reel-in and goes straight to FLY, straining at the claw
             // until the hand lets go.
@@ -47,7 +47,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Rocket second = Act.BindRocket(scene, candy, rocketIndex: 0);
 
-            Assert.Same(second, candy.activeRocket);
+            Assert.Same(second, candy.Lifecycle.Attachments.Rocket);
             Assert.Equal(Rocket.STATE_ROCKET_EXAUST, first.state);
         }
 
@@ -87,7 +87,7 @@ namespace CutTheRopeDX.Tests.Interactions
             _ = Act.BindRocket(scene, candy);
             HeadlessGame.StepFrames(scene, 150);
 
-            Assert.Null(candy.antSegment);
+            Assert.Null(candy.Lifecycle.Attachments.AntSegment);
         }
 
         [Fact]
@@ -98,8 +98,8 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Rocket rocket = Act.BindRocket(scene, candy);
 
-            Assert.True(candy.carriedByMouse);
-            Assert.Same(rocket, candy.activeRocket);
+            Assert.True(candy.Lifecycle.Attachments.CarriedByMouse);
+            Assert.Same(rocket, candy.Lifecycle.Attachments.Rocket);
             Assert.Equal(Rocket.STATE_ROCKET_FLY, rocket.state);
         }
 

--- a/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
+++ b/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
@@ -294,14 +294,16 @@ namespace CutTheRopeDX.Tests.Interactions
         {
             Assert.Equal(0, scene.AttachedRopeCount(candy));
             Assert.Null(candy.WholeBody.Bubble);
-            Assert.Null(candy.activeRocket);
-            Assert.Null(candy.capturingHand);
+            Assert.Null(candy.Lifecycle.Attachments.Rocket);
+            Assert.Null(candy.Lifecycle.Attachments.Hand);
             Assert.False(scene.MouseCarries(candy));
-            Assert.False(candy.carriedByMouse);
-            Assert.Null(candy.antSegment);
-            Assert.Null(candy.lastAntSegment);
+            Assert.False(candy.Lifecycle.Attachments.CarriedByMouse);
+            Assert.Null(candy.Lifecycle.Attachments.AntSegment);
+            Assert.Null(candy.Lifecycle.Attachments.LastAntSegment);
             Assert.Equal(0, scene.SnailCount(candy));
-            Assert.False(candy.inLantern);
+            Assert.False(candy.Lifecycle.Attachments.InLantern);
+            Assert.False(candy.Lifecycle.Attachments.HasAny);
+            Assert.False(candy.Lifecycle.IsGravitySuppressed);
             Assert.False(candy.WholeBody.Point.disableGravity);
         }
 

--- a/CutTheRopeDX.Tests/Interactions/SnailAttachRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/SnailAttachRowTests.cs
@@ -30,7 +30,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             _ = Act.RideSnail(scene, candy);
 
-            Assert.Same(hand, candy.capturingHand);
+            Assert.Same(hand, candy.Lifecycle.Attachments.Hand);
             Assert.Equal(1, scene.SnailCount(candy));
         }
 
@@ -42,7 +42,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             _ = Act.RideSnail(scene, candy);
 
-            Assert.Same(rocket, candy.activeRocket);
+            Assert.Same(rocket, candy.Lifecycle.Attachments.Rocket);
             Assert.Equal(1, scene.SnailCount(candy));
         }
 
@@ -79,7 +79,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             _ = Act.RideSnail(scene, candy);
 
-            Assert.NotNull(candy.antSegment);
+            Assert.NotNull(candy.Lifecycle.Attachments.AntSegment);
             Assert.Equal(1, scene.SnailCount(candy));
         }
 
@@ -91,7 +91,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             _ = Act.RideSnail(scene, candy);
 
-            Assert.True(candy.carriedByMouse);
+            Assert.True(candy.Lifecycle.Attachments.CarriedByMouse);
             Assert.Equal(1, scene.SnailCount(candy));
         }
 

--- a/CutTheRopeDX.Tests/Interactions/SpiderRemovalInvariantTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/SpiderRemovalInvariantTests.cs
@@ -84,7 +84,7 @@ namespace CutTheRopeDX.Tests.Interactions
             scene.SpiderWon(scene.Grabs()[0]);
 
             scene.AssertNoLiveAttachments(captured);
-            Assert.True(mouseCandy.carriedByMouse);
+            Assert.True(mouseCandy.Lifecycle.Attachments.CarriedByMouse);
             Assert.True(scene.MouseCarries(mouseCandy));
         }
 

--- a/CutTheRopeDX.Tests/LanternReleaseTests.cs
+++ b/CutTheRopeDX.Tests/LanternReleaseTests.cs
@@ -23,8 +23,8 @@ namespace CutTheRopeDX.Tests
             int restoredIndex = LanternRelease.RestoreReleasedCandy(candies, secondPoint);
 
             Assert.Equal(1, restoredIndex);
-            Assert.True(first.inLantern);
-            Assert.False(second.inLantern);
+            Assert.True(first.Lifecycle.Attachments.InLantern);
+            Assert.False(second.Lifecycle.Attachments.InLantern);
             Assert.True(RGBAColor.RGBAEqual(RGBAColor.transparentRGBA, first.WholeBody.Visual.color));
             Assert.True(RGBAColor.RGBAEqual(RGBAColor.solidOpaqueRGBA, second.WholeBody.Visual.color));
             Assert.False(second.WholeBody.Visual.passTransformationsToChilds);
@@ -45,7 +45,9 @@ namespace CutTheRopeDX.Tests
                 CapturedVisual(),
                 CapturedVisual());
 
-            return new CandyContext(body) { inLantern = true };
+            CandyContext candy = new(body);
+            _ = candy.Lifecycle.Attachments.CaptureInLantern();
+            return candy;
         }
 
         private static GameObject CapturedVisual()

--- a/CutTheRopeDX.Tests/LightBulbPresentationTests.cs
+++ b/CutTheRopeDX.Tests/LightBulbPresentationTests.cs
@@ -20,7 +20,7 @@ namespace CutTheRopeDX.Tests
                 .Build();
             CandyContext context = scene.Candies().Single(candy => candy.emitsLight);
 
-            Assert.True(context.Lifecycle.TryRemove(CandyRemovalReason.OffScreen));
+            Assert.True(context.Lifecycle.TryRemove(CandyRemovalReason.OffScreen, out _));
 
             context.LightBulb.Update(0.016f);
 

--- a/CutTheRopeDX/GameMain/CandyAttachments.cs
+++ b/CutTheRopeDX/GameMain/CandyAttachments.cs
@@ -87,7 +87,7 @@ namespace CutTheRopeDX.GameMain
             || CarriedByMouse;
 
         /// <summary>Gets whether an attachment currently owns gravity for the candy point.</summary>
-        public bool IsGravitySuppressed => InLantern
+        public bool SuppressGravity => InLantern
             || Rocket != null
             || AntSegment != null
             || CarriedByMouse;

--- a/CutTheRopeDX/GameMain/CandyAttachments.cs
+++ b/CutTheRopeDX/GameMain/CandyAttachments.cs
@@ -1,0 +1,286 @@
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.Framework.Helpers;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>Immutable owners released by an authoritative attachment transition.</summary>
+    internal sealed class CandyAttachmentSnapshot
+    {
+        internal CandyAttachmentSnapshot(
+            bool inLantern,
+            Rocket rocket,
+            AntsPathSegment antSegment,
+            MechanicalHand hand,
+            bool carriedByMouse)
+        {
+            InLantern = inLantern;
+            Rocket = rocket;
+            AntSegment = antSegment;
+            Hand = hand;
+            CarriedByMouse = carriedByMouse;
+        }
+
+        /// <summary>Gets whether a lantern owned the candy.</summary>
+        public bool InLantern { get; }
+
+        /// <summary>Gets the rocket that owned the candy, if any.</summary>
+        public Rocket Rocket { get; }
+
+        /// <summary>Gets the ant segment that actively carried the candy, if any.</summary>
+        public AntsPathSegment AntSegment { get; }
+
+        /// <summary>Gets the mechanical hand that owned the candy, if any.</summary>
+        public MechanicalHand Hand { get; }
+
+        /// <summary>Gets whether the mouse owned the candy.</summary>
+        public bool CarriedByMouse { get; }
+    }
+
+    /// <summary>
+    /// Authoritative runtime attachment state for one logical candy. Mutations are expressed as
+    /// complete transitions so device ownership and ant-conveyor bookkeeping cannot drift apart.
+    /// </summary>
+    internal sealed class CandyAttachments
+    {
+        private float antCooldown;
+
+        /// <summary>Gets whether a lantern currently contains the candy.</summary>
+        public bool InLantern { get; private set; }
+
+        /// <summary>Gets the rocket currently bound to the candy, if any.</summary>
+        public Rocket Rocket { get; private set; }
+
+        /// <summary>Gets whether a rocket is currently bound to the candy.</summary>
+        public bool HasActiveRocket => Rocket != null;
+
+        /// <summary>Gets the ant segment currently carrying the candy, if any.</summary>
+        public AntsPathSegment AntSegment { get; private set; }
+
+        /// <summary>Gets the last ant segment, retained during the reattachment cooldown.</summary>
+        public AntsPathSegment LastAntSegment { get; private set; }
+
+        /// <summary>Gets the remaining ant reattachment cooldown.</summary>
+        public float AntCooldown => antCooldown;
+
+        /// <summary>Gets whether the candy must leave the ant lane before reattaching.</summary>
+        public bool AntWaitingForExit { get; private set; }
+
+        /// <summary>Gets the candy's independent marker on its ant segment.</summary>
+        public Vector AntInteractionPoint { get; private set; }
+
+        /// <summary>Gets the elapsed time of the current ant interaction.</summary>
+        public float AntInteractionTime { get; private set; }
+
+        /// <summary>Gets the mechanical hand currently holding the candy, if any.</summary>
+        public MechanicalHand Hand { get; private set; }
+
+        /// <summary>Gets whether the active mouse currently carries the candy.</summary>
+        public bool CarriedByMouse { get; private set; }
+
+        /// <summary>Gets whether the aggregate contains a live attachment or reattachment guard.</summary>
+        public bool HasAny => InLantern
+            || Rocket != null
+            || AntSegment != null
+            || LastAntSegment != null
+            || AntWaitingForExit
+            || Hand != null
+            || CarriedByMouse;
+
+        /// <summary>Gets whether an attachment currently owns gravity for the candy point.</summary>
+        public bool IsGravitySuppressed => InLantern
+            || Rocket != null
+            || AntSegment != null
+            || CarriedByMouse;
+
+        /// <summary>
+        /// Captures the candy in a lantern and atomically releases every incompatible carrier.
+        /// </summary>
+        /// <returns>The former rocket, hand, ant, and mouse owners for scene-level cleanup.</returns>
+        public CandyAttachmentSnapshot CaptureInLantern()
+        {
+            CandyAttachmentSnapshot snapshot = new(
+                inLantern: false,
+                rocket: Rocket,
+                antSegment: AntSegment,
+                hand: Hand,
+                carriedByMouse: CarriedByMouse);
+            InLantern = true;
+            Rocket = null;
+            Hand = null;
+            CarriedByMouse = false;
+            ResetAnts();
+            return snapshot;
+        }
+
+        /// <summary>Records that the candy has left its lantern.</summary>
+        public void ReleaseFromLantern()
+        {
+            InLantern = false;
+        }
+
+        /// <summary>Binds a non-null rocket to the candy.</summary>
+        /// <returns><see langword="true"/> when the binding was recorded.</returns>
+        public bool BindRocket(Rocket rocket)
+        {
+            if (rocket == null)
+            {
+                return false;
+            }
+
+            Rocket = rocket;
+            return true;
+        }
+
+        /// <summary>Releases the rocket only when it is still the current owner.</summary>
+        /// <returns><see langword="true"/> when the expected rocket was released.</returns>
+        public bool TryReleaseRocket(Rocket expectedRocket)
+        {
+            if (expectedRocket == null || !ReferenceEquals(Rocket, expectedRocket))
+            {
+                return false;
+            }
+
+            Rocket = null;
+            return true;
+        }
+
+        /// <summary>Records a non-null mechanical hand as the current holder.</summary>
+        /// <returns><see langword="true"/> when the holder was recorded.</returns>
+        public bool CaptureByHand(MechanicalHand hand)
+        {
+            if (hand == null)
+            {
+                return false;
+            }
+
+            Hand = hand;
+            return true;
+        }
+
+        /// <summary>Releases the hand only when it is still the current owner.</summary>
+        /// <returns><see langword="true"/> when the expected hand was released.</returns>
+        public bool TryReleaseHand(MechanicalHand expectedHand)
+        {
+            if (expectedHand == null || !ReferenceEquals(Hand, expectedHand))
+            {
+                return false;
+            }
+
+            Hand = null;
+            return true;
+        }
+
+        /// <summary>Synchronizes ownership with the active mouse.</summary>
+        public void SetCarriedByMouse(bool carried)
+        {
+            CarriedByMouse = carried;
+        }
+
+        /// <summary>Starts a complete ant-conveyor carry interaction.</summary>
+        /// <returns><see langword="true"/> when a non-null segment was attached.</returns>
+        public bool BeginAntCarry(
+            AntsPathSegment segment,
+            Vector interactionPoint,
+            float cooldown,
+            float interactionTime)
+        {
+            if (segment == null)
+            {
+                return false;
+            }
+
+            AntSegment = segment;
+            LastAntSegment = segment;
+            antCooldown = cooldown;
+            AntInteractionPoint = interactionPoint;
+            AntInteractionTime = interactionTime;
+            return true;
+        }
+
+        /// <summary>Advances the marker and elapsed time of the current ant carry.</summary>
+        public void AdvanceAntCarry(float delta)
+        {
+            if (AntSegment == null)
+            {
+                return;
+            }
+
+            AntInteractionTime += delta;
+            AntInteractionPoint = new Vector(
+                AntInteractionPoint.X + (AntSegment.speed.X * delta),
+                AntInteractionPoint.Y + (AntSegment.speed.Y * delta));
+        }
+
+        /// <summary>Records whether the candy must leave the ant lane before it can reattach.</summary>
+        public void SetAntWaitingForExit(bool waiting)
+        {
+            AntWaitingForExit = waiting;
+        }
+
+        /// <summary>Ends the active ant carry while retaining cooldown state for reattachment rules.</summary>
+        public void EndAntCarry(bool waitForExit)
+        {
+            AntSegment = null;
+            AntWaitingForExit = waitForExit;
+        }
+
+        /// <summary>Advances the inactive ant cooldown and forgets the last segment at zero.</summary>
+        /// <returns><see langword="true"/> when the cooldown reached zero during this call.</returns>
+        public bool AdvanceAntCooldown(float delta)
+        {
+            if (LastAntSegment == null || AntSegment != null)
+            {
+                return false;
+            }
+
+            bool expired = Mover.MoveVariableToTarget(ref antCooldown, 0f, 1f, delta);
+            if (expired)
+            {
+                LastAntSegment = null;
+            }
+
+            return expired;
+        }
+
+        /// <summary>Clears active and residual ant-conveyor state together.</summary>
+        public void ResetAnts()
+        {
+            AntWaitingForExit = false;
+            AntSegment = null;
+            LastAntSegment = null;
+            antCooldown = 0f;
+            AntInteractionPoint = default;
+            AntInteractionTime = 0f;
+        }
+
+        /// <summary>
+        /// Clears carriers that cannot survive transport while preserving a bound rocket.
+        /// </summary>
+        /// <returns>The former hand, ant, and mouse owners for scene-level cleanup.</returns>
+        public CandyAttachmentSnapshot DetachForTransport()
+        {
+            CandyAttachmentSnapshot snapshot = new(
+                inLantern: false,
+                rocket: null,
+                antSegment: AntSegment,
+                hand: Hand,
+                carriedByMouse: CarriedByMouse);
+            Hand = null;
+            CarriedByMouse = false;
+            ResetAnts();
+            return snapshot;
+        }
+
+        /// <summary>Atomically clears every attachment and returns the former owners.</summary>
+        public CandyAttachmentSnapshot DetachAll()
+        {
+            CandyAttachmentSnapshot snapshot = new(InLantern, Rocket, AntSegment, Hand, CarriedByMouse);
+            InLantern = false;
+            Rocket = null;
+            Hand = null;
+            CarriedByMouse = false;
+            ResetAnts();
+            return snapshot;
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/CandyCollision.cs
+++ b/CutTheRopeDX/GameMain/CandyCollision.cs
@@ -42,7 +42,7 @@ namespace CutTheRopeDX.GameMain
         public static bool ShouldParticipate(CandyContext ctx)
         {
             return ctx != null
-                && ShouldParticipate(ctx.HasNoWholeBodyInPlay, ctx.inLantern)
+                && ShouldParticipate(ctx.HasNoWholeBodyInPlay, ctx.Lifecycle.Attachments.InLantern)
                 && ctx.Capabilities.CanCollideWithCandyBodies;
         }
 

--- a/CutTheRopeDX/GameMain/CandyContext.cs
+++ b/CutTheRopeDX/GameMain/CandyContext.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 
-using CutTheRopeDX.Framework.Core;
 using CutTheRopeDX.Framework.Helpers;
 using CutTheRopeDX.Framework.Visual;
 
@@ -45,15 +44,6 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         public bool HasNoWholeBodyInPlay => Lifecycle.Presence != CandyPresence.Present;
 
-        /// <summary>True while this candy is captured in a lantern (was the singleton <c>isCandyInLantern</c>).</summary>
-        public bool inLantern;
-
-        /// <summary>The rocket currently flying this candy, if any (was the singleton <c>activeRocket</c>).</summary>
-        public Rocket activeRocket;
-
-        /// <summary>True while a rocket is bound to and flying this candy.</summary>
-        public bool HasActiveRocket => activeRocket != null;
-
         /// <summary>
         /// True when this candy can be grabbed by a mechanical hand right now: it is present and its
         /// capabilities permit it. The <c>Is*</c> form folds in presence; <see cref="CandyCapabilities"/>
@@ -63,34 +53,6 @@ namespace CutTheRopeDX.GameMain
 
         /// <summary>True when this candy can attach to an ant conveyor right now: present and capable.</summary>
         public bool IsAntAttachable => !HasNoWholeBodyInPlay && Capabilities.CanAttachAnts;
-
-        /// <summary>Ant-conveyor segment currently carrying this candy (null if not carried).</summary>
-        public AntsPathSegment antSegment;
-
-        /// <summary>Last segment that carried this candy, held during the re-attach cooldown.</summary>
-        public AntsPathSegment lastAntSegment;
-
-        /// <summary>Re-attach cooldown timer for this candy's last segment.</summary>
-        public float antCooldown;
-
-        /// <summary>True while this candy must leave a segment's external bounds before re-attaching.</summary>
-        public bool antWaitForFly;
-
-        /// <summary>
-        /// This candy's own carrier marker on <see cref="antSegment"/>. It starts at the candy's
-        /// projection onto the segment and advances at the segment speed, so multiple candies ride the
-        /// same lane independently, each keeping the spacing it had on entry. Unused when not carried.
-        /// </summary>
-        public Vector antInteractionPoint;
-
-        /// <summary>Seconds since this candy attached to <see cref="antSegment"/> (carry snap + detach grace).</summary>
-        public float antInteractionTime;
-
-        /// <summary>The mechanical hand currently holding this candy, if any (one candy per hand).</summary>
-        public MechanicalHand capturingHand;
-
-        /// <summary>True while this candy is the one carried by the active mouse (single-occupancy).</summary>
-        public bool carriedByMouse;
 
         /// <summary>Behavior flags for this candy-like physics body.</summary>
         public CandyCapabilities Capabilities = CandyCapabilities.Candy;

--- a/CutTheRopeDX/GameMain/CandyLifecycle.cs
+++ b/CutTheRopeDX/GameMain/CandyLifecycle.cs
@@ -10,6 +10,7 @@ namespace CutTheRopeDX.GameMain
             Presence = presence;
             WholeBody = wholeBody;
             Split = split;
+            Attachments = new CandyAttachments();
         }
 
         /// <summary>Gets the candy's current lifecycle topology.</summary>
@@ -26,6 +27,15 @@ namespace CutTheRopeDX.GameMain
 
         /// <summary>Gets the current hidden transport session, or <see langword="null"/> outside transport.</summary>
         public CandyTransportSession Transport { get; private set; }
+
+        /// <summary>Gets the authoritative whole-candy attachment state.</summary>
+        public CandyAttachments Attachments { get; }
+
+        /// <summary>Gets whether the present candy may start a transport operation.</summary>
+        public bool CanEnterTransport => Presence == CandyPresence.Present && !Attachments.InLantern;
+
+        /// <summary>Gets whether lifecycle or attachment ownership currently suppresses gravity.</summary>
+        public bool IsGravitySuppressed => Presence == CandyPresence.Hidden || Attachments.IsGravitySuppressed;
 
         /// <summary>Gets the physical bodies currently available to scene systems.</summary>
         public IReadOnlyList<CandyBody> ActiveBodies =>
@@ -88,21 +98,26 @@ namespace CutTheRopeDX.GameMain
             return true;
         }
 
-        /// <summary>Permanently removes a present candy for the specified reason.</summary>
+        /// <summary>
+        /// Permanently removes a present candy and atomically detaches its whole-candy owners.
+        /// </summary>
         /// <param name="reason">The reason the candy is removed.</param>
+        /// <param name="detachedAttachments">Former attachment owners for scene-level cleanup.</param>
         /// <returns>
-        /// <see langword="true"/> when the candy transitions from present to removed;
-        /// otherwise, <see langword="false"/> when the transition is illegal or already terminal.
+        /// <see langword="true"/> when the candy transitioned to removed; otherwise,
+        /// <see langword="false"/> without changing lifecycle or attachment state.
         /// </returns>
-        public bool TryRemove(CandyRemovalReason reason)
+        public bool TryRemove(CandyRemovalReason reason, out CandyAttachmentSnapshot detachedAttachments)
         {
             if (Presence != CandyPresence.Present)
             {
+                detachedAttachments = null;
                 return false;
             }
 
             Presence = CandyPresence.Removed;
             RemovalReason = reason;
+            detachedAttachments = Attachments.DetachAll();
             return true;
         }
 
@@ -125,17 +140,22 @@ namespace CutTheRopeDX.GameMain
 
         /// <summary>Temporarily hides a present whole body inside the specified transport session.</summary>
         /// <param name="session">The exact transport session that will later complete this transition.</param>
+        /// <param name="detachedAttachments">Former incompatible carriers for scene-level cleanup.</param>
         /// <returns>
         /// <see langword="true"/> when a present whole candy becomes hidden; otherwise,
         /// <see langword="false"/> when the lifecycle is removed, split, or already hidden.
         /// </returns>
-        public bool TryHide(CandyTransportSession session)
+        public bool TryHide(
+            CandyTransportSession session,
+            out CandyAttachmentSnapshot detachedAttachments)
         {
-            if (Presence != CandyPresence.Present)
+            if (session == null || !CanEnterTransport)
             {
+                detachedAttachments = null;
                 return false;
             }
 
+            detachedAttachments = Attachments.DetachForTransport();
             Transport = session;
             Presence = CandyPresence.Hidden;
             return true;

--- a/CutTheRopeDX/GameMain/CandyLifecycle.cs
+++ b/CutTheRopeDX/GameMain/CandyLifecycle.cs
@@ -35,7 +35,7 @@ namespace CutTheRopeDX.GameMain
         public bool CanEnterTransport => Presence == CandyPresence.Present && !Attachments.InLantern;
 
         /// <summary>Gets whether lifecycle or attachment ownership currently suppresses gravity.</summary>
-        public bool IsGravitySuppressed => Presence == CandyPresence.Hidden || Attachments.IsGravitySuppressed;
+        public bool IsGravitySuppressed => Presence == CandyPresence.Hidden || Attachments.SuppressGravity;
 
         /// <summary>Gets the physical bodies currently available to scene systems.</summary>
         public IReadOnlyList<CandyBody> ActiveBodies =>

--- a/CutTheRopeDX/GameMain/GameScene.Ants.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Ants.cs
@@ -1,5 +1,4 @@
 using CutTheRopeDX.Framework.Core;
-using CutTheRopeDX.Framework.Helpers;
 using CutTheRopeDX.Framework.Physics;
 
 namespace CutTheRopeDX.GameMain
@@ -46,42 +45,34 @@ namespace CutTheRopeDX.GameMain
         {
             // The caller only offers whole bodies, so this candy rides the conveyor on one point.
             ConstraintedPoint point = ctx.WholeBody.Point;
+            CandyAttachments attachments = ctx.Lifecycle.Attachments;
 
             // Advance this candy's own carrier marker along its segment (replaces the segment-level
             // marker; lets several candies ride one lane, each keeping the spacing it entered with).
-            if (ctx.antSegment != null)
-            {
-                ctx.antInteractionTime += delta;
-                ctx.antInteractionPoint = new Vector(
-                    ctx.antInteractionPoint.X + (ctx.antSegment.speed.X * delta),
-                    ctx.antInteractionPoint.Y + (ctx.antSegment.speed.Y * delta));
-            }
+            attachments.AdvanceAntCarry(delta);
 
-            if (ctx.antWaitForFly)
+            if (attachments.AntWaitingForExit)
             {
-                ctx.antWaitForFly = false;
+                bool stillInside = false;
                 foreach (AntsPathSegment segment in antsPathsSegments)
                 {
                     if (segment.ContainsPoint(point.pos, external: true))
                     {
-                        ctx.antWaitForFly = true;
+                        stillInside = true;
                         break;
                     }
                 }
+
+                attachments.SetAntWaitingForExit(stillInside);
             }
 
-            if (ctx.lastAntSegment != null
-                && ctx.antSegment == null
-                && Mover.MoveVariableToTarget(ref ctx.antCooldown, 0f, 1f, 0.01f))
-            {
-                ctx.lastAntSegment = null;
-            }
+            _ = attachments.AdvanceAntCooldown(0.01f);
 
-            AntsPathSegment carrier = ctx.antSegment;
+            AntsPathSegment carrier = attachments.AntSegment;
             if (AntCandyInteraction.ShouldDetach(
                 candyCarriedBySegment: carrier != null,
                 segmentInteracting: carrier != null,
-                interactionTime: ctx.antInteractionTime,
+                interactionTime: attachments.AntInteractionTime,
                 candyInsideInternalBounds: carrier?.ContainsPoint(point.pos) == true))
             {
                 bool otherSegmentContainsCandyExternally = false;
@@ -95,8 +86,8 @@ namespace CutTheRopeDX.GameMain
                 }
 
                 bool shouldSlowStop = AntCandyInteraction.ShouldSlowStopAfterDetach(otherSegmentContainsCandyExternally);
-                point.disableGravity = ctx.HasActiveRocket;
-                ctx.antSegment = null;
+                attachments.EndAntCarry(waitForExit: false);
+                point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
 
                 if (shouldSlowStop)
                 {
@@ -105,7 +96,7 @@ namespace CutTheRopeDX.GameMain
                 }
             }
 
-            if (ctx.antSegment == null)
+            if (attachments.AntSegment == null)
             {
                 bool attached = false;
                 foreach (AntsPathSegment segment in antsPathsSegments)
@@ -144,22 +135,22 @@ namespace CutTheRopeDX.GameMain
             {
                 CandyContext ctx = candies[ci];
                 ConstraintedPoint point = ctx.WholeBody.Point;
-                if (ctx.antSegment == null || point == null)
+                if (ctx.Lifecycle.Attachments.AntSegment == null || point == null)
                 {
                     continue;
                 }
 
                 Vector nextPos = AntConveyorLogic.ComputeCarrierFollowPosition(
                     point.pos,
-                    ctx.antInteractionPoint,
-                    ctx.antInteractionTime,
+                    ctx.Lifecycle.Attachments.AntInteractionPoint,
+                    ctx.Lifecycle.Attachments.AntInteractionTime,
                     snapDistance);
 
                 point.pos = nextPos;
 
-                if (ctx.activeRocket?.point != null)
+                if (ctx.Lifecycle.Attachments.Rocket?.point != null)
                 {
-                    ctx.activeRocket.point.pos = nextPos;
+                    ctx.Lifecycle.Attachments.Rocket.point.pos = nextPos;
                 }
             }
         }
@@ -180,7 +171,7 @@ namespace CutTheRopeDX.GameMain
             }
 
             CandyContext ctx = CandyForPointOrNull(point);
-            if (ctx == null || ctx.WholeBody.Point != point || ctx.antSegment == null)
+            if (ctx == null || ctx.WholeBody.Point != point || ctx.Lifecycle.Attachments.AntSegment == null)
             {
                 return false;
             }
@@ -193,11 +184,11 @@ namespace CutTheRopeDX.GameMain
                 return false;
             }
 
-            ctx.antWaitForFly = true;
+            ctx.Lifecycle.Attachments.SetAntWaitingForExit(true);
             ApplyConveyorBrake(ctx);
-            ctx.antSegment = null;
+            ctx.Lifecycle.Attachments.EndAntCarry(waitForExit: true);
             PlayAntConveyorDetachSound();
-            point.disableGravity = ctx.HasActiveRocket;
+            point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
             return true;
         }
 
@@ -227,20 +218,15 @@ namespace CutTheRopeDX.GameMain
                 return;
             }
 
-            if (ctx.antSegment != null)
+            bool wasCarried = ctx.Lifecycle.Attachments.AntSegment != null;
+            ctx.Lifecycle.Attachments.ResetAnts();
+            if (wasCarried)
             {
                 PlayAntConveyorDetachSound();
 
                 // A candy can only hold a segment if it had a point when it attached.
-                ctx.WholeBody.Point.disableGravity = ctx.HasActiveRocket;
+                ctx.WholeBody.Point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
             }
-
-            ctx.antWaitForFly = false;
-            ctx.antSegment = null;
-            ctx.lastAntSegment = null;
-            ctx.antCooldown = 0f;
-            ctx.antInteractionPoint = default;
-            ctx.antInteractionTime = 0f;
         }
 
         /// <summary>
@@ -264,34 +250,30 @@ namespace CutTheRopeDX.GameMain
             if (!AntCandyInteraction.CanAttach(
                 candyPresent: point != null,
                 segmentCanInteract: segment.canInteract,
-                candyWaitingForFly: ctx.antWaitForFly,
-                isLastSegment: segment == ctx.lastAntSegment,
+                candyWaitingForFly: ctx.Lifecycle.Attachments.AntWaitingForExit,
+                isLastSegment: segment == ctx.Lifecycle.Attachments.LastAntSegment,
                 candyInsideBounds: contains,
-                candyHeldByHand: ctx.capturingHand != null,
-                candyInLantern: ctx.inLantern,
+                candyHeldByHand: ctx.Lifecycle.Attachments.Hand != null,
+                candyInLantern: ctx.Lifecycle.Attachments.InLantern,
                 candyInTransport: ctx.Lifecycle.Presence == CandyPresence.Hidden,
-                candyCarriedByMouse: ctx.carriedByMouse))
+                candyCarriedByMouse: ctx.Lifecycle.Attachments.CarriedByMouse))
             {
                 return false;
             }
 
             // Sound the pickup only when this candy first boards the conveyor, not on the internal
             // segment-to-segment hops (lastAntSegment is still set while it hops within a path).
-            bool freshPickup = ctx.lastAntSegment == null;
-
-            ctx.WholeBody.Point.disableGravity = true;
-            ctx.antSegment = segment;
-            ctx.lastAntSegment = segment;
-            ctx.antCooldown = 0.3f;
+            bool freshPickup = ctx.Lifecycle.Attachments.LastAntSegment == null;
 
             // Seed this candy's marker at its projection onto the segment, then nudge it one tick
             // (mirrors the segment's old StartInteraction + Update(0.01) on attach).
-            ctx.antInteractionPoint = AntsPathSegment.GetPointOnSegmentFromPointtoPointnearestToPoint(
+            Vector interactionPoint = AntsPathSegment.GetPointOnSegmentFromPointtoPointnearestToPoint(
                 segment.startPoint, segment.endPoint, ctx.WholeBody.Point.pos);
-            ctx.antInteractionTime = 0.01f;
-            ctx.antInteractionPoint = new Vector(
-                ctx.antInteractionPoint.X + (segment.speed.X * 0.01f),
-                ctx.antInteractionPoint.Y + (segment.speed.Y * 0.01f));
+            interactionPoint = new Vector(
+                interactionPoint.X + (segment.speed.X * 0.01f),
+                interactionPoint.Y + (segment.speed.Y * 0.01f));
+            _ = ctx.Lifecycle.Attachments.BeginAntCarry(segment, interactionPoint, 0.3f, 0.01f);
+            ctx.WholeBody.Point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
 
             if (freshPickup)
             {
@@ -332,7 +314,7 @@ namespace CutTheRopeDX.GameMain
 
             ConstraintedPoint tail = rope.tail;
             CandyContext ctx = CandyForPointOrNull(tail);
-            bool carried = ctx != null && ctx.WholeBody.Point == tail && ctx.antSegment != null;
+            bool carried = ctx != null && ctx.WholeBody.Point == tail && ctx.Lifecycle.Attachments.AntSegment != null;
             if (!carried)
             {
                 rope.Update(delta * ropePhysicsSpeed);

--- a/CutTheRopeDX/GameMain/GameScene.CandyCollision.cs
+++ b/CutTheRopeDX/GameMain/GameScene.CandyCollision.cs
@@ -38,7 +38,7 @@ namespace CutTheRopeDX.GameMain
                         continue;
                     }
                     // Handclap exemption: two hand-held candies pass through each other (spec §4).
-                    if (ca.capturingHand != null && cb.capturingHand != null)
+                    if (ca.Lifecycle.Attachments.Hand != null && cb.Lifecycle.Attachments.Hand != null)
                     {
                         continue;
                     }

--- a/CutTheRopeDX/GameMain/GameScene.CandyRemoval.cs
+++ b/CutTheRopeDX/GameMain/GameScene.CandyRemoval.cs
@@ -15,28 +15,35 @@ namespace CutTheRopeDX.GameMain
         /// <returns><see langword="true"/> only when the body transitioned to removed.</returns>
         private bool TryRetireCandyBody(CandyBody body, CandyRemovalReason reason)
         {
-            if (body?.Owner == null || !TryCommitCandyRemoval(body, reason))
+            if (body?.Owner == null || !TryCommitCandyRemoval(body, reason, out CandyAttachmentSnapshot detached))
             {
                 return false;
             }
 
-            ReleaseRemovalOwnership(body, reason);
+            ReleaseRemovalOwnership(body, reason, detached);
             return true;
         }
 
-        private static bool TryCommitCandyRemoval(CandyBody body, CandyRemovalReason reason)
+        private static bool TryCommitCandyRemoval(
+            CandyBody body,
+            CandyRemovalReason reason,
+            out CandyAttachmentSnapshot detached)
         {
             SplitCandyState split = body.Owner.Lifecycle.Split;
+            detached = null;
             return body.Role switch
             {
                 CandyBodyRole.LeftHalf => split?.Left.TryRemove(reason) == true,
                 CandyBodyRole.RightHalf => split?.Right.TryRemove(reason) == true,
-                CandyBodyRole.Whole => body.Owner.Lifecycle.TryRemove(reason),
+                CandyBodyRole.Whole => body.Owner.Lifecycle.TryRemove(reason, out detached),
                 _ => false,
             };
         }
 
-        private void ReleaseRemovalOwnership(CandyBody body, CandyRemovalReason reason)
+        private void ReleaseRemovalOwnership(
+            CandyBody body,
+            CandyRemovalReason reason,
+            CandyAttachmentSnapshot detached)
         {
             ReleaseRopesForBody(body);
             DetachRopeConstraintsForPoint(body.Point);
@@ -48,21 +55,84 @@ namespace CutTheRopeDX.GameMain
 
             if (body.Role == CandyBodyRole.Whole)
             {
-                CandyContext ctx = body.Owner;
-                DetachHandsForPoint(body.Point);
+                ReleaseDetachedHand(detached?.Hand, body.Point);
                 DetachSnailsForPoint(body.Point);
                 DropMouseCandyForPoint(body.Point);
-                ctx.carriedByMouse = false;
-                DetachCandyFromConveyor(ctx);
-                ExhaustRocketForCandy(ctx);
+                if (detached?.AntSegment != null)
+                {
+                    PlayAntConveyorDetachSound();
+                }
+                ExhaustDetachedRocket(detached?.Rocket);
                 CancelPendingLanternCaptureForRemoval(body.Point);
                 _ = Lantern.CancelCandyCaptureForRemoval(body.Point);
-                ctx.inLantern = false;
             }
 
             // Carrier release ordering is deliberately closed here: no owner may leave a retired
             // point gravity-suppressed. Authored/device-specific weight is preserved.
             body.Point.disableGravity = false;
+        }
+
+        private void ReleaseDetachedHand(MechanicalHand hand, ConstraintedPoint point)
+        {
+            if (hand == null)
+            {
+                return;
+            }
+
+            hand.cPoint.RemoveConstraint(point);
+            hand.state = MechanicalHand.STATE_HAND_RELEASE;
+            hand.doRotateCandy = false;
+            hand.releaseSoundPlayed = true;
+            hand.AnimateReleaseWithAnimationsPool(aniPool);
+            CTRSoundMgr.PlaySound(Resources.Snd.ExpHandDrop);
+        }
+
+        private void ReleaseTransportAttachments(
+            CandyAttachmentSnapshot detached,
+            ConstraintedPoint point)
+        {
+            ReleaseDetachedHand(detached?.Hand, point);
+            DropMouseCandyForPoint(point);
+            if (detached?.AntSegment != null)
+            {
+                PlayAntConveyorDetachSound();
+            }
+
+            CandyContext ctx = CandyForPointOrNull(point);
+            if (ctx != null)
+            {
+                point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
+            }
+        }
+
+        private void ReleaseLanternCaptureAttachments(
+            CandyAttachmentSnapshot detached,
+            ConstraintedPoint point)
+        {
+            ReleaseDetachedHand(detached?.Hand, point);
+            DropMouseCandyForPoint(point);
+            if (detached?.AntSegment != null)
+            {
+                PlayAntConveyorDetachSound();
+            }
+            ExhaustDetachedRocket(detached?.Rocket);
+
+            CandyContext ctx = CandyForPointOrNull(point);
+            if (ctx != null)
+            {
+                point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
+            }
+        }
+
+        private static void ExhaustDetachedRocket(Rocket rocket)
+        {
+            if (rocket == null)
+            {
+                return;
+            }
+
+            rocket.state = Rocket.STATE_ROCKET_EXAUST;
+            rocket.StopAnimation();
         }
 
         private void CancelPendingLanternCaptureForRemoval(ConstraintedPoint point)
@@ -85,7 +155,7 @@ namespace CutTheRopeDX.GameMain
             pendingLanternCapturePoint = null;
             pendingLanternCapture = null;
             CandyContext ctx = CandyForPointOrNull(point);
-            if (lantern != null && ctx?.inLantern == true)
+            if (lantern != null && ctx?.Lifecycle.Attachments.InLantern == true)
             {
                 lantern.CaptureCandy(point);
             }

--- a/CutTheRopeDX/GameMain/GameScene.Draw.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Draw.cs
@@ -198,7 +198,7 @@ namespace CutTheRopeDX.GameMain
                 Grab grab = (Grab)bungeeObj;
                 // Reset blend mode per grab to avoid state leakage from child draws.
                 Renderer.SetBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONEMINUSSRCALPHA);
-                grab.GunSource?.SetDisabled(candies[0].inLantern);
+                grab.GunSource?.SetDisabled(candies[0].Lifecycle.Attachments.InLantern);
                 grab.DrawBack();
             }
             foreach (object bungeeObj in bungees)
@@ -248,7 +248,7 @@ namespace CutTheRopeDX.GameMain
                     for (int ci = 0; ci < candies.Count; ci++)
                     {
                         CandyContext ctx = candies[ci];
-                        if (rocket == ctx.activeRocket && ctx.Lifecycle.Presence == CandyPresence.Hidden)
+                        if (rocket == ctx.Lifecycle.Attachments.Rocket && ctx.Lifecycle.Presence == CandyPresence.Hidden)
                         {
                             hiddenForTransit = true;
                             break;
@@ -266,7 +266,7 @@ namespace CutTheRopeDX.GameMain
             foreach (CandyBody body in ActiveCandyBodies())
             {
                 CandyContext ctx = body.Owner;
-                if (body.Role != CandyBodyRole.Whole || ctx.emitsLight || ctx.inLantern)
+                if (body.Role != CandyBodyRole.Whole || ctx.emitsLight || ctx.Lifecycle.Attachments.InLantern)
                 {
                     continue;
                 }

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -189,27 +189,24 @@ namespace CutTheRopeDX.GameMain
                 session.BambooTube.ThrowCandy(body.Point);
                 session.BambooTube.ThrowParticlesOut(particlesAniPool);
                 body.Visual.PlayTimeline(2);
-                if (ctx.HasActiveRocket)
+                if (ctx.Lifecycle.Attachments.HasActiveRocket)
                 {
-                    ctx.activeRocket.visible = true;
+                    ctx.Lifecycle.Attachments.Rocket.visible = true;
                     Vector holeOut = session.BambooTube.HoleOut;
                     Vector tubeCenter = Vect(session.BambooTube.x, session.BambooTube.y);
-                    ctx.activeRocket.rotation = RADIANS_TO_DEGREES(VectAngleNormalized(VectSub(tubeCenter, holeOut)));
-                    ctx.activeRocket.startRotation = ctx.activeRocket.rotation;
-                    ctx.activeRocket.startCandyRotation = 0f;
+                    ctx.Lifecycle.Attachments.Rocket.rotation = RADIANS_TO_DEGREES(VectAngleNormalized(VectSub(tubeCenter, holeOut)));
+                    ctx.Lifecycle.Attachments.Rocket.startRotation = ctx.Lifecycle.Attachments.Rocket.rotation;
+                    ctx.Lifecycle.Attachments.Rocket.startCandyRotation = 0f;
                     GameObject rocketCandyVisual = body.Main ?? body.Visual;
                     rocketCandyVisual.rotation = 0f;
-                    ctx.activeRocket.additionalAngle = 0f;
-                    ctx.activeRocket.UpdateRotation();
-                    ctx.activeRocket.point.posDelta = vectZero;
-                    ctx.activeRocket.point.pos = body.Point.pos;
-                    ctx.activeRocket.point.prevPos = ctx.activeRocket.point.pos;
-                    ctx.activeRocket.point.v = vectZero;
+                    ctx.Lifecycle.Attachments.Rocket.additionalAngle = 0f;
+                    ctx.Lifecycle.Attachments.Rocket.UpdateRotation();
+                    ctx.Lifecycle.Attachments.Rocket.point.posDelta = vectZero;
+                    ctx.Lifecycle.Attachments.Rocket.point.pos = body.Point.pos;
+                    ctx.Lifecycle.Attachments.Rocket.point.prevPos = ctx.Lifecycle.Attachments.Rocket.point.pos;
+                    ctx.Lifecycle.Attachments.Rocket.point.v = vectZero;
                 }
-                else
-                {
-                    body.Point.disableGravity = false;
-                }
+                body.Point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
 
                 return;
             }
@@ -229,19 +226,21 @@ namespace CutTheRopeDX.GameMain
                 body.Point.posDelta = VectDiv(body.Point.v, 60f);
                 body.Point.prevPos = VectSub(body.Point.pos, body.Point.posDelta);
 
-                if (ctx.HasActiveRocket)
+                if (ctx.Lifecycle.Attachments.HasActiveRocket)
                 {
-                    ctx.activeRocket.visible = true;
-                    ctx.activeRocket.point.pos = body.Point.pos;
-                    ctx.activeRocket.point.prevPos = body.Point.prevPos;
-                    ctx.activeRocket.point.v = body.Point.v;
-                    ctx.activeRocket.point.posDelta = body.Point.posDelta;
-                    ctx.activeRocket.rotation = session.Sock.rotation + DEG_90;
-                    ctx.activeRocket.startRotation = session.Sock.rotation + DEG_90;
-                    ctx.activeRocket.startCandyRotation = body.Main.rotation;
-                    ctx.activeRocket.additionalAngle = 0f;
-                    ctx.activeRocket.UpdateRotation();
+                    ctx.Lifecycle.Attachments.Rocket.visible = true;
+                    ctx.Lifecycle.Attachments.Rocket.point.pos = body.Point.pos;
+                    ctx.Lifecycle.Attachments.Rocket.point.prevPos = body.Point.prevPos;
+                    ctx.Lifecycle.Attachments.Rocket.point.v = body.Point.v;
+                    ctx.Lifecycle.Attachments.Rocket.point.posDelta = body.Point.posDelta;
+                    ctx.Lifecycle.Attachments.Rocket.rotation = session.Sock.rotation + DEG_90;
+                    ctx.Lifecycle.Attachments.Rocket.startRotation = session.Sock.rotation + DEG_90;
+                    ctx.Lifecycle.Attachments.Rocket.startCandyRotation = body.Main.rotation;
+                    ctx.Lifecycle.Attachments.Rocket.additionalAngle = 0f;
+                    ctx.Lifecycle.Attachments.Rocket.UpdateRotation();
                 }
+
+                body.Point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
             }
         }
 
@@ -322,7 +321,7 @@ namespace CutTheRopeDX.GameMain
         {
             for (int i = 0; i < candies.Count; i++)
             {
-                if (candies[i].inLantern)
+                if (candies[i].Lifecycle.Attachments.InLantern)
                 {
                     return true;
                 }
@@ -335,7 +334,7 @@ namespace CutTheRopeDX.GameMain
         {
             for (int i = 0; i < candies.Count; i++)
             {
-                if (candies[i].activeRocket == rocket)
+                if (candies[i].Lifecycle.Attachments.Rocket == rocket)
                 {
                     return candies[i];
                 }
@@ -348,7 +347,7 @@ namespace CutTheRopeDX.GameMain
         {
             for (int i = 0; i < candies.Count; i++)
             {
-                if (candies[i].capturingHand == hand)
+                if (candies[i].Lifecycle.Attachments.Hand == hand)
                 {
                     return candies[i];
                 }
@@ -367,7 +366,7 @@ namespace CutTheRopeDX.GameMain
             for (int i = 0; i < candies.Count; i++)
             {
                 CandyContext ctx = candies[i];
-                if (!ctx.IsHandGrabbable || ctx.inLantern || ctx.Lifecycle.Transport?.Sock != null)
+                if (!ctx.IsHandGrabbable || ctx.Lifecycle.Attachments.InLantern || ctx.Lifecycle.Transport?.Sock != null)
                 {
                     continue;
                 }
@@ -384,13 +383,14 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Exhausts the rocket bound to <paramref name="ctx"/> (one-time consume) and clears the binding.</summary>
         private static void ExhaustRocketForCandy(CandyContext ctx)
         {
-            if (ctx.activeRocket == null)
+            Rocket rocket = ctx?.Lifecycle.Attachments.Rocket;
+            if (rocket == null)
             {
                 return;
             }
-            ctx.activeRocket.state = Rocket.STATE_ROCKET_EXAUST;
-            ctx.activeRocket.StopAnimation();
-            ctx.activeRocket = null;
+            rocket.state = Rocket.STATE_ROCKET_EXAUST;
+            rocket.StopAnimation();
+            _ = ctx.Lifecycle.Attachments.TryReleaseRocket(rocket);
         }
 
         /// <summary>
@@ -589,6 +589,16 @@ namespace CutTheRopeDX.GameMain
             }
 
             miceManager.ReleaseAllCandy();
+            foreach (CandyContext ctx in candies)
+            {
+                if (!ctx.Lifecycle.Attachments.CarriedByMouse)
+                {
+                    continue;
+                }
+
+                ctx.Lifecycle.Attachments.SetCarriedByMouse(false);
+                ctx.WholeBody.Point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
+            }
 
             if (mice != null)
             {
@@ -726,7 +736,7 @@ namespace CutTheRopeDX.GameMain
                 foreach (CandyBody body in ActiveCandyBodies(CandyInteraction.Hazard))
                 {
                     CandyContext ctx = body.Owner;
-                    if (!ctx.Capabilities.CanBeBrokenByHazards || ctx.inLantern)
+                    if (!ctx.Capabilities.CanBeBrokenByHazards || ctx.Lifecycle.Attachments.InLantern)
                     {
                         continue;
                     }
@@ -946,6 +956,12 @@ namespace CutTheRopeDX.GameMain
             if (MouseOwnership.CarriesCandy(miceManager?.ActiveMouseCarriedStar(), point))
             {
                 miceManager.ForceDropCandy();
+                CandyContext ctx = CandyForPointOrNull(point);
+                ctx?.Lifecycle.Attachments.SetCarriedByMouse(false);
+                if (ctx != null)
+                {
+                    point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
+                }
             }
         }
 
@@ -994,7 +1010,7 @@ namespace CutTheRopeDX.GameMain
 
         /// <summary>
         /// Releases all mechanical hands currently holding a candy. Once a candy's
-        /// <see cref="CandyContext.capturingHand"/> is cleared the ant conveyor is free to pick it up
+        /// <see cref="CandyAttachments.Hand"/> is cleared the ant conveyor is free to pick it up
         /// again, so no global conveyor unblock is needed.
         /// </summary>
         public void DetachActiveHands()
@@ -1015,7 +1031,7 @@ namespace CutTheRopeDX.GameMain
                     hand.doRotateCandy = false;
                     hand.releaseSoundPlayed = false;
                     hand.AnimateReleaseWithAnimationsPool(aniPool);
-                    _ = (held?.capturingHand = null);
+                    _ = held?.Lifecycle.Attachments.TryReleaseHand(hand);
                 }
             }
         }
@@ -1053,7 +1069,7 @@ namespace CutTheRopeDX.GameMain
                     hand.doRotateCandy = false;
                     hand.releaseSoundPlayed = true;
                     hand.AnimateReleaseWithAnimationsPool(aniPool);
-                    _ = (held?.capturingHand = null);
+                    _ = held?.Lifecycle.Attachments.TryReleaseHand(hand);
                     CTRSoundMgr.PlaySound(Resources.Snd.ExpHandDrop);
                 }
             }

--- a/CutTheRopeDX/GameMain/GameScene.Input.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Input.cs
@@ -92,8 +92,14 @@ namespace CutTheRopeDX.GameMain
             float worldX = tx + camera.pos.X;
             float worldY = ty + camera.pos.Y;
             waterLayer?.AddParticlesAtXY(worldX, worldY);
-            if (miceManager != null && miceManager.HandleClick(worldX, worldY))
+            if (miceManager != null && miceManager.HandleClick(worldX, worldY, out ConstraintedPoint droppedMouseCandy))
             {
+                CandyContext droppedCandy = CandyForPointOrNull(droppedMouseCandy);
+                droppedCandy?.Lifecycle.Attachments.SetCarriedByMouse(false);
+                if (droppedCandy != null)
+                {
+                    droppedMouseCandy.disableGravity = droppedCandy.Lifecycle.IsGravitySuppressed;
+                }
                 return true;
             }
             Vector vector = Vect(tx, ty);
@@ -173,7 +179,7 @@ namespace CutTheRopeDX.GameMain
                 {
                     Grab grab = (Grab)obj;
                     GunSource gun = grab.GunSource;
-                    if (gun != null && gun.CanFire(candies[0].inLantern))
+                    if (gun != null && gun.CanFire(candies[0].Lifecycle.Attachments.InLantern))
                     {
                         float mapLeftX = waterLayer?.x ?? 0f;
                         float mapRightX = waterLayer != null ? waterLayer.x + waterLayer.width : mapWidth;
@@ -260,7 +266,7 @@ namespace CutTheRopeDX.GameMain
                         hand.doRotateCandy = false;
                         hand.releaseSoundPlayed = true;
                         hand.AnimateReleaseWithAnimationsPool(aniPool);
-                        _ = (held?.capturingHand = null);
+                        _ = held?.Lifecycle.Attachments.TryReleaseHand(hand);
                         CTRSoundMgr.PlaySound(Resources.Snd.ExpHandDrop);
                         return true;
                     }

--- a/CutTheRopeDX/GameMain/GameScene.LoadObjects.cs
+++ b/CutTheRopeDX/GameMain/GameScene.LoadObjects.cs
@@ -20,7 +20,10 @@ namespace CutTheRopeDX.GameMain
             List<XElement> list = [.. map.Elements()];
             // Establish captured state before grabs are loaded so XML object order cannot attach a
             // fixed rope to candy that starts inside a lantern.
-            candies[0].inLantern = NormalRopeLoad.CandyStartsInLantern(map);
+            if (NormalRopeLoad.CandyStartsInLantern(map))
+            {
+                _ = candies[0].Lifecycle.Attachments.CaptureInLantern();
+            }
 
             // Preload candy-like auxiliary bodies (light bulbs, axes) so grabs can resolve them
             // regardless of XML order.

--- a/CutTheRopeDX/GameMain/GameScene.Systems.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Systems.cs
@@ -249,7 +249,7 @@ namespace CutTheRopeDX.GameMain
             // TryHide is the entry gate as well as the transition: it refuses a candy that is already
             // hidden in another transit, removed, or split.
             CandyTransportSession session = CandyTransportSession.ForBamboo(ctx, bambooTube);
-            if (!ctx.Lifecycle.TryHide(session))
+            if (!ctx.Lifecycle.TryHide(session, out CandyAttachmentSnapshot detached))
             {
                 return;
             }
@@ -258,16 +258,11 @@ namespace CutTheRopeDX.GameMain
             CandyBody body = ctx.WholeBody;
             GameObject candyVisual = body.Visual;
             ReleaseRopesForPoint(body.Point);
-            DetachHandsForPoint(body.Point);
-            DropMouseCandyForPoint(body.Point);
-            // Take the candy off the ants too: a lingering antSegment hard-overwrites the point
-            // position all through transit and then yanks/brakes the candy at the exit tube,
-            // killing the teleport throw.
-            DetachCandyFromConveyor(ctx);
+            ReleaseTransportAttachments(detached, body.Point);
             // The Experiments reference's operateTube: sets the rocket invisible for the transit.
-            if (ctx.HasActiveRocket)
+            if (ctx.Lifecycle.Attachments.HasActiveRocket)
             {
-                ctx.activeRocket.visible = false;
+                ctx.Lifecycle.Attachments.Rocket.visible = false;
             }
             dd.CallObjectSelectorParamafterDelay(new DelayedDispatcher.DispatchFunc(Selector_teleport), session, 0.15f);
             body.Point.disableGravity = true;

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -308,7 +308,7 @@ namespace CutTheRopeDX.GameMain
                     {
                         body.ResidualRotation = 0f;
                     }
-                    else if (!rotatedBodies.Contains(body) && body.Owner.capturingHand == null)
+                    else if (!rotatedBodies.Contains(body) && body.Owner.Lifecycle.Attachments.Hand == null)
                     {
                         RotatedVisualOf(body).rotation += MIN(5, body.ResidualRotation);
                         body.ResidualRotation *= 0.98f;
@@ -584,7 +584,7 @@ namespace CutTheRopeDX.GameMain
                     }
 
                     CandyContext ctx = body.Owner;
-                    if (ctx.HasActiveRocket)
+                    if (ctx.Lifecycle.Attachments.HasActiveRocket)
                     {
                         // Rocket-bound candy pops bubbles it touches instead of entering
                         // them (Experiments reference): the bubble is consumed, never captured.
@@ -703,7 +703,7 @@ namespace CutTheRopeDX.GameMain
                         continue;
                     }
                     bool inRange = bambooTube.TryCatchCandy(body.Point);
-                    if (TransportEntry.ShouldEnter(candyPresent: true, alreadyInTransit: false, ctx.inLantern, splitActive: false, inRange))
+                    if (ctx.Lifecycle.CanEnterTransport && inRange)
                     {
                         OperateBambooTube(bambooTube, ctx);
                         CTRSoundMgr.PlaySound(Resources.Snd.ExpBambooChute);
@@ -741,13 +741,13 @@ namespace CutTheRopeDX.GameMain
                         continue;
                     }
                     bool inRange = VectDistance(body.Point.pos, Vect(lantern.x, lantern.y)) < ActivePhysicsConstants.LanternCaptureRadius;
-                    if (!LanternCapture.ShouldCapture(lanternInactive, groupOccupied, candyPresent: true, ctx.inLantern, inRange))
+                    if (!LanternCapture.ShouldCapture(lanternInactive, groupOccupied, candyPresent: true, ctx.Lifecycle.Attachments.InLantern, inRange))
                     {
                         continue;
                     }
 
-                    ctx.inLantern = true;
-                    ExhaustRocketForCandy(ctx);
+                    CandyAttachmentSnapshot detached = ctx.Lifecycle.Attachments.CaptureInLantern();
+                    ReleaseLanternCaptureAttachments(detached, body.Point);
                     body.Visual.passTransformationsToChilds = true;
                     body.Main.scaleX = body.Main.scaleY = 1f;
                     body.Top.scaleX = body.Top.scaleY = 1f;
@@ -762,8 +762,6 @@ namespace CutTheRopeDX.GameMain
                     body.Visual.AddTimelinewithID(timeline, 0);
                     body.Visual.PlayTimeline(0);
                     ReleaseRopesForPoint(body.Point);
-                    DetachHandsForPoint(body.Point);
-                    DropMouseCandyForPoint(body.Point);
                     // Lantern capture is terminal for this candy's riders: snails hop off (giving
                     // their weight back) and ants stop carrying it, mirroring hand-grab.
                     int lanternDetachedSnails = ActiveSnailCountForPoint(body.Point);
@@ -772,7 +770,6 @@ namespace CutTheRopeDX.GameMain
                     {
                         body.Point.SetWeight(SnailWeight.AfterForceDetach(body.Point.weight, lanternDetachedSnails));
                     }
-                    DetachCandyFromConveyor(ctx);
                     PopCandyBubble(body);
                     pendingLanternCapturePoint = body.Point;
                     pendingLanternCapture = lantern;
@@ -841,7 +838,7 @@ namespace CutTheRopeDX.GameMain
                     foreach (CandyBody body in ActiveCandyBodies(CandyInteraction.Mouse))
                     {
                         CandyContext ctx = body.Owner;
-                        if (ctx.inLantern || !ctx.Capabilities.CanBeGrabbedByMouse)
+                        if (ctx.Lifecycle.Attachments.InLantern || !ctx.Capabilities.CanBeGrabbedByMouse)
                         {
                             continue;
                         }
@@ -858,7 +855,8 @@ namespace CutTheRopeDX.GameMain
                 ConstraintedPoint carried = miceManager.ActiveMouseCarriedStar();
                 for (int ci = 0; ci < candies.Count; ci++)
                 {
-                    candies[ci].carriedByMouse = MouseOwnership.CarriesCandy(carried, candies[ci].WholeBody.Point);
+                    candies[ci].Lifecycle.Attachments.SetCarriedByMouse(
+                        MouseOwnership.CarriesCandy(carried, candies[ci].WholeBody.Point));
                 }
             }
             float collisionHalfSize = ActivePhysicsConstants.SockCatchHalfSize;
@@ -899,7 +897,7 @@ namespace CutTheRopeDX.GameMain
                          LineInRect(sock3.b1.X, sock3.b1.Y, sock3.b2.X, sock3.b2.Y, bbX, bbY, bbSize, bbSize));
                     anyCandyHits = anyCandyHits || candyHits;
 
-                    if (!wasIdle || !TransportEntry.ShouldEnter(candyPresent: true, alreadyInTransit: false, ctx.inLantern, splitActive: false, candyHits))
+                    if (!wasIdle || !ctx.Lifecycle.CanEnterTransport || !candyHits)
                     {
                         continue;
                     }
@@ -913,7 +911,7 @@ namespace CutTheRopeDX.GameMain
                             // The exit speed is read off the entry velocity, so the session has to be
                             // built before anything below disturbs the point.
                             CandyTransportSession session = CandyTransportSession.ForSock(ctx, sock4, exitSpeed);
-                            if (!ctx.Lifecycle.TryHide(session))
+                            if (!ctx.Lifecycle.TryHide(session, out CandyAttachmentSnapshot detached))
                             {
                                 break;
                             }
@@ -921,17 +919,12 @@ namespace CutTheRopeDX.GameMain
                             sock4.state = Sock.SOCK_THROWING;
                             sock4.idleTimeout = 0.8f;
                             ReleaseRopesForPoint(body.Point);
-                            DetachHandsForPoint(body.Point);
-                            DropMouseCandyForPoint(body.Point);
-                            // Take the candy off the ants too: a lingering antSegment hard-overwrites
-                            // the point position all through transit and then yanks/brakes the candy
-                            // at the exit sock, killing the teleport throw.
-                            DetachCandyFromConveyor(ctx);
+                            ReleaseTransportAttachments(detached, body.Point);
                             // The rocket teleports with the candy; hide it for the transit like the
                             // reference (Gift catch sets visible = 0; Teleport re-shows it).
-                            if (ctx.HasActiveRocket)
+                            if (ctx.Lifecycle.Attachments.HasActiveRocket)
                             {
-                                ctx.activeRocket.visible = false;
+                                ctx.Lifecycle.Attachments.Rocket.visible = false;
                             }
                             sock3.light.PlayTimeline(0);
                             sock3.light.visible = true;
@@ -989,7 +982,7 @@ namespace CutTheRopeDX.GameMain
                     // wobble, frozen in as a position drift if the candy is dropped mid-jitter.
                     // Parked: no satisfaction, no thrust; position snap, rotation sync, fuse tick
                     // and gravity heal keep running, and full flight resumes on drop.
-                    bool parkedOnMouse = rocketCandy?.carriedByMouse == true;
+                    bool parkedOnMouse = rocketCandy?.Lifecycle.Attachments.CarriedByMouse == true;
                     if (parkedOnMouse && carriesCandy)
                     {
                         // prevPos too: rocket.Update integrates the point next, and a bare pos
@@ -1034,7 +1027,7 @@ namespace CutTheRopeDX.GameMain
                                 if (bungee != null)
                                 {
                                     Bungee rope = bungee.Rope;
-                                    if (rope != null && rope.tail == rocketStar && rope.cut == -1 && rope.relaxed > 0 && rocketCandy?.capturingHand == null)
+                                    if (rope != null && rope.tail == rocketStar && rope.cut == -1 && rope.relaxed > 0 && rocketCandy?.Lifecycle.Attachments.Hand == null)
                                     {
                                         ropeRelaxed = true;
                                         AlignRocketAngleToRope(rocket, rope, delta);
@@ -1079,14 +1072,14 @@ namespace CutTheRopeDX.GameMain
                         rocket.point.pos.Y = rocketStar.pos.Y;
                         if (rocket.time != -1f && Mover.MoveVariableToTarget(ref rocket.time, 0f, 1f, delta))
                         {
-                            rocketStar.disableGravity = false;
                             ExhaustRocketForCandy(rocketCandy);
+                            rocketStar.disableGravity = rocketCandy?.Lifecycle.IsGravitySuppressed == true;
                         }
                     }
                     if (carriesCandy && rocket.state == Rocket.STATE_ROCKET_DIST)
                     {
                         // Per-candy: only a hand holding THIS rocket's candy skips the reel-in.
-                        if (rocketCandy?.capturingHand != null || Mover.MoveVariableToTarget(ref dist, 0f, ActivePhysicsConstants.RocketReelSpeed, delta))
+                        if (rocketCandy?.Lifecycle.Attachments.Hand != null || Mover.MoveVariableToTarget(ref dist, 0f, ActivePhysicsConstants.RocketReelSpeed, delta))
                         {
                             rocket.state = Rocket.STATE_ROCKET_FLY;
                         }
@@ -1105,7 +1098,7 @@ namespace CutTheRopeDX.GameMain
                                 continue;
                             }
                             bool intersects = GameObject.ObjectsIntersectRotatedWithUnrotated(rocket, body.Visual);
-                            if (!RocketBind.ShouldBind(rocket.state == Rocket.STATE_ROCKET_IDLE, candyPresent: true, ctx.inLantern, intersects))
+                            if (!RocketBind.ShouldBind(rocket.state == Rocket.STATE_ROCKET_IDLE, candyPresent: true, ctx.Lifecycle.Attachments.InLantern, intersects))
                             {
                                 continue;
                             }
@@ -1119,7 +1112,7 @@ namespace CutTheRopeDX.GameMain
                             // Per-candy: only a holder of THIS candy selects the direct-FLY bind.
                             // The rocket steals from nobody — it coexists with hand or mouse and
                             // launches when the holder releases.
-                            if (RocketBindPath.UsesDirectFlyPath(ctx.capturingHand != null, ctx.carriedByMouse))
+                            if (RocketBindPath.UsesDirectFlyPath(ctx.Lifecycle.Attachments.Hand != null, ctx.Lifecycle.Attachments.CarriedByMouse))
                             {
                                 rocket.point.pos = body.Point.pos;
                                 rocket.point.AddConstraintwithRestLengthofType(body.Point, 0f, Constraint.CONSTRAINT.NOT_MORE_THAN);
@@ -1138,14 +1131,14 @@ namespace CutTheRopeDX.GameMain
                             body.Point.disableGravity = true;
 
                             // Exhaust any rocket already bound to this candy before re-binding (one-time-use safety).
-                            if (ctx.HasActiveRocket && ctx.activeRocket != rocket)
+                            if (ctx.Lifecycle.Attachments.HasActiveRocket && ctx.Lifecycle.Attachments.Rocket != rocket)
                             {
                                 ExhaustRocketForCandy(ctx);
                             }
 
                             CTRSoundMgr.PlaySound(Resources.Snd.ExpRocketStart);
                             rocket.flyLoopSound = CTRSoundMgr.PlaySoundLooped(Resources.Snd.ExpRocketFlyLooped);
-                            ctx.activeRocket = rocket;
+                            _ = ctx.Lifecycle.Attachments.BindRocket(rocket);
                             rocket.isOperating = -1;
                             rocket.startCandyRotation = body.Main.rotation;
 
@@ -1207,7 +1200,7 @@ namespace CutTheRopeDX.GameMain
                     foreach (CandyBody body in ActiveCandyBodies(CandyInteraction.Hazard))
                     {
                         CandyContext ctx = body.Owner;
-                        if (!ctx.Capabilities.CanBeBrokenByHazards || ctx.inLantern)
+                        if (!ctx.Capabilities.CanBeBrokenByHazards || ctx.Lifecycle.Attachments.InLantern)
                         {
                             continue;
                         }
@@ -1272,15 +1265,15 @@ namespace CutTheRopeDX.GameMain
                     }
                     float damping = ActivePhysicsConstants.WaterDamping;
                     float verticalWaterImpulse = ActivePhysicsConstants.WaterVerticalImpulseBase / body.Point.weight;
-                    if (ctx.HasActiveRocket)
+                    if (ctx.Lifecycle.Attachments.HasActiveRocket)
                     {
                         verticalWaterImpulse /= ActivePhysicsConstants.WaterRocketImpulseDivisor;
                         damping *= ActivePhysicsConstants.WaterRocketDampingMultiplier;
-                        if (ctx.activeRocket.state == Rocket.STATE_ROCKET_FLY)
+                        if (ctx.Lifecycle.Attachments.Rocket.state == Rocket.STATE_ROCKET_FLY)
                         {
                             CTRSoundMgr.PlaySound(Resources.Snd.ExpRocketInWater);
-                            ctx.activeRocket.state = Rocket.STATE_ROCKET_EXAUST;
-                            ctx.activeRocket.StopAnimation();
+                            ctx.Lifecycle.Attachments.Rocket.state = Rocket.STATE_ROCKET_EXAUST;
+                            ctx.Lifecycle.Attachments.Rocket.StopAnimation();
                         }
                     }
                     body.Point.ApplyImpulseDelta(Vect(-body.Point.v.X / damping, (-body.Point.v.Y / damping) + verticalWaterImpulse), delta);
@@ -1366,7 +1359,7 @@ namespace CutTheRopeDX.GameMain
             for (int ci = 0; ci < candies.Count; ci++)
             {
                 CandyContext ctx = candies[ci];
-                if (ctx.activeRocket == null)
+                if (ctx.Lifecycle.Attachments.Rocket == null)
                 {
                     continue;
                 }
@@ -1385,7 +1378,7 @@ namespace CutTheRopeDX.GameMain
             List<CandyView> candyViews = [];
             foreach (CandyBody body in ActiveCandyBodies(CandyInteraction.Eat))
             {
-                if (!body.Owner.inLantern)
+                if (!body.Owner.Lifecycle.Attachments.InLantern)
                 {
                     candyViews.Add(body.ToView());
                 }
@@ -1728,7 +1721,7 @@ namespace CutTheRopeDX.GameMain
                             rotatingCandyVisual.rotation += hand.rotatingSegment.RotationDelta();
                         }
                     }
-                    else if (heldCandy.HasActiveRocket)
+                    else if (heldCandy.Lifecycle.Attachments.HasActiveRocket)
                     {
                         _ = hand.IsRotating();
                         hand.doRotateCandy = true;
@@ -1776,7 +1769,7 @@ namespace CutTheRopeDX.GameMain
                     && HandGrab.ShouldGrab(
                         hand.state == MechanicalHand.STATE_HAND_IDLE,
                         !nearestCandy.HasNoWholeBodyInPlay,
-                        nearestCandy.inLantern,
+                        nearestCandy.Lifecycle.Attachments.InLantern,
                         nearestCandy.Lifecycle.Transport?.Sock != null,
                         distance < MechanicalHand.MH_GRAB_DISTANCE))
                 {
@@ -1792,7 +1785,7 @@ namespace CutTheRopeDX.GameMain
                             if (otherHand != null && HandSteal.ShouldReleaseOtherHand(
                                     otherHand != hand,
                                     otherHand.state == MechanicalHand.STATE_HAND_CANDY,
-                                    ctx.capturingHand == otherHand))
+                                    ctx.Lifecycle.Attachments.Hand == otherHand))
                             {
                                 otherHand.cPoint.RemoveConstraint(grabbedBody.Point);
                                 otherHand.state = MechanicalHand.STATE_HAND_RELEASE;
@@ -1807,7 +1800,7 @@ namespace CutTheRopeDX.GameMain
                     hand.state = MechanicalHand.STATE_HAND_CANDY;
                     hand.releaseSoundPlayed = false;
                     selectedHandIndex = hands.IndexOf(hand);
-                    ctx.capturingHand = hand;
+                    _ = ctx.Lifecycle.Attachments.CaptureByHand(hand);
 
                     // Take this candy off the ants (if it was riding them). Other candies keep
                     // their conveyor; ants won't re-grab this one while the hand holds it.
@@ -1817,7 +1810,7 @@ namespace CutTheRopeDX.GameMain
                     // ends up.
                     PopCandyBubbleAt(grabbedBody, hand.ClawPosition());
 
-                    if (ctx.HasActiveRocket)
+                    if (ctx.Lifecycle.Attachments.HasActiveRocket)
                     {
                         int count = Preferences.GetIntForKey("PREFS_GRAB_ROCKET") + 1;
                         Preferences.SetIntForKey(count, "PREFS_GRAB_ROCKET", false);

--- a/CutTheRopeDX/GameMain/GameScene.cs
+++ b/CutTheRopeDX/GameMain/GameScene.cs
@@ -447,8 +447,8 @@ namespace CutTheRopeDX.GameMain
             CandyContext ctx = RocketBoundCandy(r);
             if (ctx != null)
             {
-                ctx.activeRocket = null;
-                ctx.WholeBody.Point.disableGravity = false;
+                _ = ctx.Lifecycle.Attachments.TryReleaseRocket(r);
+                ctx.WholeBody.Point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
             }
         }
 

--- a/CutTheRopeDX/GameMain/LanternRelease.cs
+++ b/CutTheRopeDX/GameMain/LanternRelease.cs
@@ -21,7 +21,7 @@ namespace CutTheRopeDX.GameMain
                     continue;
                 }
 
-                ctx.inLantern = false;
+                ctx.Lifecycle.Attachments.ReleaseFromLantern();
                 body.Visual.color = RGBAColor.solidOpaqueRGBA;
                 body.Visual.passTransformationsToChilds = false;
                 body.Visual.scaleX = body.Visual.scaleY = 0.71f;

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadGrabs.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadGrabs.cs
@@ -145,7 +145,7 @@ namespace CutTheRopeDX.GameMain
                 // A part="L"/"R" grab binds to a half, so the owner lookup has to resolve halves too;
                 // an unowned point (no candy at all) simply carries no lantern state.
                 CandyContext ropeTarget = CandyForPointOrNull(constraintedPoint);
-                if (NormalRopeLoad.ShouldCreate(ropeTarget?.inLantern == true))
+                if (NormalRopeLoad.ShouldCreate(ropeTarget?.Lifecycle.Attachments.InLantern == true))
                 {
                     Bungee bungee = new Bungee().InitWithHeadAtXYTailAtTXTYandLength(null, hx, hy, constraintedPoint, constraintedPoint.pos.X, constraintedPoint.pos.Y, len);
                     bungee.bungeeAnchor.pin = bungee.bungeeAnchor.pos;

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadLanterns.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadLanterns.cs
@@ -27,7 +27,7 @@ namespace CutTheRopeDX.GameMain
             lantern.ParseMover(xmlNode);
             if (isCandyCaptured)
             {
-                candies[0].inLantern = true;
+                _ = candies[0].Lifecycle.Attachments.CaptureInLantern();
                 lantern.CaptureCandy(star);
                 candy.x = star.pos.X;
                 candy.y = star.pos.Y;

--- a/CutTheRopeDX/GameMain/MiceObject.cs
+++ b/CutTheRopeDX/GameMain/MiceObject.cs
@@ -144,12 +144,14 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         /// <param name="x">X coordinate of the click.</param>
         /// <param name="y">Y coordinate of the click.</param>
+        /// <param name="droppedCandy">Receives the candy point released by the click.</param>
         /// <returns>
         /// <see langword="true" /> if the click was handled and candy was dropped;
         /// otherwise <see langword="false" />.
         /// </returns>
-        public bool HandleClick(float x, float y)
+        public bool HandleClick(float x, float y, out ConstraintedPoint droppedCandy)
         {
+            droppedCandy = null;
             if (activeMouse == null || !activeMouse.HasCandy)
             {
                 return false;
@@ -157,6 +159,7 @@ namespace CutTheRopeDX.GameMain
 
             if (activeMouse.IsClickable(x, y))
             {
+                droppedCandy = ActiveMouseCarriedStar();
                 activeMouse.DropCandyAndRetreat();
                 carriedStar = null;
                 carriedCandy = null;


### PR DESCRIPTION
## Description

- Add a lifecycle-owned `CandyAttachments` aggregate for lantern, rocket, hand, mouse, and ant state.
- Make lantern capture, transport entry, and candy removal authoritative transactions that return detached-owner snapshots.
- Centralize `CanEnterTransport`, `IsGravitySuppressed`, and complete attachment cleanup.
- Synchronize mouse release immediately to avoid one-frame stale ownership.
- Keep bubble state per `CandyBody` because split halves require independent bubble ownership.
- Add regression coverage for attachment transitions, transport, retirement, lantern capture, loss, and mouse release.