### PR TITLE
refactor: Make mouse carry state a single source of truth

### DIFF
--- a/CutTheRopeDX.Tests/CandyAttachmentsTests.cs
+++ b/CutTheRopeDX.Tests/CandyAttachmentsTests.cs
@@ -68,14 +68,11 @@ namespace CutTheRopeDX.Tests
             _ = attachments.BindRocket(rocket);
             _ = attachments.CaptureByHand(hand);
             _ = attachments.BeginAntCarry(segment, new Vector(25f, 5f), 0.3f, 0.01f);
-            attachments.SetCarriedByMouse(true);
-
             CandyAttachmentSnapshot detached = attachments.DetachAll();
 
             Assert.Same(rocket, detached.Rocket);
             Assert.Same(hand, detached.Hand);
             Assert.Same(segment, detached.AntSegment);
-            Assert.True(detached.CarriedByMouse);
             Assert.True(detached.InLantern);
             Assert.False(attachments.HasAny);
             Assert.False(attachments.SuppressGravity);
@@ -93,18 +90,14 @@ namespace CutTheRopeDX.Tests
             _ = attachments.BindRocket(rocket);
             _ = attachments.CaptureByHand(hand);
             _ = attachments.BeginAntCarry(segment, new Vector(25f, 5f), 0.3f, 0.01f);
-            attachments.SetCarriedByMouse(true);
-
             CandyAttachmentSnapshot detached = attachments.DetachForTransport();
 
             Assert.Same(hand, detached.Hand);
             Assert.Same(segment, detached.AntSegment);
-            Assert.True(detached.CarriedByMouse);
             Assert.Null(detached.Rocket);
             Assert.Same(rocket, attachments.Rocket);
             Assert.Null(attachments.Hand);
             Assert.Null(attachments.AntSegment);
-            Assert.False(attachments.CarriedByMouse);
         }
 
         [Fact]
@@ -117,20 +110,16 @@ namespace CutTheRopeDX.Tests
             _ = attachments.BindRocket(rocket);
             _ = attachments.CaptureByHand(hand);
             _ = attachments.BeginAntCarry(segment, new Vector(25f, 5f), 0.3f, 0.01f);
-            attachments.SetCarriedByMouse(true);
-
             CandyAttachmentSnapshot detached = attachments.CaptureInLantern();
 
             Assert.Same(rocket, detached.Rocket);
             Assert.Same(hand, detached.Hand);
             Assert.Same(segment, detached.AntSegment);
-            Assert.True(detached.CarriedByMouse);
             Assert.False(detached.InLantern);
             Assert.True(attachments.InLantern);
             Assert.Null(attachments.Rocket);
             Assert.Null(attachments.Hand);
             Assert.Null(attachments.AntSegment);
-            Assert.False(attachments.CarriedByMouse);
             Assert.True(attachments.SuppressGravity);
         }
     }

--- a/CutTheRopeDX.Tests/CandyLifecycleTests.cs
+++ b/CutTheRopeDX.Tests/CandyLifecycleTests.cs
@@ -58,11 +58,9 @@ namespace CutTheRopeDX.Tests
         {
             CandyLifecycle lifecycle = PresentLifecycle();
             _ = lifecycle.Attachments.CaptureInLantern();
-            lifecycle.Attachments.SetCarriedByMouse(true);
 
             Assert.True(lifecycle.TryRemove(CandyRemovalReason.Hazard, out CandyAttachmentSnapshot detached));
 
-            Assert.True(detached.CarriedByMouse);
             Assert.True(detached.InLantern);
             Assert.False(lifecycle.Attachments.HasAny);
             Assert.False(lifecycle.IsGravitySuppressed);

--- a/CutTheRopeDX.Tests/Interactions/Act.cs
+++ b/CutTheRopeDX.Tests/Interactions/Act.cs
@@ -107,7 +107,7 @@ namespace CutTheRopeDX.Tests.Interactions
         public static Mouse CarryByMouse(GameScene scene, CandyContext candy)
         {
             Mouse mouse = scene.Mice()[0];
-            Chase(scene, candy, position => MoveTo(mouse, position), () => candy.Lifecycle.Attachments.CarriedByMouse, "the mouse never took the candy");
+            Chase(scene, candy, position => MoveTo(mouse, position), () => scene.MouseCarries(candy), "the mouse never took the candy");
             return mouse;
         }
 
@@ -122,7 +122,7 @@ namespace CutTheRopeDX.Tests.Interactions
         public static Mouse CarryByMouseWithoutMovingIt(GameScene scene, CandyContext candy)
         {
             Assert.True(
-                Interaction.StepUntil(scene, () => candy.Lifecycle.Attachments.CarriedByMouse),
+                Interaction.StepUntil(scene, () => scene.MouseCarries(candy)),
                 "the mouse never took the candy");
             HeadlessGame.StepFrames(scene, SettleFrames);
             return scene.Mice()[0];

--- a/CutTheRopeDX.Tests/Interactions/AttachmentSetupTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/AttachmentSetupTests.cs
@@ -91,7 +91,7 @@ namespace CutTheRopeDX.Tests.Interactions
             Interaction.Hover(candy);
             Interaction.PlaceCandyAt(candy, Interaction.At(Scenario.New().WorldX(160), Scenario.WorldY(200)));
 
-            Assert.True(Interaction.StepUntil(scene, () => candy.Lifecycle.Attachments.CarriedByMouse));
+            Assert.True(Interaction.StepUntil(scene, () => scene.MouseCarries(candy)));
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/Interactions/BambooTubeEntryRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/BambooTubeEntryRowTests.cs
@@ -94,7 +94,6 @@ namespace CutTheRopeDX.Tests.Interactions
             Act.EnterBambooTube(scene, candy, TubeMouth.CatchesFalling);
 
             Assert.False(scene.MouseCarries(candy));
-            Assert.False(candy.Lifecycle.Attachments.CarriedByMouse);
         }
 
         private static (GameScene Scene, CandyContext Candy) Rig(TubeMouth mouth, Func<Scenario, Scenario> attachment)

--- a/CutTheRopeDX.Tests/Interactions/BubbleCaptureRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/BubbleCaptureRowTests.cs
@@ -86,7 +86,7 @@ namespace CutTheRopeDX.Tests.Interactions
             Bubble bubble = Act.CaptureInBubble(scene, candy);
 
             Assert.Same(bubble, candy.WholeBody.Bubble);
-            Assert.True(candy.Lifecycle.Attachments.CarriedByMouse);
+            Assert.True(scene.MouseCarries(candy));
         }
 
         private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment)

--- a/CutTheRopeDX.Tests/Interactions/EatenRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/EatenRowTests.cs
@@ -80,7 +80,6 @@ namespace CutTheRopeDX.Tests.Interactions
             (GameScene scene, CandyContext candy) = Rig(s => s.Mouse(160, 200));
             _ = Act.CarryByMouse(scene, candy);
             Act.Eat(scene, candy);
-            Assert.False(candy.Lifecycle.Attachments.CarriedByMouse);
             Assert.False(scene.MouseCarries(candy));
         }
 

--- a/CutTheRopeDX.Tests/Interactions/HandGrabRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/HandGrabRowTests.cs
@@ -92,7 +92,6 @@ namespace CutTheRopeDX.Tests.Interactions
             _ = Act.GrabWithHand(scene, candy);
 
             Assert.False(scene.MouseCarries(candy));
-            Assert.False(candy.Lifecycle.Attachments.CarriedByMouse);
         }
 
         private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment)

--- a/CutTheRopeDX.Tests/Interactions/LanternCaptureRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/LanternCaptureRowTests.cs
@@ -91,7 +91,6 @@ namespace CutTheRopeDX.Tests.Interactions
             Act.CaptureInLantern(scene, candy);
 
             Assert.False(scene.MouseCarries(candy));
-            Assert.False(candy.Lifecycle.Attachments.CarriedByMouse);
         }
 
         private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment)

--- a/CutTheRopeDX.Tests/Interactions/LostRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/LostRowTests.cs
@@ -98,7 +98,6 @@ namespace CutTheRopeDX.Tests.Interactions
             Act.BreakOnSpikes(scene, candy);
 
             Assert.False(scene.MouseCarries(candy));
-            Assert.False(candy.Lifecycle.Attachments.CarriedByMouse);
         }
 
         [Fact]
@@ -116,7 +115,6 @@ namespace CutTheRopeDX.Tests.Interactions
             scene.GameLost();
 
             Assert.False(scene.MouseCarries(surviving));
-            Assert.False(surviving.Lifecycle.Attachments.CarriedByMouse);
             Assert.False(surviving.Lifecycle.IsGravitySuppressed);
             Assert.False(surviving.WholeBody.Point.disableGravity);
         }
@@ -169,7 +167,6 @@ namespace CutTheRopeDX.Tests.Interactions
             scene.BreakCandyBody(candy.WholeBody);
 
             Assert.False(scene.MouseCarries(candy));
-            Assert.False(candy.Lifecycle.Attachments.CarriedByMouse);
         }
 
         [Fact]
@@ -305,7 +302,7 @@ namespace CutTheRopeDX.Tests.Interactions
             HeadlessGame.StepFrames(scene, 60);
 
             Assert.Equal(0, scene.Outcomes().LostCount);
-            Assert.True(candy.Lifecycle.Attachments.CarriedByMouse);
+            Assert.True(scene.MouseCarries(candy));
         }
 
         private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment)

--- a/CutTheRopeDX.Tests/Interactions/MagicHatEntryRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/MagicHatEntryRowTests.cs
@@ -91,7 +91,6 @@ namespace CutTheRopeDX.Tests.Interactions
             Act.EnterHat(scene, candy);
 
             Assert.False(scene.MouseCarries(candy));
-            Assert.False(candy.Lifecycle.Attachments.CarriedByMouse);
         }
 
         private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment)

--- a/CutTheRopeDX.Tests/Interactions/MouseGrabRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/MouseGrabRowTests.cs
@@ -34,7 +34,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Assert.Null(candy.Lifecycle.Attachments.Hand);
             Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, hand.state);
-            Assert.True(candy.Lifecycle.Attachments.CarriedByMouse);
+            Assert.True(scene.MouseCarries(candy));
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace CutTheRopeDX.Tests.Interactions
             _ = Act.CarryByMouseWithoutMovingIt(scene, candy);
             HeadlessGame.StepFrames(scene, 30);
 
-            Assert.True(candy.Lifecycle.Attachments.CarriedByMouse);
+            Assert.True(scene.MouseCarries(candy));
             Assert.Null(candy.Lifecycle.Attachments.AntSegment);
         }
 
@@ -95,8 +95,30 @@ namespace CutTheRopeDX.Tests.Interactions
             Assert.True(scene.TouchDownXYIndex((int)mouse.x, (int)mouse.y, 0));
 
             Assert.False(scene.MouseCarries(candy));
-            Assert.False(candy.Lifecycle.Attachments.CarriedByMouse);
             Assert.Equal(candy.Lifecycle.IsGravitySuppressed, candy.WholeBody.Point.disableGravity);
+        }
+
+        [Fact]
+        public void RetreatTransfersTheSameCarryToTheNextMouse()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(20, 460)
+                .Mouse(160, 200, index: 1)
+                .Mouse(300, 200, index: 2)
+                .Build();
+            CandyContext candy = scene.Candy();
+            Interaction.Hover(candy);
+            Mouse first = Act.CarryByMouse(scene, candy);
+            Mouse second = scene.Mice()[1];
+
+            first.BeginRetreat();
+
+            Assert.True(
+                Interaction.StepUntil(scene, () => second.IsActive && scene.MouseCarries(candy)),
+                "the next mouse never received the carried candy");
+            Assert.False(first.HasCandy);
+            Assert.True(second.HasCandy);
         }
 
         private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment, int mouseY = 40)

--- a/CutTheRopeDX.Tests/Interactions/PerCandyIsolationTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/PerCandyIsolationTests.cs
@@ -113,7 +113,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             _ = Act.CarryByMouse(scene, stolen);
 
-            Assert.True(stolen.Lifecycle.Attachments.CarriedByMouse);
+            Assert.True(scene.MouseCarries(stolen));
             Assert.Same(hand, kept.Lifecycle.Attachments.Hand);
         }
 

--- a/CutTheRopeDX.Tests/Interactions/RocketBindRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/RocketBindRowTests.cs
@@ -98,7 +98,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Rocket rocket = Act.BindRocket(scene, candy);
 
-            Assert.True(candy.Lifecycle.Attachments.CarriedByMouse);
+            Assert.True(scene.MouseCarries(candy));
             Assert.Same(rocket, candy.Lifecycle.Attachments.Rocket);
             Assert.Equal(Rocket.STATE_ROCKET_FLY, rocket.state);
         }

--- a/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
+++ b/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
@@ -283,8 +283,7 @@ namespace CutTheRopeDX.Tests.Interactions
         public static bool MouseCarries(this GameScene scene, CandyContext candy)
         {
             MiceObject mice = Field<MiceObject>(scene, "miceManager");
-            ConstraintedPoint carried = mice?.ActiveMouseCarriedStar();
-            return carried != null && carried == candy.WholeBody.Point;
+            return mice?.CarriesCandy(candy.WholeBody.Point) == true;
         }
 
         /// <summary>Asserts that a retired whole candy has no observable live attachment owner.</summary>
@@ -297,7 +296,6 @@ namespace CutTheRopeDX.Tests.Interactions
             Assert.Null(candy.Lifecycle.Attachments.Rocket);
             Assert.Null(candy.Lifecycle.Attachments.Hand);
             Assert.False(scene.MouseCarries(candy));
-            Assert.False(candy.Lifecycle.Attachments.CarriedByMouse);
             Assert.Null(candy.Lifecycle.Attachments.AntSegment);
             Assert.Null(candy.Lifecycle.Attachments.LastAntSegment);
             Assert.Equal(0, scene.SnailCount(candy));

--- a/CutTheRopeDX.Tests/Interactions/SnailAttachRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/SnailAttachRowTests.cs
@@ -91,7 +91,7 @@ namespace CutTheRopeDX.Tests.Interactions
 
             _ = Act.RideSnail(scene, candy);
 
-            Assert.True(candy.Lifecycle.Attachments.CarriedByMouse);
+            Assert.True(scene.MouseCarries(candy));
             Assert.Equal(1, scene.SnailCount(candy));
         }
 

--- a/CutTheRopeDX.Tests/Interactions/SpiderRemovalInvariantTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/SpiderRemovalInvariantTests.cs
@@ -84,7 +84,6 @@ namespace CutTheRopeDX.Tests.Interactions
             scene.SpiderWon(scene.Grabs()[0]);
 
             scene.AssertNoLiveAttachments(captured);
-            Assert.True(mouseCandy.Lifecycle.Attachments.CarriedByMouse);
             Assert.True(scene.MouseCarries(mouseCandy));
         }
 

--- a/CutTheRopeDX.Tests/MouseCarrySingleSourceTests.cs
+++ b/CutTheRopeDX.Tests/MouseCarrySingleSourceTests.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class MouseCarrySingleSourceTests
+    {
+        private const BindingFlags InstanceFields = BindingFlags.Instance
+            | BindingFlags.Public
+            | BindingFlags.NonPublic;
+
+        [Fact]
+        public void MouseOwnsOneCarryValueInsteadOfIndependentCandyFields()
+        {
+            FieldInfo[] fields = typeof(Mouse).GetFields(InstanceFields);
+
+            FieldInfo carry = Assert.Single(fields, field => field.FieldType.Name == "MouseCarry");
+            Assert.Equal("carry", carry.Name);
+            Assert.DoesNotContain(fields, field => field.Name is "carriedStar" or "carriedCandy");
+        }
+
+        [Fact]
+        public void ManagerAndCandyAttachmentsDoNotRetainMouseCarryState()
+        {
+            FieldInfo[] managerFields = typeof(MiceObject).GetFields(InstanceFields);
+
+            Assert.DoesNotContain(managerFields, field => field.Name is "carriedStar" or "carriedCandy");
+            Assert.DoesNotContain(managerFields, field => field.FieldType.Name == "MouseCarry");
+            Assert.Null(typeof(CandyAttachments).GetProperty("CarriedByMouse"));
+            Assert.Null(typeof(CandyAttachments).GetMethod("SetCarriedByMouse"));
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/CandyAttachments.cs
+++ b/CutTheRopeDX/GameMain/CandyAttachments.cs
@@ -3,21 +3,19 @@ using CutTheRopeDX.Framework.Helpers;
 
 namespace CutTheRopeDX.GameMain
 {
-    /// <summary>Immutable owners released by an authoritative attachment transition.</summary>
+    /// <summary>Immutable device owners released by an authoritative attachment transition.</summary>
     internal sealed class CandyAttachmentSnapshot
     {
         internal CandyAttachmentSnapshot(
             bool inLantern,
             Rocket rocket,
             AntsPathSegment antSegment,
-            MechanicalHand hand,
-            bool carriedByMouse)
+            MechanicalHand hand)
         {
             InLantern = inLantern;
             Rocket = rocket;
             AntSegment = antSegment;
             Hand = hand;
-            CarriedByMouse = carriedByMouse;
         }
 
         /// <summary>Gets whether a lantern owned the candy.</summary>
@@ -32,8 +30,6 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Gets the mechanical hand that owned the candy, if any.</summary>
         public MechanicalHand Hand { get; }
 
-        /// <summary>Gets whether the mouse owned the candy.</summary>
-        public bool CarriedByMouse { get; }
     }
 
     /// <summary>
@@ -74,40 +70,33 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Gets the mechanical hand currently holding the candy, if any.</summary>
         public MechanicalHand Hand { get; private set; }
 
-        /// <summary>Gets whether the active mouse currently carries the candy.</summary>
-        public bool CarriedByMouse { get; private set; }
-
         /// <summary>Gets whether the aggregate contains a live attachment or reattachment guard.</summary>
         public bool HasAny => InLantern
             || Rocket != null
             || AntSegment != null
             || LastAntSegment != null
             || AntWaitingForExit
-            || Hand != null
-            || CarriedByMouse;
+            || Hand != null;
 
         /// <summary>Gets whether an attachment currently owns gravity for the candy point.</summary>
         public bool SuppressGravity => InLantern
             || Rocket != null
-            || AntSegment != null
-            || CarriedByMouse;
+            || AntSegment != null;
 
         /// <summary>
         /// Captures the candy in a lantern and atomically releases every incompatible carrier.
         /// </summary>
-        /// <returns>The former rocket, hand, ant, and mouse owners for scene-level cleanup.</returns>
+        /// <returns>The former rocket, hand, and ant owners for scene-level cleanup.</returns>
         public CandyAttachmentSnapshot CaptureInLantern()
         {
             CandyAttachmentSnapshot snapshot = new(
                 inLantern: false,
                 rocket: Rocket,
                 antSegment: AntSegment,
-                hand: Hand,
-                carriedByMouse: CarriedByMouse);
+                hand: Hand);
             InLantern = true;
             Rocket = null;
             Hand = null;
-            CarriedByMouse = false;
             ResetAnts();
             return snapshot;
         }
@@ -168,12 +157,6 @@ namespace CutTheRopeDX.GameMain
 
             Hand = null;
             return true;
-        }
-
-        /// <summary>Synchronizes ownership with the active mouse.</summary>
-        public void SetCarriedByMouse(bool carried)
-        {
-            CarriedByMouse = carried;
         }
 
         /// <summary>Starts a complete ant-conveyor carry interaction.</summary>
@@ -256,17 +239,15 @@ namespace CutTheRopeDX.GameMain
         /// <summary>
         /// Clears carriers that cannot survive transport while preserving a bound rocket.
         /// </summary>
-        /// <returns>The former hand, ant, and mouse owners for scene-level cleanup.</returns>
+        /// <returns>The former hand and ant owners for scene-level cleanup.</returns>
         public CandyAttachmentSnapshot DetachForTransport()
         {
             CandyAttachmentSnapshot snapshot = new(
                 inLantern: false,
                 rocket: null,
                 antSegment: AntSegment,
-                hand: Hand,
-                carriedByMouse: CarriedByMouse);
+                hand: Hand);
             Hand = null;
-            CarriedByMouse = false;
             ResetAnts();
             return snapshot;
         }
@@ -274,11 +255,10 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Atomically clears every attachment and returns the former owners.</summary>
         public CandyAttachmentSnapshot DetachAll()
         {
-            CandyAttachmentSnapshot snapshot = new(InLantern, Rocket, AntSegment, Hand, CarriedByMouse);
+            CandyAttachmentSnapshot snapshot = new(InLantern, Rocket, AntSegment, Hand);
             InLantern = false;
             Rocket = null;
             Hand = null;
-            CarriedByMouse = false;
             ResetAnts();
             return snapshot;
         }

--- a/CutTheRopeDX/GameMain/GameScene.Ants.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Ants.cs
@@ -87,7 +87,7 @@ namespace CutTheRopeDX.GameMain
 
                 bool shouldSlowStop = AntCandyInteraction.ShouldSlowStopAfterDetach(otherSegmentContainsCandyExternally);
                 attachments.EndAntCarry(waitForExit: false);
-                point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
+                point.disableGravity = IsCandyGravitySuppressed(ctx);
 
                 if (shouldSlowStop)
                 {
@@ -188,7 +188,7 @@ namespace CutTheRopeDX.GameMain
             ApplyConveyorBrake(ctx);
             ctx.Lifecycle.Attachments.EndAntCarry(waitForExit: true);
             PlayAntConveyorDetachSound();
-            point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
+            point.disableGravity = IsCandyGravitySuppressed(ctx);
             return true;
         }
 
@@ -211,7 +211,7 @@ namespace CutTheRopeDX.GameMain
         /// <see cref="AntCandyInteraction.CanAttach"/>.
         /// </summary>
         /// <param name="ctx">The candy to detach from the conveyor.</param>
-        private static void DetachCandyFromConveyor(CandyContext ctx)
+        private void DetachCandyFromConveyor(CandyContext ctx)
         {
             if (ctx == null)
             {
@@ -225,7 +225,7 @@ namespace CutTheRopeDX.GameMain
                 PlayAntConveyorDetachSound();
 
                 // A candy can only hold a segment if it had a point when it attached.
-                ctx.WholeBody.Point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
+                ctx.WholeBody.Point.disableGravity = IsCandyGravitySuppressed(ctx);
             }
         }
 
@@ -256,7 +256,7 @@ namespace CutTheRopeDX.GameMain
                 candyHeldByHand: ctx.Lifecycle.Attachments.Hand != null,
                 candyInLantern: ctx.Lifecycle.Attachments.InLantern,
                 candyInTransport: ctx.Lifecycle.Presence == CandyPresence.Hidden,
-                candyCarriedByMouse: ctx.Lifecycle.Attachments.CarriedByMouse))
+                candyCarriedByMouse: MouseCarries(ctx)))
             {
                 return false;
             }
@@ -273,7 +273,7 @@ namespace CutTheRopeDX.GameMain
                 interactionPoint.X + (segment.speed.X * 0.01f),
                 interactionPoint.Y + (segment.speed.Y * 0.01f));
             _ = ctx.Lifecycle.Attachments.BeginAntCarry(segment, interactionPoint, 0.3f, 0.01f);
-            ctx.WholeBody.Point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
+            ctx.WholeBody.Point.disableGravity = IsCandyGravitySuppressed(ctx);
 
             if (freshPickup)
             {

--- a/CutTheRopeDX/GameMain/GameScene.CandyRemoval.cs
+++ b/CutTheRopeDX/GameMain/GameScene.CandyRemoval.cs
@@ -101,7 +101,7 @@ namespace CutTheRopeDX.GameMain
             CandyContext ctx = CandyForPointOrNull(point);
             if (ctx != null)
             {
-                point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
+                point.disableGravity = IsCandyGravitySuppressed(ctx);
             }
         }
 
@@ -120,7 +120,7 @@ namespace CutTheRopeDX.GameMain
             CandyContext ctx = CandyForPointOrNull(point);
             if (ctx != null)
             {
-                point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
+                point.disableGravity = IsCandyGravitySuppressed(ctx);
             }
         }
 

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -206,7 +206,7 @@ namespace CutTheRopeDX.GameMain
                     ctx.Lifecycle.Attachments.Rocket.point.prevPos = ctx.Lifecycle.Attachments.Rocket.point.pos;
                     ctx.Lifecycle.Attachments.Rocket.point.v = vectZero;
                 }
-                body.Point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
+                body.Point.disableGravity = IsCandyGravitySuppressed(ctx);
 
                 return;
             }
@@ -240,7 +240,7 @@ namespace CutTheRopeDX.GameMain
                     ctx.Lifecycle.Attachments.Rocket.UpdateRotation();
                 }
 
-                body.Point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
+                body.Point.disableGravity = IsCandyGravitySuppressed(ctx);
             }
         }
 
@@ -588,16 +588,11 @@ namespace CutTheRopeDX.GameMain
                 return;
             }
 
+            ConstraintedPoint released = miceManager.ActiveMouseCarriedStar();
             miceManager.ReleaseAllCandy();
-            foreach (CandyContext ctx in candies)
+            if (CandyForPointOrNull(released) is CandyContext releasedCandy)
             {
-                if (!ctx.Lifecycle.Attachments.CarriedByMouse)
-                {
-                    continue;
-                }
-
-                ctx.Lifecycle.Attachments.SetCarriedByMouse(false);
-                ctx.WholeBody.Point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
+                releasedCandy.WholeBody.Point.disableGravity = IsCandyGravitySuppressed(releasedCandy);
             }
 
             if (mice != null)
@@ -957,12 +952,23 @@ namespace CutTheRopeDX.GameMain
             {
                 miceManager.ForceDropCandy();
                 CandyContext ctx = CandyForPointOrNull(point);
-                ctx?.Lifecycle.Attachments.SetCarriedByMouse(false);
                 if (ctx != null)
                 {
-                    point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
+                    point.disableGravity = IsCandyGravitySuppressed(ctx);
                 }
             }
+        }
+
+        /// <summary>Gets whether the active mouse is the authoritative owner of this candy.</summary>
+        private bool MouseCarries(CandyContext ctx)
+        {
+            return ctx != null && miceManager?.CarriesCandy(ctx.WholeBody.Point) == true;
+        }
+
+        /// <summary>Combines lifecycle-owned gravity suppression with derived mouse ownership.</summary>
+        private bool IsCandyGravitySuppressed(CandyContext ctx)
+        {
+            return ctx?.Lifecycle.IsGravitySuppressed == true || MouseCarries(ctx);
         }
 
         /// <summary>

--- a/CutTheRopeDX/GameMain/GameScene.Input.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Input.cs
@@ -95,10 +95,9 @@ namespace CutTheRopeDX.GameMain
             if (miceManager != null && miceManager.HandleClick(worldX, worldY, out ConstraintedPoint droppedMouseCandy))
             {
                 CandyContext droppedCandy = CandyForPointOrNull(droppedMouseCandy);
-                droppedCandy?.Lifecycle.Attachments.SetCarriedByMouse(false);
                 if (droppedCandy != null)
                 {
-                    droppedMouseCandy.disableGravity = droppedCandy.Lifecycle.IsGravitySuppressed;
+                    droppedMouseCandy.disableGravity = IsCandyGravitySuppressed(droppedCandy);
                 }
                 return true;
             }

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -851,13 +851,6 @@ namespace CutTheRopeDX.GameMain
                     }
                 }
 
-                // Sync per-candy carried flag from the active mouse (covers grab + every drop path).
-                ConstraintedPoint carried = miceManager.ActiveMouseCarriedStar();
-                for (int ci = 0; ci < candies.Count; ci++)
-                {
-                    candies[ci].Lifecycle.Attachments.SetCarriedByMouse(
-                        MouseOwnership.CarriesCandy(carried, candies[ci].WholeBody.Point));
-                }
             }
             float collisionHalfSize = ActivePhysicsConstants.SockCatchHalfSize;
             foreach (object obj11 in socks)
@@ -982,7 +975,7 @@ namespace CutTheRopeDX.GameMain
                     // wobble, frozen in as a position drift if the candy is dropped mid-jitter.
                     // Parked: no satisfaction, no thrust; position snap, rotation sync, fuse tick
                     // and gravity heal keep running, and full flight resumes on drop.
-                    bool parkedOnMouse = rocketCandy?.Lifecycle.Attachments.CarriedByMouse == true;
+                    bool parkedOnMouse = MouseCarries(rocketCandy);
                     if (parkedOnMouse && carriesCandy)
                     {
                         // prevPos too: rocket.Update integrates the point next, and a bare pos
@@ -1073,7 +1066,7 @@ namespace CutTheRopeDX.GameMain
                         if (rocket.time != -1f && Mover.MoveVariableToTarget(ref rocket.time, 0f, 1f, delta))
                         {
                             ExhaustRocketForCandy(rocketCandy);
-                            rocketStar.disableGravity = rocketCandy?.Lifecycle.IsGravitySuppressed == true;
+                            rocketStar.disableGravity = IsCandyGravitySuppressed(rocketCandy);
                         }
                     }
                     if (carriesCandy && rocket.state == Rocket.STATE_ROCKET_DIST)
@@ -1112,7 +1105,7 @@ namespace CutTheRopeDX.GameMain
                             // Per-candy: only a holder of THIS candy selects the direct-FLY bind.
                             // The rocket steals from nobody — it coexists with hand or mouse and
                             // launches when the holder releases.
-                            if (RocketBindPath.UsesDirectFlyPath(ctx.Lifecycle.Attachments.Hand != null, ctx.Lifecycle.Attachments.CarriedByMouse))
+                            if (RocketBindPath.UsesDirectFlyPath(ctx.Lifecycle.Attachments.Hand != null, MouseCarries(ctx)))
                             {
                                 rocket.point.pos = body.Point.pos;
                                 rocket.point.AddConstraintwithRestLengthofType(body.Point, 0f, Constraint.CONSTRAINT.NOT_MORE_THAN);

--- a/CutTheRopeDX/GameMain/GameScene.cs
+++ b/CutTheRopeDX/GameMain/GameScene.cs
@@ -448,7 +448,7 @@ namespace CutTheRopeDX.GameMain
             if (ctx != null)
             {
                 _ = ctx.Lifecycle.Attachments.TryReleaseRocket(r);
-                ctx.WholeBody.Point.disableGravity = ctx.Lifecycle.IsGravitySuppressed;
+                ctx.WholeBody.Point.disableGravity = IsCandyGravitySuppressed(ctx);
             }
         }
 

--- a/CutTheRopeDX/GameMain/MiceObject.cs
+++ b/CutTheRopeDX/GameMain/MiceObject.cs
@@ -67,9 +67,10 @@ namespace CutTheRopeDX.GameMain
             bool hasIndexOne = mice.Any(m => m != null && m.index == 1);
             if (sharedSpriteContainer.HasValue && (index == 1 || (activeMouse == null && !hasIndexOne)))
             {
+                MouseCarry carry = activeMouse?.DetachCarriedCandy();
                 activeMouse = mouse;
                 activeIndex = index;
-                mouse.Spawn(sharedSpriteContainer.Value, carriedCandy, carriedStar);
+                mouse.Spawn(sharedSpriteContainer.Value, carry);
             }
         }
 
@@ -104,8 +105,6 @@ namespace CutTheRopeDX.GameMain
             // a later candy is grabbed, since that path matches the singleton star points.
             scene.ReleaseRopesForPoint(star);
             scene.DetachHandsForPoint(star);
-            carriedStar = star;
-            carriedCandy = candy;
             activeMouse.GrabCandy(star, candy);
         }
 
@@ -121,7 +120,13 @@ namespace CutTheRopeDX.GameMain
         /// <summary>The point the active mouse is currently carrying, or null when it carries nothing.</summary>
         public ConstraintedPoint ActiveMouseCarriedStar()
         {
-            return (activeMouse?.HasCandy ?? false) ? carriedStar : null;
+            return activeMouse?.CarriedStar;
+        }
+
+        /// <summary>Gets whether the active mouse owns the specified candy point.</summary>
+        public bool CarriesCandy(ConstraintedPoint point)
+        {
+            return MouseOwnership.CarriesCandy(activeMouse?.CarriedStar, point);
         }
 
         /// <summary>
@@ -135,8 +140,6 @@ namespace CutTheRopeDX.GameMain
             }
 
             activeMouse.DropCandyAndRetreat();
-            carriedStar = null;
-            carriedCandy = null;
         }
 
         /// <summary>
@@ -161,8 +164,6 @@ namespace CutTheRopeDX.GameMain
             {
                 droppedCandy = ActiveMouseCarriedStar();
                 activeMouse.DropCandyAndRetreat();
-                carriedStar = null;
-                carriedCandy = null;
                 return true;
             }
 
@@ -191,13 +192,11 @@ namespace CutTheRopeDX.GameMain
             int nextIdx = (currentIdx + 1) % ordered.Count;
             Mouse nextMouse = ordered[nextIdx];
 
-            (ConstraintedPoint star, GameObject candy) = currentMouse.DetachCarriedCandy();
-            carriedStar = star;
-            carriedCandy = candy;
+            MouseCarry carry = currentMouse.DetachCarriedCandy();
 
             activeIndex = nextMouse.index;
             activeMouse = nextMouse;
-            nextMouse.Spawn(sharedSpriteContainer.Value, carriedCandy, carriedStar);
+            nextMouse.Spawn(sharedSpriteContainer.Value, carry);
         }
 
         /// <summary>
@@ -214,8 +213,6 @@ namespace CutTheRopeDX.GameMain
                 _ = mouse?.ReleaseCarriedCandy();
             }
 
-            carriedStar = null;
-            carriedCandy = null;
         }
 
         /// <summary>
@@ -376,14 +373,5 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         private bool advanceLocked;
 
-        /// <summary>
-        /// Star point currently being handed off between mice.
-        /// </summary>
-        private ConstraintedPoint carriedStar;
-
-        /// <summary>
-        /// Candy object currently being handed off between mice.
-        /// </summary>
-        private GameObject carriedCandy;
     }
 }

--- a/CutTheRopeDX/GameMain/Mouse.cs
+++ b/CutTheRopeDX/GameMain/Mouse.cs
@@ -183,8 +183,7 @@ namespace CutTheRopeDX.GameMain
             IsActive = false;
             retreating = false;
             elapsedActive = 0f;
-            carriedStar = null;
-            carriedCandy = null;
+            carry = null;
             grabAnimating = false;
             entryOffsets = new Vector[4];
             exitOffsets = new Vector[3];
@@ -223,8 +222,7 @@ namespace CutTheRopeDX.GameMain
             IsActive = false;
             retreating = false;
             elapsedActive = 0f;
-            carriedStar = null;
-            carriedCandy = null;
+            carry = null;
 
             float angleRad = DEGREES_TO_RADIANS(angleDeg);
             Vector origin = default;
@@ -265,13 +263,11 @@ namespace CutTheRopeDX.GameMain
         /// Plays the entry animation and sets up initial state.
         /// </summary>
         /// <param name="sprites">Shared sprite resources for rendering.</param>
-        /// <param name="carriedCandy">Optional candy object to carry from spawn.</param>
-        /// <param name="carriedStar">Optional star point constraint for the candy.</param>
-        public void Spawn(SharedMouseSprites sprites, GameObject carriedCandy, ConstraintedPoint carriedStar)
+        /// <param name="carry">Optional complete candy payload transferred from another mouse.</param>
+        public void Spawn(SharedMouseSprites sprites, MouseCarry carry)
         {
             sharedSprites = sprites;
-            this.carriedCandy = carriedCandy;
-            this.carriedStar = carriedStar;
+            this.carry = carry;
 
             mouseGroup.RemoveAllChilds();
             _ = mouseGroup.AddChild(sprites.Container);
@@ -282,14 +278,7 @@ namespace CutTheRopeDX.GameMain
                 sprites.Container.AddTimelinewithID(bounceTimeline, (int)MouseAnimationId.Bounce);
             }
 
-            if (carriedCandy != null && carriedStar == null)
-            {
-                Vector offset = entryOffsets[3];
-                carriedCandy.x = x + offset.X;
-                carriedCandy.y = y + offset.Y;
-            }
-
-            PlayAnimation(carriedCandy != null ? MouseAnimationId.EntryWithCandy : MouseAnimationId.EntryEmpty);
+            PlayAnimation(carry != null ? MouseAnimationId.EntryWithCandy : MouseAnimationId.EntryEmpty);
             retreating = false;
             IsActive = false;
             elapsedActive = 0f;
@@ -297,9 +286,9 @@ namespace CutTheRopeDX.GameMain
 
             sprites.Eyes.visible = false;
 
-            if (carriedStar != null)
+            if (carry != null)
             {
-                AttachExistingCandy(carriedStar, carriedCandy);
+                AttachExistingCandy(carry);
             }
 
             CTRSoundMgr.PlaySound(Resources.Snd.MouseRustle);
@@ -325,8 +314,7 @@ namespace CutTheRopeDX.GameMain
         /// <param name="candy">The candy game object being grabbed.</param>
         public void GrabCandy(ConstraintedPoint star, GameObject candy)
         {
-            carriedStar = star;
-            carriedCandy = candy;
+            carry = new MouseCarry(star, candy);
 
             star.disableGravity = true;
             star.v = default;
@@ -353,15 +341,15 @@ namespace CutTheRopeDX.GameMain
         /// <returns><see langword="true"/> when candy was actually carried and has been released.</returns>
         public bool ReleaseCarriedCandy()
         {
-            if (carriedStar == null)
+            MouseCarry released = carry;
+            if (released == null)
             {
                 return false;
             }
 
-            carriedStar.disableGravity = false;
-            carriedStar.prevPos = carriedStar.pos;
-            carriedStar = null;
-            carriedCandy = null;
+            released.Star.disableGravity = false;
+            released.Star.prevPos = released.Star.pos;
+            carry = null;
             grabAnimating = false;
             return true;
         }
@@ -400,7 +388,7 @@ namespace CutTheRopeDX.GameMain
 
             SharedMouseSprites? sprites = sharedSprites;
 
-            bool hasCandy = carriedStar != null;
+            bool hasCandy = carry != null;
 
             // iOS: only hide eyes when exiting empty (not when exiting with candy)
             if (!hasCandy && sprites.HasValue)
@@ -442,10 +430,10 @@ namespace CutTheRopeDX.GameMain
                 grabAnimating = false;
             }
 
-            if (carriedStar != null)
+            if (carry != null)
             {
-                carriedStar.pos = Vect(x + mouthOffset.X, y + mouthOffset.Y);
-                carriedStar.prevPos = carriedStar.pos;
+                carry.Star.pos = Vect(x + mouthOffset.X, y + mouthOffset.Y);
+                carry.Star.prevPos = carry.Star.pos;
             }
 
             if (IsActive && !retreating && !grabAnimating)
@@ -466,17 +454,15 @@ namespace CutTheRopeDX.GameMain
         /// and initiating the entry path animation. Used when transferring
         /// candy between mice.
         /// </summary>
-        /// <param name="star">The constrained star point to attach.</param>
-        /// <param name="candy">The candy game object to attach.</param>
-        public void AttachExistingCandy(ConstraintedPoint star, GameObject candy)
+        /// <param name="existingCarry">The complete candy payload to attach.</param>
+        private void AttachExistingCandy(MouseCarry existingCarry)
         {
-            carriedStar = star;
-            carriedCandy = candy;
-            star.disableGravity = true;
-            star.v = default;
+            carry = existingCarry;
+            existingCarry.Star.disableGravity = true;
+            existingCarry.Star.v = default;
             Vector offset = entryOffsets[3];
-            star.pos = Vect(x + offset.X, y + offset.Y);
-            star.prevPos = star.pos;
+            existingCarry.Star.pos = Vect(x + offset.X, y + offset.Y);
+            existingCarry.Star.prevPos = existingCarry.Star.pos;
             mouthPathPlayer.Play(CreateEntryPath());
             grabAnimating = true;
         }
@@ -484,7 +470,10 @@ namespace CutTheRopeDX.GameMain
         /// <summary>
         /// Gets a value indicating whether the mouse is currently carrying candy.
         /// </summary>
-        public bool HasCandy => carriedStar != null;
+        public bool HasCandy => carry != null;
+
+        /// <summary>Gets the physics point currently carried by this mouse.</summary>
+        public ConstraintedPoint CarriedStar => carry?.Star;
 
         /// <summary>
         /// Determines whether the mouse can be clicked at the specified coordinates
@@ -498,7 +487,7 @@ namespace CutTheRopeDX.GameMain
         /// </returns>
         public bool IsClickable(float clickX, float clickY)
         {
-            return IsActive && carriedStar != null && !retreating && VectDistance(Vect(x, y), Vect(clickX, clickY)) < grabRadius;
+            return IsActive && carry != null && !retreating && VectDistance(Vect(x, y), Vect(clickX, clickY)) < grabRadius;
         }
 
         /// <summary>
@@ -538,8 +527,7 @@ namespace CutTheRopeDX.GameMain
             retreating = true;
             IsActive = false;
             grabAnimating = false;
-            carriedStar = null;
-            carriedCandy = null;
+            carry = null;
 
             if (sharedSprites.HasValue)
             {
@@ -557,15 +545,13 @@ namespace CutTheRopeDX.GameMain
         /// internal references. Used when transferring candy between mice.
         /// </summary>
         /// <returns>
-        /// A tuple containing the carried star point and candy object, both of which may be <see langword="null"/>.
+        /// The complete carried payload, or <see langword="null"/> when the mouse is empty.
         /// </returns>
-        public (ConstraintedPoint star, GameObject candy) DetachCarriedCandy()
+        public MouseCarry DetachCarriedCandy()
         {
-            ConstraintedPoint star = carriedStar;
-            GameObject candy = carriedCandy;
-            carriedStar = null;
-            carriedCandy = null;
-            return (star, candy);
+            MouseCarry detached = carry;
+            carry = null;
+            return detached;
         }
 
         /// <inheritdoc />
@@ -799,14 +785,9 @@ namespace CutTheRopeDX.GameMain
         private float elapsedActive;
 
         /// <summary>
-        /// Star point currently carried by the mouse.
+        /// Complete candy payload currently owned by the mouse.
         /// </summary>
-        private ConstraintedPoint carriedStar;
-
-        /// <summary>
-        /// Candy object currently carried by the mouse.
-        /// </summary>
-        private GameObject carriedCandy;
+        private MouseCarry carry;
 
         /// <summary>
         /// Shared sprite set currently attached to this mouse.

--- a/CutTheRopeDX/GameMain/MouseCarry.cs
+++ b/CutTheRopeDX/GameMain/MouseCarry.cs
@@ -1,0 +1,15 @@
+using CutTheRopeDX.Framework.Helpers;
+using CutTheRopeDX.Framework.Physics;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>The complete candy payload owned by one mouse.</summary>
+    internal sealed class MouseCarry(ConstraintedPoint star, GameObject candy)
+    {
+        /// <summary>Gets the carried candy's physics point.</summary>
+        public ConstraintedPoint Star { get; } = star;
+
+        /// <summary>Gets the carried candy's visual object.</summary>
+        public GameObject Candy { get; } = candy;
+    }
+}


### PR DESCRIPTION
## Description

- Add a single immutable `MouseCarry` value owned by the carrying `Mouse`.
- Remove the duplicate `carriedStar` and `carriedCandy` state from `MiceObject`.
- Remove `CarriedByMouse` from `CandyAttachments`.
- Derive candy ownership and gravity decisions from the active mouse.
- Transfer the complete carry value atomically when advancing between mice.
- Remove per-frame and manual synchronization paths that could become stale.
- Add structural and behavioral regression coverage for ownership, drops, and mouse-to-mouse handoff.