### PR TITLE
fix: Prevent rocket drift after mouse release

### DIFF
--- a/CutTheRopeDX.Tests/ConstraintedPointTests.cs
+++ b/CutTheRopeDX.Tests/ConstraintedPointTests.cs
@@ -1,0 +1,27 @@
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.Framework.Physics;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class ConstraintedPointTests
+    {
+        [Theory]
+        [InlineData((int)Constraint.CONSTRAINT.DISTANCE)]
+        [InlineData((int)Constraint.CONSTRAINT.NOT_MORE_THAN)]
+        [InlineData((int)Constraint.CONSTRAINT.NOT_LESS_THAN)]
+        public void CoincidentZeroRestConstraintDoesNotInventASeparationDirection(int typeValue)
+        {
+            Vector position = new(10f, 20f);
+            ConstraintedPoint first = new() { pos = position };
+            ConstraintedPoint second = new() { pos = position };
+            first.AddConstraintwithRestLengthofType(second, 0f, (Constraint.CONSTRAINT)typeValue);
+
+            ConstraintedPoint.SatisfyConstraints(first);
+
+            Assert.Equal(position, first.pos);
+            Assert.Equal(position, second.pos);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/RocketBindRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/RocketBindRowTests.cs
@@ -103,6 +103,45 @@ namespace CutTheRopeDX.Tests.Interactions
             Assert.Equal(Rocket.STATE_ROCKET_FLY, rocket.state);
         }
 
+        [Fact]
+        public void RocketFliesStraightAfterReleaseFromSecondMouse()
+        {
+            GameScene scene = Scenario.New()
+                .MapSize(640, 480)
+                .Special(0)
+                .Design("nightLevel", "false")
+                .Design("useMobilePhysics", "true")
+                .Candy(82, 100, number: "0")
+                .OmNom(106, 346)
+                .Mouse(85, 194, radius: 50, index: 1, activeTime: 1f)
+                .Mouse(246, 142, radius: 50, index: 2, activeTime: 1f)
+                .Rocket(245, 115, angle: 0f, impulse: 20f, impulseFactor: 0.6f)
+                .Build();
+            CandyContext candy = scene.Candy();
+
+            Assert.True(
+                Interaction.StepUntil(scene, () => scene.Mice()[1].IsActive && scene.MouseCarries(candy), maxFrames: 360),
+                "the second mouse never received the candy");
+            Assert.NotNull(candy.Lifecycle.Attachments.Rocket);
+
+            Mouse second = scene.Mice()[1];
+            Rocket rocket = candy.Lifecycle.Attachments.Rocket;
+            Assert.True(scene.TouchDownXYIndex((int)second.x, (int)second.y, 0));
+            float releaseX = candy.WholeBody.Point.pos.X;
+            float releaseY = candy.WholeBody.Point.pos.Y;
+            float rocketReleaseX = rocket.x;
+
+            HeadlessGame.StepFrames(scene, 60);
+
+            Assert.True(
+                candy.WholeBody.Point.pos.X > releaseX + 20f,
+                "the rocket did not fly forward after release");
+            Assert.True(rocket.x > rocketReleaseX + 20f, "the rocket visual did not follow the candy");
+            Assert.InRange(candy.WholeBody.Point.pos.Y, releaseY - 5f, releaseY + 5f);
+            Assert.InRange(rocket.y, releaseY - 5f, releaseY + 5f);
+            Assert.InRange(rocket.x - candy.WholeBody.Point.pos.X, -2f, 2f);
+        }
+
         private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> attachment, float rocketImpulse = 0f)
         {
             // Rocket 0 is the one under test and parks in a corner until Act.BindRocket brings it

--- a/CutTheRopeDX.Tests/Interactions/Scenario.cs
+++ b/CutTheRopeDX.Tests/Interactions/Scenario.cs
@@ -28,8 +28,9 @@ namespace CutTheRopeDX.Tests.Interactions
 
         private readonly List<XElement> objects = [];
         private readonly List<XAttribute> design = [];
-        private readonly int width = DefaultWidth;
-        private readonly int height = DefaultHeight;
+        private int width = DefaultWidth;
+        private int height = DefaultHeight;
+        private int special = 1;
         private bool splitCandy;
 
         internal Scenario()
@@ -288,13 +289,14 @@ namespace CutTheRopeDX.Tests.Interactions
         /// <param name="y">Level-space Y.</param>
         /// <param name="radius">Grab radius in level units.</param>
         /// <param name="index">Mouse index; index 1 is the one that starts active.</param>
+        /// <param name="activeTime">Seconds before the mouse retreats.</param>
         /// <returns>This scenario.</returns>
-        public Scenario Mouse(int x, int y, int radius = 80, int index = 1)
+        public Scenario Mouse(int x, int y, int radius = 80, int index = 1, float activeTime = 600f)
         {
             XElement mouse = Node("mouse", x, y);
             mouse.SetAttributeValue("angle", Num(0));
             mouse.SetAttributeValue("radius", Num(radius));
-            mouse.SetAttributeValue("activeTime", Num(600));
+            mouse.SetAttributeValue("activeTime", Num(activeTime));
             mouse.SetAttributeValue("index", Num(index));
             return Add(mouse);
         }
@@ -410,6 +412,21 @@ namespace CutTheRopeDX.Tests.Interactions
             return this;
         }
 
+        /// <summary>Sets the authored map dimensions.</summary>
+        public Scenario MapSize(int mapWidth, int mapHeight)
+        {
+            width = mapWidth;
+            height = mapHeight;
+            return this;
+        }
+
+        /// <summary>Sets the authored special-tutorial identifier.</summary>
+        public Scenario Special(int specialId)
+        {
+            special = specialId;
+            return this;
+        }
+
         /// <summary>Boots the scenario and returns the live scene.</summary>
         /// <returns>The loaded scene, ready to be stepped.</returns>
         public GameScene Build()
@@ -427,7 +444,7 @@ namespace CutTheRopeDX.Tests.Interactions
                 new XElement(
                     "gameDesign",
                     new XAttribute("ropePhysicsSpeed", "1.0"),
-                    new XAttribute("special", "1"),
+                    new XAttribute("special", special),
                     new XAttribute("twoParts", Flag(splitCandy)),
                     design));
 

--- a/CutTheRopeDX/Framework/Physics/ConstraintedPoint.cs
+++ b/CutTheRopeDX/Framework/Physics/ConstraintedPoint.cs
@@ -235,12 +235,16 @@ namespace CutTheRopeDX.Framework.Physics
                 Vector deltaVector = new(
                     constraint.cp.pos.X - constrainedPoint.pos.X,
                     constraint.cp.pos.Y - constrainedPoint.pos.Y);
+                float restLength = constraint.restLength;
                 if (deltaVector.X == 0f && deltaVector.Y == 0f)
                 {
+                    if (restLength == 0f)
+                    {
+                        continue;
+                    }
                     deltaVector = DEFAULT_NON_ZERO_CONSTRAINT_DIRECTION;
                 }
                 float deltaLength = VectLength(deltaVector);
-                float restLength = constraint.restLength;
                 Constraint.CONSTRAINT type = constraint.type;
 
                 bool shouldApplyConstraint = (type == Constraint.CONSTRAINT.DISTANCE)


### PR DESCRIPTION
## Description

Repeated constraint relaxation applied the solver's fallback `(1,1)` direction after a zero-rest rocket constraint reached exact coincidence. This introduced an artificial vertical impulse, causing the rocket to float or drift instead of following its heading.

This PR introduces a fix by treating coincident zero-rest constraints as already satisfied, preventing the solver from applying an arbitrary separation direction. It also adds a code-built headless regression test that reproduces the reported level configuration and verifies that the rocket flies straight after release.