### PR TITLE
refactor: Centralize per-pointer gesture state

### DIFF
--- a/CutTheRopeDX.Tests/PointerGestureStateTests.cs
+++ b/CutTheRopeDX.Tests/PointerGestureStateTests.cs
@@ -4,6 +4,9 @@ using System.Reflection;
 using CutTheRopeDX.Framework.Core;
 using CutTheRopeDX.GameMain;
 
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input.Touch;
+
 using Xunit;
 
 namespace CutTheRopeDX.Tests
@@ -118,6 +121,83 @@ namespace CutTheRopeDX.Tests
             });
 
             Assert.Null(exception);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void OutcomePointerDrawsATrailWithoutCreatingInteractiveCuts(bool won)
+        {
+            _ = HeadlessGame.Boot();
+            GameScene scene = HeadlessGame.LoadLevel(pack: 1, level: 4);
+            HeadlessGame.StepFrames(scene, 60);
+            PointerGestureState gesture = GetPointerGesture(scene, 0);
+            if (won)
+            {
+                scene.gameplayFlow.MarkWon();
+                scene.gameplayFlow.EndTransition();
+            }
+            else
+            {
+                scene.gameplayFlow.MarkLost();
+            }
+
+            Assert.True(scene.TouchDownXYIndex(10_000f, 10_000f, 0));
+            Assert.True(scene.TouchMoveXYIndex(10_020f, 10_000f, 0));
+
+            Assert.True(gesture.IsDragging);
+            Assert.True(gesture.Trace.IsAlive);
+            Assert.Empty(gesture.Cuts);
+
+            Assert.True(scene.TouchUpXYIndex(10_020f, 10_000f, 0));
+            Assert.False(gesture.IsDragging);
+        }
+
+        [Fact]
+        public void ResultsOverlayRoutesUnclaimedTouchesToVisualTrailInput()
+        {
+            _ = HeadlessGame.Boot();
+            GameController controller = HeadlessGame.LoadLevelWithController(pack: 1, level: 4);
+            GameScene scene = (GameScene)controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_GAME_SCENE);
+            HeadlessGame.StepFrames(scene, 60);
+            PointerGestureState gesture = GetPointerGesture(scene, 0);
+            scene.gameplayFlow.MarkWon();
+            scene.gameplayFlow.EndTransition();
+            controller.LevelWon(LevelResultCalculator.Calculate(elapsedTime: 20f, starsCollected: 2));
+
+            _ = controller.TouchesBeganwithEvent([
+                new TouchLocation(37, TouchLocationState.Pressed, new Vector2(10_000f, 10_000f))
+            ]);
+            _ = controller.TouchesMovedwithEvent([
+                new TouchLocation(37, TouchLocationState.Moved, new Vector2(10_020f, 10_000f))
+            ]);
+            _ = controller.TouchesMovedwithEvent([
+                new TouchLocation(37, TouchLocationState.Moved, new Vector2(10_040f, 10_000f))
+            ]);
+
+            Assert.True(gesture.Trace.IsAlive);
+            Assert.Empty(gesture.Cuts);
+
+            _ = controller.TouchesEndedwithEvent([
+                new TouchLocation(37, TouchLocationState.Released, new Vector2(10_040f, 10_000f))
+            ]);
+            Assert.False(gesture.IsDragging);
+            Assert.True(gesture.Trace.IsAlive);
+
+            scene.updateable = false;
+            for (int frame = 0; frame < 120; frame++)
+            {
+                controller.Update(0.016f);
+            }
+
+            Assert.False(gesture.Trace.IsAlive);
+        }
+
+        private static PointerGestureState GetPointerGesture(GameScene scene, int pointerIndex)
+        {
+            FieldInfo field = typeof(GameScene).GetField("pointerGestures", InstanceFields);
+            PointerGestureState[] gestures = Assert.IsType<PointerGestureState[]>(field?.GetValue(scene));
+            return gestures[pointerIndex];
         }
     }
 }

--- a/CutTheRopeDX.Tests/PointerGestureStateTests.cs
+++ b/CutTheRopeDX.Tests/PointerGestureStateTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Reflection;
+
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class PointerGestureStateTests
+    {
+        private const BindingFlags InstanceFields = BindingFlags.Instance
+            | BindingFlags.Public
+            | BindingFlags.NonPublic;
+
+        [Fact]
+        public void GameSceneOwnsOnePointerGestureCollectionInsteadOfParallelArrays()
+        {
+            FieldInfo[] fields = typeof(GameScene).GetFields(InstanceFields);
+
+            FieldInfo gestures = Assert.Single(
+                fields,
+                field => field.FieldType == typeof(PointerGestureState[]));
+            Assert.Equal("pointerGestures", gestures.Name);
+            Assert.DoesNotContain(
+                fields,
+                field => field.Name is "dragging"
+                    or "startPos"
+                    or "prevStartPos"
+                    or "fingerTraceDownPos"
+                    or "fingerTraceDragging"
+                    or "fingerCuts"
+                    or "fingerTraces");
+        }
+
+        [Fact]
+        public void BeginMoveAndEndAdvanceOneGestureAtomically()
+        {
+            PointerGestureState gesture = new(FingerTraceFactory.Create(0));
+
+            gesture.Begin(new Vector(2f, 3f), new Vector(12f, 13f));
+
+            Assert.True(gesture.IsDragging);
+            Assert.Equal(2f, gesture.StartPosition.X);
+            Assert.Equal(3f, gesture.StartPosition.Y);
+            Assert.Equal(12f, gesture.TraceDownPosition.X);
+            Assert.Equal(13f, gesture.TraceDownPosition.Y);
+            Assert.False(gesture.IsTraceDragging);
+
+            Assert.True(gesture.Move(new Vector(5f, 7f), new Vector(15f, 17f), out Vector segmentStart));
+            Assert.Equal(2f, segmentStart.X);
+            Assert.Equal(3f, segmentStart.Y);
+            Assert.False(gesture.IsTraceDragging);
+
+            Assert.True(gesture.Move(new Vector(8f, 11f), new Vector(18f, 21f), out _));
+            Assert.Equal(5f, gesture.PreviousStartPosition.X);
+            Assert.Equal(7f, gesture.PreviousStartPosition.Y);
+            Assert.True(gesture.IsTraceDragging);
+
+            gesture.End();
+
+            Assert.False(gesture.IsDragging);
+            Assert.False(gesture.IsTraceDragging);
+            Assert.False(gesture.Move(default, default, out _));
+        }
+
+        [Fact]
+        public void CancelEndsEveryActivePartOfTheGesture()
+        {
+            PointerGestureState gesture = new(FingerTraceFactory.Create(0));
+            gesture.Begin(default, default);
+            _ = gesture.Move(new Vector(10f, 0f), new Vector(10f, 0f), out _);
+
+            Assert.True(gesture.Trace.IsAlive);
+
+            gesture.Cancel();
+
+            Assert.False(gesture.IsDragging);
+            Assert.False(gesture.IsTraceDragging);
+            Assert.False(gesture.Trace.IsAlive);
+        }
+
+        [Fact]
+        public void ResetClearsAllGestureStateForANewScene()
+        {
+            PointerGestureState gesture = new(FingerTraceFactory.Create(0));
+            gesture.Begin(new Vector(2f, 3f), new Vector(12f, 13f));
+            _ = gesture.Move(new Vector(12f, 3f), new Vector(22f, 13f), out _);
+            gesture.Cuts.Add(new GameScene.FingerCut());
+
+            gesture.Reset();
+
+            Assert.False(gesture.IsDragging);
+            Assert.False(gesture.IsTraceDragging);
+            Assert.Equal(default, gesture.StartPosition);
+            Assert.Equal(default, gesture.PreviousStartPosition);
+            Assert.Equal(default, gesture.TraceDownPosition);
+            Assert.Empty(gesture.Cuts);
+            Assert.False(gesture.Trace.IsAlive);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(5)]
+        public void SceneInputRejectsInvalidPointerBeforeGestureAccess(int pointerIndex)
+        {
+            _ = HeadlessGame.Boot();
+            GameScene scene = HeadlessGame.LoadLevel(pack: 1, level: 4);
+            HeadlessGame.StepFrames(scene, 60);
+
+            Exception exception = Record.Exception(() =>
+            {
+                Assert.True(scene.TouchDownXYIndex(10_000f, 10_000f, pointerIndex));
+                Assert.True(scene.TouchMoveXYIndex(10_000f, 10_000f, pointerIndex));
+                Assert.True(scene.TouchUpXYIndex(10_000f, 10_000f, pointerIndex));
+                Assert.False(scene.TouchDraggedXYIndex(10_000f, 10_000f, pointerIndex));
+            });
+
+            Assert.Null(exception);
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/GameController.cs
+++ b/CutTheRopeDX/GameMain/GameController.cs
@@ -28,6 +28,12 @@ namespace CutTheRopeDX.GameMain
             }
             base.Update(t);
 
+            GameScene gameScene = (GameScene)GetView(0)?.GetChild(GameView.VIEW_ELEMENT_GAME_SCENE);
+            if (gameScene?.AcceptsVisualOnlyPointerInput == true && !gameScene.updateable)
+            {
+                gameScene.UpdatePointerGestureVisuals(t);
+            }
+
             if (levelWatcher != null && levelWatcher.TryConsumeChange(DateTime.UtcNow))
             {
                 ApplyCustomLevelChange();
@@ -750,7 +756,7 @@ namespace CutTheRopeDX.GameMain
             {
                 return true;
             }
-            if (!gameScene.touchable)
+            if (!CanRoutePointerInput(gameScene))
             {
                 return false;
             }
@@ -785,7 +791,7 @@ namespace CutTheRopeDX.GameMain
             {
                 return true;
             }
-            if (!gameScene.touchable)
+            if (!CanRoutePointerInput(gameScene))
             {
                 return false;
             }
@@ -824,7 +830,7 @@ namespace CutTheRopeDX.GameMain
             {
                 return true;
             }
-            if (!gameScene.touchable)
+            if (!CanRoutePointerInput(gameScene))
             {
                 return false;
             }
@@ -922,12 +928,19 @@ namespace CutTheRopeDX.GameMain
                 return false;
             }
             GameScene gameScene = (GameScene)view.GetChild(0);
-            if (gameScene == null || !gameScene.touchable)
+            if (gameScene == null || !CanRoutePointerInput(gameScene))
             {
                 return false;
             }
             _ = gameScene.TouchDraggedXYIndex(x, y, 0);
             return true;
+        }
+
+        /// <summary>Allows gameplay input normally and visual-only trails during a stable outcome.</summary>
+        private bool CanRoutePointerInput(GameScene gameScene)
+        {
+            return gameScene.touchable
+                || (!navigationExitActive && gameScene.AcceptsVisualOnlyPointerInput);
         }
 
         /// <inheritdoc />

--- a/CutTheRopeDX/GameMain/GameScene.Draw.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Draw.cs
@@ -337,9 +337,9 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         public void DrawCuts()
         {
-            for (int i = 0; i < 5; i++)
+            foreach (PointerGestureState gesture in pointerGestures)
             {
-                fingerTraces[i]?.Draw();
+                gesture.Trace?.Draw();
             }
         }
     }

--- a/CutTheRopeDX/GameMain/GameScene.Init.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Init.cs
@@ -81,11 +81,10 @@ namespace CutTheRopeDX.GameMain
                 hudStar[i].y = hudStar[i].height / 2;
                 _ = AddChild(hudStar[i]);
             }
-            for (int j = 0; j < 5; j++)
+            int selectedTraceIndex = Preferences.GetIntForKey("PREFS_SELECTED_TRACE");
+            for (int j = 0; j < pointerGestures.Length; j++)
             {
-                fingerCuts[j] = [];
-                int selectedTraceIndex = Preferences.GetIntForKey("PREFS_SELECTED_TRACE");
-                fingerTraces[j] = FingerTraceFactory.Create(selectedTraceIndex);
+                pointerGestures[j] = new PointerGestureState(FingerTraceFactory.Create(selectedTraceIndex));
             }
             clickToCut = Preferences.GetBooleanForKey("PREFS_CLICK_TO_CUT");
         }

--- a/CutTheRopeDX/GameMain/GameScene.Input.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Input.cs
@@ -77,21 +77,22 @@ namespace CutTheRopeDX.GameMain
         /// <returns><see langword="true"/> when the touch-down event was consumed; otherwise, <see langword="false"/>.</returns>
         public bool TouchDownXYIndex(float tx, float ty, int ti)
         {
+            if (!TryGetPointerGesture(ti, out PointerGestureState gesture))
+            {
+                return true;
+            }
+            // Outcome input owns only the visual trace; it must not reach any gameplay object.
+            if (AcceptsVisualOnlyPointerInput)
+            {
+                gesture.Begin(Vect(tx, ty), Vect(tx + camera.pos.X, ty + camera.pos.Y));
+                return true;
+            }
             if (ignoreTouches)
             {
                 if (camera.type == CAMERATYPE.CAMERASPEEDPIXELS)
                 {
                     fastenCamera = true;
                 }
-                return true;
-            }
-            // Suppress all gameplay interactions while a win/loss transition is running.
-            if (gameplayFlow.TransitionActive)
-            {
-                return true;
-            }
-            if (!TryGetPointerGesture(ti, out PointerGestureState gesture))
-            {
                 return true;
             }
             if (gravityButton != null && ((Button)gravityButton.GetChild(gravityButton.On() ? 1 : 0)).IsInTouchZoneXYforTouchDown(tx + camera.pos.X, ty + camera.pos.Y, true))
@@ -445,16 +446,17 @@ namespace CutTheRopeDX.GameMain
         /// <returns><see langword="true"/> when the touch-up event was consumed; otherwise, <see langword="false"/>.</returns>
         public bool TouchUpXYIndex(float tx, float ty, int ti)
         {
-            if (ignoreTouches)
-            {
-                return true;
-            }
-            // Suppress all gameplay interactions while a win/loss transition is running.
-            if (gameplayFlow.TransitionActive)
-            {
-                return true;
-            }
             if (!TryGetPointerGesture(ti, out PointerGestureState gesture))
+            {
+                return true;
+            }
+            // Outcome input ends the visual trace without reaching any gameplay object.
+            if (AcceptsVisualOnlyPointerInput)
+            {
+                gesture.End();
+                return true;
+            }
+            if (ignoreTouches)
             {
                 return true;
             }
@@ -595,21 +597,22 @@ namespace CutTheRopeDX.GameMain
         /// <returns><see langword="true"/> when the touch-move event was consumed; otherwise, <see langword="false"/>.</returns>
         public bool TouchMoveXYIndex(float tx, float ty, int ti)
         {
-            if (ignoreTouches)
-            {
-                return true;
-            }
-            // Suppress all gameplay interactions while a win/loss transition is running.
-            if (gameplayFlow.TransitionActive)
-            {
-                return true;
-            }
             if (!TryGetPointerGesture(ti, out PointerGestureState gesture))
             {
                 return true;
             }
             Vector vector = Vect(tx, ty);
             Vector world = Vect(tx + camera.pos.X, ty + camera.pos.Y);
+            // Outcome input advances only the visual trace; no cuts or object handlers run.
+            if (AcceptsVisualOnlyPointerInput)
+            {
+                _ = gesture.Move(vector, world, out _);
+                return true;
+            }
+            if (ignoreTouches)
+            {
+                return true;
+            }
             if (rockets != null)
             {
                 foreach (Rocket rocket in rockets)
@@ -874,8 +877,8 @@ namespace CutTheRopeDX.GameMain
             {
                 return false;
             }
-            // Suppress all gameplay interactions while a win/loss transition is running.
-            if (gameplayFlow.TransitionActive)
+            // Hover state is gameplay-only; outcome drawing is handled by the gesture lifecycle.
+            if (AcceptsVisualOnlyPointerInput)
             {
                 return true;
             }

--- a/CutTheRopeDX/GameMain/GameScene.Input.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Input.cs
@@ -49,14 +49,23 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         public void EndActiveFingerTraces()
         {
-            for (int i = 0; i < fingerTraces.Length; i++)
+            foreach (PointerGestureState gesture in pointerGestures)
             {
-                if (fingerTraceDragging[i])
-                {
-                    fingerTraces[i]?.End();
-                    fingerTraceDragging[i] = false;
-                }
+                gesture?.Cancel();
             }
+        }
+
+        /// <summary>Resolves a supported pointer index before any gesture state is accessed.</summary>
+        private bool TryGetPointerGesture(int pointerIndex, out PointerGestureState gesture)
+        {
+            if ((uint)pointerIndex < (uint)pointerGestures.Length)
+            {
+                gesture = pointerGestures[pointerIndex];
+                return gesture != null;
+            }
+
+            gesture = null;
+            return false;
         }
 
         /// <summary>
@@ -81,7 +90,7 @@ namespace CutTheRopeDX.GameMain
             {
                 return true;
             }
-            if (ti >= 5)
+            if (!TryGetPointerGesture(ti, out PointerGestureState gesture))
             {
                 return true;
             }
@@ -143,13 +152,7 @@ namespace CutTheRopeDX.GameMain
                     return true;
                 }
             }
-            if (!dragging[ti])
-            {
-                dragging[ti] = true;
-                prevStartPos[ti] = startPos[ti] = vector;
-                fingerTraceDownPos[ti] = world;
-                fingerTraceDragging[ti] = false;
-            }
+            gesture.Begin(vector, world);
             foreach (object obj in spikes)
             {
                 Spikes spike = (Spikes)obj;
@@ -416,7 +419,7 @@ namespace CutTheRopeDX.GameMain
             }
             if (conveyors.OnPointerDown(worldX, worldY, ti))
             {
-                dragging[ti] = false;
+                gesture.Cancel();
                 return true;
             }
             if (clickToCut && !ignoreTouches)
@@ -451,16 +454,11 @@ namespace CutTheRopeDX.GameMain
             {
                 return true;
             }
-            dragging[ti] = false;
-            if (fingerTraceDragging[ti])
-            {
-                fingerTraces[ti]?.End();
-                fingerTraceDragging[ti] = false;
-            }
-            if (ti >= 5)
+            if (!TryGetPointerGesture(ti, out PointerGestureState gesture))
             {
                 return true;
             }
+            gesture.End();
             if (rockets != null)
             {
                 foreach (Rocket rocket in rockets)
@@ -606,11 +604,11 @@ namespace CutTheRopeDX.GameMain
             {
                 return true;
             }
-            Vector vector = Vect(tx, ty);
-            if (ti >= 5)
+            if (!TryGetPointerGesture(ti, out PointerGestureState gesture))
             {
                 return true;
             }
+            Vector vector = Vect(tx, ty);
             Vector world = Vect(tx + camera.pos.X, ty + camera.pos.Y);
             if (rockets != null)
             {
@@ -626,7 +624,7 @@ namespace CutTheRopeDX.GameMain
             foreach (object obj in pumps)
             {
                 Pump pump3 = (Pump)obj;
-                if (pump3.pumpTouch == ti && pump3.pumpTouchTimer != 0 && VectDistance(startPos[ti], vector) > 10)
+                if (pump3.pumpTouch == ti && pump3.pumpTouchTimer != 0 && VectDistance(gesture.StartPosition, vector) > 10)
                 {
                     pump3.pumpTouchTimer = 0f;
                 }
@@ -794,7 +792,7 @@ namespace CutTheRopeDX.GameMain
                     }
                     // Cancel stick timer if moved too much (kickable grabs)
                     if (grab2.Mount is SuctionMount dragMount && !dragMount.IsMounted && grab2.Rope != null &&
-                        VectLength(VectSub(startPos[ti], vector)) > Grab.KICK_MOVE_LENGTH)
+                        VectLength(VectSub(gesture.StartPosition, vector)) > Grab.KICK_MOVE_LENGTH)
                     {
                         dragMount.CancelSticking();
                     }
@@ -804,9 +802,9 @@ namespace CutTheRopeDX.GameMain
             {
                 return true;
             }
-            if (dragging[ti])
+            if (gesture.Move(vector, world, out Vector segmentStart))
             {
-                Vector start = VectAdd(startPos[ti], camera.pos);
+                Vector start = VectAdd(segmentStart, camera.pos);
                 Vector end = VectAdd(Vect(tx, ty), camera.pos);
                 FingerCut fingerCut = new()
                 {
@@ -816,9 +814,9 @@ namespace CutTheRopeDX.GameMain
                     endSize = 5f,
                     c = RGBAColor.whiteRGBA
                 };
-                fingerCuts[ti].Add(fingerCut);
+                gesture.Cuts.Add(fingerCut);
                 int ropesCutThisFrame = 0;
-                foreach (object obj2 in fingerCuts[ti])
+                foreach (object obj2 in gesture.Cuts)
                 {
                     FingerCut item = (FingerCut)obj2;
                     ropesCutThisFrame += CutWithRazorOrLine1Line2Immediate(null, item.start, item.end, false);
@@ -858,25 +856,6 @@ namespace CutTheRopeDX.GameMain
                         CTRRootController.PostAchievementName("1058248892", ACHIEVEMENT_STRING("\"Ultimate Rope Cutter\""));
                     }
                 }
-                prevStartPos[ti] = startPos[ti];
-                startPos[ti] = vector;
-                if (fingerTraces[ti] != null)
-                {
-                    if (!fingerTraceDragging[ti])
-                    {
-                        float dx = world.X - fingerTraceDownPos[ti].X;
-                        float dy = world.Y - fingerTraceDownPos[ti].Y;
-                        if ((dx * dx) + (dy * dy) >= 100f)
-                        {
-                            fingerTraceDragging[ti] = true;
-                        }
-                    }
-
-                    if (fingerTraceDragging[ti])
-                    {
-                        fingerTraces[ti].Append(world);
-                    }
-                }
             }
             return true;
         }
@@ -891,7 +870,7 @@ namespace CutTheRopeDX.GameMain
         /// <returns><see langword="true"/> when the drag was recorded; otherwise, <see langword="false"/>.</returns>
         public bool TouchDraggedXYIndex(float tx, float ty, int index)
         {
-            if (index > 5)
+            if (!TryGetPointerGesture(index, out _))
             {
                 return false;
             }

--- a/CutTheRopeDX/GameMain/GameScene.Show.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Show.cs
@@ -108,11 +108,9 @@ namespace CutTheRopeDX.GameMain
                 timeline6.delegateTimelineDelegate = staticAniPool;
                 _ = staticAniPool.AddChild(text);
             }
-            for (int m = 0; m < 5; m++)
+            foreach (PointerGestureState gesture in pointerGestures)
             {
-                dragging[m] = false;
-                startPos[m] = prevStartPos[m] = vectZero;
-                fingerTraces[m]?.Reset();
+                gesture?.Reset();
             }
             if (clickToCut)
             {

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -29,15 +29,15 @@ namespace CutTheRopeDX.GameMain
             dd.Update(delta);
             pollenDrawer.Update(delta);
             CTRRootController cTRRootController = (CTRRootController)Application.SharedRootController();
-            for (int i = 0; i < 5; i++)
+            foreach (PointerGestureState gesture in pointerGestures)
             {
-                for (int j = 0; j < fingerCuts[i].Count; j++)
+                for (int j = 0; j < gesture.Cuts.Count; j++)
                 {
-                    FingerCut fingerCut = fingerCuts[i][j];
+                    FingerCut fingerCut = gesture.Cuts[j];
                     float alpha = fingerCut.c.AlphaChannel;
                     if (Mover.MoveVariableToTarget(ref alpha, 0, 10, delta))
                     {
-                        _ = fingerCuts[i].Remove(fingerCut);
+                        _ = gesture.Cuts.Remove(fingerCut);
                         j--;
                     }
                     else
@@ -45,7 +45,7 @@ namespace CutTheRopeDX.GameMain
                         fingerCut.c.AlphaChannel = alpha;
                     }
                 }
-                fingerTraces[i]?.Update(delta);
+                gesture.Trace?.Update(delta);
             }
             if (earthAnims != null)
             {

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -29,24 +29,7 @@ namespace CutTheRopeDX.GameMain
             dd.Update(delta);
             pollenDrawer.Update(delta);
             CTRRootController cTRRootController = (CTRRootController)Application.SharedRootController();
-            foreach (PointerGestureState gesture in pointerGestures)
-            {
-                for (int j = 0; j < gesture.Cuts.Count; j++)
-                {
-                    FingerCut fingerCut = gesture.Cuts[j];
-                    float alpha = fingerCut.c.AlphaChannel;
-                    if (Mover.MoveVariableToTarget(ref alpha, 0, 10, delta))
-                    {
-                        _ = gesture.Cuts.Remove(fingerCut);
-                        j--;
-                    }
-                    else
-                    {
-                        fingerCut.c.AlphaChannel = alpha;
-                    }
-                }
-                gesture.Trace?.Update(delta);
-            }
+            UpdatePointerGestureVisuals(delta);
             if (earthAnims != null)
             {
                 foreach (object obj in earthAnims)
@@ -1536,7 +1519,7 @@ namespace CutTheRopeDX.GameMain
                     }
                 }
             }
-            if (clickToCut && !ignoreTouches)
+            if (clickToCut && !ignoreTouches && !AcceptsVisualOnlyPointerInput)
             {
                 ResetBungeeHighlight();
                 bool flag12 = false;
@@ -1618,6 +1601,15 @@ namespace CutTheRopeDX.GameMain
                 case RestartStep.None:
                 default:
                     break;
+            }
+        }
+
+        /// <summary>Advances pointer visuals even when outcome presentation freezes gameplay simulation.</summary>
+        internal void UpdatePointerGestureVisuals(float delta)
+        {
+            foreach (PointerGestureState gesture in pointerGestures)
+            {
+                gesture.UpdateVisuals(delta);
             }
         }
 

--- a/CutTheRopeDX/GameMain/GameScene.cs
+++ b/CutTheRopeDX/GameMain/GameScene.cs
@@ -937,20 +937,11 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         private float targetBaseScaleY = 1f;
 
-        /// <summary>
-        /// Per-touch flags indicating which touches are currently dragging.
-        /// </summary>
-        private readonly bool[] dragging = new bool[5];
+        /// <summary>Number of simultaneous pointer gestures supported by gameplay.</summary>
+        private const int PointerGestureCount = 5;
 
-        /// <summary>
-        /// Starting positions for active touches.
-        /// </summary>
-        private readonly Vector[] startPos = new Vector[5];
-
-        /// <summary>
-        /// Previous starting positions for active touches.
-        /// </summary>
-        private readonly Vector[] prevStartPos = new Vector[5];
+        /// <summary>Authoritative per-pointer rope-cut gesture state.</summary>
+        private readonly PointerGestureState[] pointerGestures = new PointerGestureState[PointerGestureCount];
 
         /// <summary>
         /// Current rope physics time scale.
@@ -1141,26 +1132,6 @@ namespace CutTheRopeDX.GameMain
         /// The last recorded touch position for scene-level gestures.
         /// </summary>
         public Vector slastTouch;
-
-        /// <summary>
-        /// Per-touch finger cut ribbons used for cut visualization.
-        /// </summary>
-        public List<FingerCut>[] fingerCuts = new List<FingerCut>[5];
-
-        /// <summary>
-        /// Per-touch finger trace effects.
-        /// </summary>
-        public FingerTrace[] fingerTraces = new FingerTrace[5];
-
-        /// <summary>
-        /// Touch-down positions used by the finger trace system.
-        /// </summary>
-        private readonly Vector[] fingerTraceDownPos = new Vector[5];
-
-        /// <summary>
-        /// Whether each touch is actively driving a finger trace drag.
-        /// </summary>
-        private readonly bool[] fingerTraceDragging = new bool[5];
 
         /// <summary>
         /// Represents one rendered cut segment between two touch positions.

--- a/CutTheRopeDX/GameMain/GameScene.cs
+++ b/CutTheRopeDX/GameMain/GameScene.cs
@@ -943,6 +943,11 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Authoritative per-pointer rope-cut gesture state.</summary>
         private readonly PointerGestureState[] pointerGestures = new PointerGestureState[PointerGestureCount];
 
+        /// <summary>Whether an outcome allows visual-only pointer trails while gameplay input is blocked.</summary>
+        internal bool AcceptsVisualOnlyPointerInput => gameplayFlow.TransitionActive
+            || gameplayFlow.WonTriggered
+            || gameplayFlow.LostTriggered;
+
         /// <summary>
         /// Current rope physics time scale.
         /// </summary>

--- a/CutTheRopeDX/GameMain/PointerGestureState.cs
+++ b/CutTheRopeDX/GameMain/PointerGestureState.cs
@@ -1,0 +1,111 @@
+using System.Collections.Generic;
+
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.Framework.Visual;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// Owns every piece of mutable rope-cut gesture state for one pointer.
+    /// </summary>
+    internal sealed class PointerGestureState(FingerTrace trace)
+    {
+        private const float TraceDragThresholdSquared = 100f;
+
+        /// <summary>Whether this pointer currently owns a rope-cut drag.</summary>
+        public bool IsDragging { get; private set; }
+
+        /// <summary>Latest pointer position in screen space.</summary>
+        public Vector StartPosition { get; private set; }
+
+        /// <summary>Screen-space pointer position preceding <see cref="StartPosition"/>.</summary>
+        public Vector PreviousStartPosition { get; private set; }
+
+        /// <summary>World-space position at which the pointer went down.</summary>
+        public Vector TraceDownPosition { get; private set; }
+
+        /// <summary>Whether movement has crossed the finger-trace activation threshold.</summary>
+        public bool IsTraceDragging { get; private set; }
+
+        /// <summary>Cut ribbons created by this pointer.</summary>
+        public List<GameScene.FingerCut> Cuts { get; } = [];
+
+        /// <summary>Visual finger trace assigned to this pointer.</summary>
+        public FingerTrace Trace { get; } = trace;
+
+        /// <summary>Begins a gesture unless this pointer is already active.</summary>
+        public void Begin(Vector screenPosition, Vector worldPosition)
+        {
+            if (IsDragging)
+            {
+                return;
+            }
+
+            IsDragging = true;
+            StartPosition = screenPosition;
+            PreviousStartPosition = screenPosition;
+            TraceDownPosition = worldPosition;
+            IsTraceDragging = false;
+        }
+
+        /// <summary>
+        /// Advances an active gesture and returns the start of the new cut segment.
+        /// </summary>
+        public bool Move(Vector screenPosition, Vector worldPosition, out Vector segmentStart)
+        {
+            segmentStart = StartPosition;
+            if (!IsDragging)
+            {
+                return false;
+            }
+
+            PreviousStartPosition = StartPosition;
+            StartPosition = screenPosition;
+
+            if (Trace != null)
+            {
+                if (!IsTraceDragging)
+                {
+                    float dx = worldPosition.X - TraceDownPosition.X;
+                    float dy = worldPosition.Y - TraceDownPosition.Y;
+                    IsTraceDragging = (dx * dx) + (dy * dy) >= TraceDragThresholdSquared;
+                }
+
+                if (IsTraceDragging)
+                {
+                    Trace.Append(worldPosition);
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>Completes a gesture while allowing its visible trace to fade out.</summary>
+        public void End()
+        {
+            IsDragging = false;
+            if (IsTraceDragging)
+            {
+                Trace?.End();
+                IsTraceDragging = false;
+            }
+        }
+
+        /// <summary>Cancels all active gesture ownership for this pointer.</summary>
+        public void Cancel()
+        {
+            End();
+        }
+
+        /// <summary>Clears this pointer for a newly shown scene.</summary>
+        public void Reset()
+        {
+            Cancel();
+            StartPosition = default;
+            PreviousStartPosition = default;
+            TraceDownPosition = default;
+            Cuts.Clear();
+            Trace?.Reset();
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/PointerGestureState.cs
+++ b/CutTheRopeDX/GameMain/PointerGestureState.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 
 using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.Framework.Helpers;
 using CutTheRopeDX.Framework.Visual;
 
 namespace CutTheRopeDX.GameMain
@@ -106,6 +107,27 @@ namespace CutTheRopeDX.GameMain
             TraceDownPosition = default;
             Cuts.Clear();
             Trace?.Reset();
+        }
+
+        /// <summary>Advances fading cut ribbons and the visual trace independently of gameplay simulation.</summary>
+        public void UpdateVisuals(float delta)
+        {
+            for (int i = 0; i < Cuts.Count; i++)
+            {
+                GameScene.FingerCut cut = Cuts[i];
+                float alpha = cut.c.AlphaChannel;
+                if (Mover.MoveVariableToTarget(ref alpha, 0f, 10f, delta))
+                {
+                    Cuts.RemoveAt(i);
+                    i--;
+                }
+                else
+                {
+                    cut.c.AlphaChannel = alpha;
+                }
+            }
+
+            Trace?.Update(delta);
         }
     }
 }


### PR DESCRIPTION
## Description

- Replace seven parallel per-pointer arrays with one authoritative `PointerGestureState[5]`.
- Centralize gesture lifecycle through `Begin`, `Move`, `End`, `Cancel`, and `Reset`.
- Validate negative and out-of-range pointer indices before accessing gesture state.
- Route touch input, conveyor cancellation, outcome cleanup, scene reset, trace updates, and drawing through the consolidated state.
- Fix touch-up accessing gesture arrays before validating the pointer index.
- Add regression coverage for lifecycle transitions, resets, trace state, structural consolidation, and invalid pointer indices.
- Allow visual-only trails after level win or loss. Close #273.