### PR TITLE
refactor: Refactor gravity into a single source of truth, allow 2+ gravity buttons

### DIFF
--- a/CutTheRopeDX.Tests/GravityStateTests.cs
+++ b/CutTheRopeDX.Tests/GravityStateTests.cs
@@ -87,6 +87,28 @@ namespace CutTheRopeDX.Tests
         }
 
         [Fact]
+        public void EveryAttachedButtonFollowsTheAuthoritativeOrientation()
+        {
+            GravityState gravity = new();
+            ToggleButton first = CreateToggleButton();
+            ToggleButton second = CreateToggleButton();
+            gravity.ConfigureBase(new Vector(0f, 100f));
+            gravity.AttachButton(first);
+            gravity.AttachButton(second);
+            gravity.Activate();
+
+            gravity.Toggle();
+
+            Assert.True(first.On());
+            Assert.True(second.On());
+
+            gravity.Toggle();
+
+            Assert.False(first.On());
+            Assert.False(second.On());
+        }
+
+        [Fact]
         public void ActivateRestoresNormalOrientationAcrossEveryRepresentation()
         {
             GravityState gravity = new();

--- a/CutTheRopeDX.Tests/GravityStateTests.cs
+++ b/CutTheRopeDX.Tests/GravityStateTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Reflection;
+
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.Framework.Physics;
+using CutTheRopeDX.Framework.Visual;
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class GravityStateTests : IDisposable
+    {
+        private const BindingFlags InstanceFields = BindingFlags.Instance
+            | BindingFlags.Public
+            | BindingFlags.NonPublic;
+
+        private readonly Vector originalGlobalGravity = MaterialPoint.globalGravity;
+        private readonly bool originalGlobalDisableGravity = MaterialPoint.globalDisableGravity;
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            MaterialPoint.globalGravity = originalGlobalGravity;
+            MaterialPoint.globalDisableGravity = originalGlobalDisableGravity;
+        }
+
+        [Fact]
+        public void GameSceneOwnsOneGravityStateInsteadOfParallelFields()
+        {
+            FieldInfo[] fields = typeof(GameScene).GetFields(InstanceFields);
+
+            FieldInfo gravity = Assert.Single(
+                fields,
+                field => field.FieldType == typeof(GravityState));
+            Assert.Equal("gravityState", gravity.Name);
+            Assert.DoesNotContain(
+                fields,
+                field => field.Name is "gravityNormal"
+                    or "gravityTouchDown"
+                    or "globalGravityX"
+                    or "globalGravityY"
+                    or "gravityButton"
+                    or "earthAnims");
+        }
+
+        [Fact]
+        public void GravityStateDoesNotExposeMutablePresentationObjects()
+        {
+            PropertyInfo[] properties = typeof(GravityState).GetProperties(
+                BindingFlags.Instance | BindingFlags.Public);
+
+            Assert.DoesNotContain(properties, property => property.PropertyType == typeof(ToggleButton));
+            Assert.DoesNotContain(properties, property => property.Name == "EarthAnimations");
+        }
+
+        [Fact]
+        public void ToggleAtomicallyUpdatesDerivedVectorPhysicsAndPresentation()
+        {
+            GravityState gravity = new();
+            ToggleButton button = CreateToggleButton();
+            Image earth = CreateEarthAnimation();
+            gravity.ConfigureBase(new Vector(12f, 34f));
+            gravity.AttachButton(button);
+            gravity.AddEarthAnimation(earth);
+
+            gravity.Activate();
+
+            Assert.False(gravity.IsInverted);
+            AssertVector(12f, 34f, gravity.BaseVector);
+            AssertVector(12f, 34f, gravity.CurrentVector);
+            AssertVector(12f, 34f, MaterialPoint.globalGravity);
+            Assert.False(MaterialPoint.globalDisableGravity);
+            Assert.False(button.On());
+            Assert.Equal(-1, earth.GetCurrentTimelineIndex());
+            Assert.Equal(0f, earth.rotation);
+
+            gravity.Toggle();
+
+            Assert.True(gravity.IsInverted);
+            AssertVector(12f, 34f, gravity.BaseVector);
+            AssertVector(12f, -34f, gravity.CurrentVector);
+            AssertVector(12f, -34f, MaterialPoint.globalGravity);
+            Assert.True(button.On());
+            Assert.Equal(1, earth.GetCurrentTimelineIndex());
+        }
+
+        [Fact]
+        public void ActivateRestoresNormalOrientationAcrossEveryRepresentation()
+        {
+            GravityState gravity = new();
+            ToggleButton button = CreateToggleButton();
+            Image earth = CreateEarthAnimation();
+            gravity.ConfigureBase(new Vector(-7f, 25f));
+            gravity.AttachButton(button);
+            gravity.AddEarthAnimation(earth);
+            gravity.Activate();
+            gravity.Toggle();
+            gravity.CaptureToggleTouch(3);
+
+            gravity.Activate();
+
+            Assert.False(gravity.IsInverted);
+            AssertVector(-7f, 25f, gravity.CurrentVector);
+            AssertVector(-7f, 25f, MaterialPoint.globalGravity);
+            Assert.False(button.On());
+            Assert.Equal(-1, earth.GetCurrentTimelineIndex());
+            Assert.Equal(0f, earth.rotation);
+            Assert.False(gravity.ReleaseToggleTouch(3));
+        }
+
+        [Fact]
+        public void ToggleTouchCanOnlyBeReleasedByItsOwningPointer()
+        {
+            GravityState gravity = new();
+
+            gravity.CaptureToggleTouch(2);
+
+            Assert.False(gravity.ReleaseToggleTouch(1));
+            Assert.True(gravity.ReleaseToggleTouch(2));
+            Assert.False(gravity.ReleaseToggleTouch(2));
+        }
+
+        [Fact]
+        public void ZeroBaseGravityDisablesGlobalGravityWithoutASecondAuthority()
+        {
+            GravityState gravity = new();
+            gravity.ConfigureBase(default);
+
+            gravity.Activate();
+
+            Assert.Equal(default, gravity.CurrentVector);
+            Assert.Equal(default, MaterialPoint.globalGravity);
+            Assert.True(MaterialPoint.globalDisableGravity);
+        }
+
+        private static ToggleButton CreateToggleButton()
+        {
+            return new ToggleButton().InitWithUpElement1DownElement1UpElement2DownElement2andID(
+                new BaseElement(),
+                new BaseElement(),
+                new BaseElement(),
+                new BaseElement(),
+                GameSceneButtonId.GravityToggle);
+        }
+
+        private static Image CreateEarthAnimation()
+        {
+            Image earth = new();
+            earth.AddTimelinewithID(new Timeline().InitWithMaxKeyFramesOnTrack(0), 0);
+            earth.AddTimelinewithID(new Timeline().InitWithMaxKeyFramesOnTrack(0), 1);
+            return earth;
+        }
+
+        private static void AssertVector(float expectedX, float expectedY, Vector actual)
+        {
+            Assert.Equal(expectedX, actual.X);
+            Assert.Equal(expectedY, actual.Y);
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/GameScene.Draw.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Draw.cs
@@ -77,7 +77,7 @@ namespace CutTheRopeDX.GameMain
             Renderer.Enable(Renderer.GL_BLEND);
             Renderer.SetBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
             pollenDrawer.Draw();
-            gravityState.DrawButton();
+            gravityState.DrawButtons();
             miceManager?.DrawHoles();
             Renderer.SetColor(Color.White);
             Renderer.Enable(Renderer.GL_TEXTURE_2D);

--- a/CutTheRopeDX/GameMain/GameScene.Draw.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Draw.cs
@@ -71,19 +71,13 @@ namespace CutTheRopeDX.GameMain
             }
             Renderer.Enable(Renderer.GL_BLEND);
             Renderer.SetBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
-            if (earthAnims != null)
-            {
-                foreach (object obj in earthAnims)
-                {
-                    ((Image)obj).Draw();
-                }
-            }
+            gravityState.DrawEarthAnimations();
             Renderer.Translate(-Canvas.xOffsetScaled, 0f, 0f);
             Renderer.PopMatrix();
             Renderer.Enable(Renderer.GL_BLEND);
             Renderer.SetBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
             pollenDrawer.Draw();
-            gravityButton?.Draw();
+            gravityState.DrawButton();
             miceManager?.DrawHoles();
             Renderer.SetColor(Color.White);
             Renderer.Enable(Renderer.GL_TEXTURE_2D);

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -761,7 +761,7 @@ namespace CutTheRopeDX.GameMain
             grid.DoRestoreCutTransparency();
             ChainFlashLight sparks = (ChainFlashLight)new ChainFlashLight().InitWithTotalParticlesandImageGrid(10, grid);
             sparks.angle = swingAngleDegrees;
-            if (gravityButton != null && !gravityNormal)
+            if (gravityState.IsInverted)
             {
                 sparks.gravity.Y = -sparks.gravity.Y;
                 sparks.angle = -swingAngleDegrees;
@@ -785,7 +785,7 @@ namespace CutTheRopeDX.GameMain
             grid.DoRestoreCutTransparency();
             ChainCutDebris debris = (ChainCutDebris)new ChainCutDebris().InitWithTotalParticlesandImageGrid(2, grid);
             debris.angle = swingAngleDegrees;
-            if (gravityButton != null && !gravityNormal)
+            if (gravityState.IsInverted)
             {
                 debris.gravity.Y = -debris.gravity.Y;
                 debris.angle = -swingAngleDegrees;
@@ -809,7 +809,7 @@ namespace CutTheRopeDX.GameMain
             Image image2 = Image.Image_createWithResID(candyResource);
             image2.DoRestoreCutTransparency();
             CandyBreak candyBreak = (CandyBreak)new CandyBreak().InitWithTotalParticlesandImageGrid(5, image2);
-            if (gravityButton != null && !gravityNormal)
+            if (gravityState.IsInverted)
             {
                 candyBreak.gravity.Y = -ActivePhysicsConstants.CandyBreakGravityY;
                 candyBreak.angle = 90f;
@@ -1087,34 +1087,10 @@ namespace CutTheRopeDX.GameMain
         /// <param name="_">Game scene button identifier.</param>
         public void OnButtonPressed(GameSceneButtonId _)
         {
-            if (MaterialPoint.globalGravity.Y == globalGravityY)
-            {
-                MaterialPoint.globalGravity.Y = -globalGravityY;
-                gravityNormal = false;
-                CTRSoundMgr.PlaySound(Resources.Snd.GravityOn);
-            }
-            else
-            {
-                MaterialPoint.globalGravity.Y = globalGravityY;
-                gravityNormal = true;
-                CTRSoundMgr.PlaySound(Resources.Snd.GravityOff);
-            }
-            if (earthAnims == null)
-            {
-                return;
-            }
-            foreach (object obj in earthAnims)
-            {
-                Image earthAnim = (Image)obj;
-                if (gravityNormal)
-                {
-                    earthAnim.PlayTimeline(0);
-                }
-                else
-                {
-                    earthAnim.PlayTimeline(1);
-                }
-            }
+            gravityState.Toggle();
+            CTRSoundMgr.PlaySound(gravityState.IsInverted
+                ? Resources.Snd.GravityOn
+                : Resources.Snd.GravityOff);
         }
 
         /// <inheritdoc />

--- a/CutTheRopeDX/GameMain/GameScene.Init.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Init.cs
@@ -193,7 +193,7 @@ namespace CutTheRopeDX.GameMain
             image.scaleY = 1f;
             image.x += xs;
             image.y += ys;
-            earthAnims.Add(image);
+            gravityState.AddEarthAnimation(image);
         }
     }
 }

--- a/CutTheRopeDX/GameMain/GameScene.Initialize.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Initialize.cs
@@ -19,8 +19,7 @@ namespace CutTheRopeDX.GameMain
             staticAniPool.RemoveAllChilds();
             decalsLayer?.RemoveAllChilds();
             Lantern.RemoveAllLanterns();
-            gravityButton = null;
-            gravityTouchDown = -1;
+            gravityState.BeginLoad();
             if (waterLayer != null)
             {
                 waterLayer.PrepareToRelease();
@@ -74,7 +73,6 @@ namespace CutTheRopeDX.GameMain
 
             mice = [];
             miceManager = null;
-            earthAnims = null;
             pollenDrawer = new PollenDrawer();
             pendingSecondGhostBubble = null;
             pendingSecondGhostBubbleOwner = null;

--- a/CutTheRopeDX/GameMain/GameScene.Input.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Input.cs
@@ -95,9 +95,9 @@ namespace CutTheRopeDX.GameMain
                 }
                 return true;
             }
-            if (gravityButton != null && ((Button)gravityButton.GetChild(gravityButton.On() ? 1 : 0)).IsInTouchZoneXYforTouchDown(tx + camera.pos.X, ty + camera.pos.Y, true))
+            if (gravityState.IsInToggleTouchZone(tx + camera.pos.X, ty + camera.pos.Y))
             {
-                gravityTouchDown = ti;
+                gravityState.CaptureToggleTouch(ti);
             }
             float worldX = tx + camera.pos.X;
             float worldY = ty + camera.pos.Y;
@@ -489,14 +489,12 @@ namespace CutTheRopeDX.GameMain
                     return true;
                 }
             }
-            if (gravityButton != null && gravityTouchDown == ti)
+            if (gravityState.ReleaseToggleTouch(ti))
             {
-                if (((Button)gravityButton.GetChild(gravityButton.On() ? 1 : 0)).IsInTouchZoneXYforTouchDown(tx + camera.pos.X, ty + camera.pos.Y, true))
+                if (gravityState.IsInToggleTouchZone(tx + camera.pos.X, ty + camera.pos.Y))
                 {
-                    gravityButton.Toggle();
                     OnButtonPressed(0);
                 }
-                gravityTouchDown = -1;
             }
 
             foreach (BambooTube bambooTube in bambooTubes)

--- a/CutTheRopeDX/GameMain/GameScene.LoadMetadata.cs
+++ b/CutTheRopeDX/GameMain/GameScene.LoadMetadata.cs
@@ -87,7 +87,6 @@ namespace CutTheRopeDX.GameMain
 
                             if (PackConfig.GetEarthBg(rc.GetPack()))
                             {
-                                earthAnims = [];
                                 if (mapWidth > SCREEN_WIDTH)
                                 {
                                     CreateEarthImageWithOffsetXY(back.width, 0f);
@@ -150,8 +149,9 @@ namespace CutTheRopeDX.GameMain
                                 }
                             }
                             ropePhysicsSpeed *= ActivePhysicsConstants.RopePhysicsSpeedMultiplier;
-                            globalGravityX = (item2.Attribute("globalGravityX") != null) ? ParseFloatOrZero(item2.Attribute("globalGravityX")?.Value) : 0f;
-                            globalGravityY = (item2.Attribute("globalGravityY") != null) ? ParseFloatOrZero(item2.Attribute("globalGravityY")?.Value) : ActivePhysicsConstants.GravityEarthY;
+                            float globalGravityX = (item2.Attribute("globalGravityX") != null) ? ParseFloatOrZero(item2.Attribute("globalGravityX")?.Value) : 0f;
+                            float globalGravityY = (item2.Attribute("globalGravityY") != null) ? ParseFloatOrZero(item2.Attribute("globalGravityY")?.Value) : ActivePhysicsConstants.GravityEarthY;
+                            gravityState.ConfigureBase(new Vector(globalGravityX, globalGravityY));
                             _ = bool.TryParse(item2.Attribute("candiesConnected")?.Value, out candiesConnected);
                             candiesConnectedLength = ParseFloatOrZero(item2.Attribute("candiesConnectedLength")?.Value) * scale;
                             candiesConnectedBreakable = GetBoolAttribute(item2, "candiesConnectedBreakable", defaultValue: true);

--- a/CutTheRopeDX/GameMain/GameScene.Show.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Show.cs
@@ -67,9 +67,7 @@ namespace CutTheRopeDX.GameMain
             }
             // spiderTookCandy = false;
             time = 0f;
-            gravityNormal = true;
-            MaterialPoint.globalGravity = Vect(globalGravityX, globalGravityY);
-            MaterialPoint.globalDisableGravity = VectEqual(MaterialPoint.globalGravity, vectZero);
+            gravityState.Activate();
             ropesCutAtOnce = 0;
             ropeAtOnceTimer = 0f;
             dd.CallObjectSelectorParamafterDelay(new DelayedDispatcher.DispatchFunc(Selector_doCandyBlink), null, 1);

--- a/CutTheRopeDX/GameMain/GameScene.Systems.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Systems.cs
@@ -87,7 +87,7 @@ namespace CutTheRopeDX.GameMain
             float verticalOffset = ActivePhysicsConstants.SteamTubeVerticalOffsetScale * tubeScale;
             float collisionRadius = ActivePhysicsConstants.SteamTubeCollisionRadiusScale * tubeScale;
             bool useMobileFormula = ActivePhysicsConstants.UseMobilePhysicsModel;
-            bool gravityInverted = gravityButton != null && !gravityNormal;
+            bool gravityInverted = gravityState.IsInverted;
 
             float rectLeft = tube.x - (tubeWidth / 2f);
             float rectTop = tube.y - currentHeight - verticalOffset;
@@ -454,7 +454,7 @@ namespace CutTheRopeDX.GameMain
             Image image = Image.Image_createWithResIDQuad(Resources.Img.ObjSpider, 11);
             image.DoRestoreCutTransparency();
             Timeline timeline = new Timeline().InitWithMaxKeyFramesOnTrack(3);
-            if (gravityButton != null && !gravityNormal)
+            if (gravityState.IsInverted)
             {
                 timeline.AddKeyFrame(KeyFrame.MakePos((int)g.Spider.Animation.x, (int)g.Spider.Animation.y, KeyFrame.TransitionType.FRAME_TRANSITION_EASE_OUT, 0));
                 timeline.AddKeyFrame(KeyFrame.MakePos((int)g.Spider.Animation.x, (int)(g.Spider.Animation.y + 50), KeyFrame.TransitionType.FRAME_TRANSITION_EASE_OUT, 0.3f));
@@ -510,7 +510,7 @@ namespace CutTheRopeDX.GameMain
             capturedCandy.y = -5f;
             _ = image.AddChild(capturedCandy);
             Timeline timeline = new Timeline().InitWithMaxKeyFramesOnTrack(3);
-            if (gravityButton != null && !gravityNormal)
+            if (gravityState.IsInverted)
             {
                 timeline.AddKeyFrame(KeyFrame.MakePos((int)sg.Spider.Animation.x, (int)(sg.Spider.Animation.y - 10), KeyFrame.TransitionType.FRAME_TRANSITION_EASE_OUT, 0));
                 timeline.AddKeyFrame(KeyFrame.MakePos((int)sg.Spider.Animation.x, (int)(sg.Spider.Animation.y + 70), KeyFrame.TransitionType.FRAME_TRANSITION_EASE_OUT, 0.3f));

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -30,13 +30,7 @@ namespace CutTheRopeDX.GameMain
             pollenDrawer.Update(delta);
             CTRRootController cTRRootController = (CTRRootController)Application.SharedRootController();
             UpdatePointerGestureVisuals(delta);
-            if (earthAnims != null)
-            {
-                foreach (object obj in earthAnims)
-                {
-                    ((Image)obj).Update(delta);
-                }
-            }
+            gravityState.UpdateEarthAnimations(delta);
             decalsLayer?.Update(delta);
             if (waterLayer != null)
             {
@@ -1327,7 +1321,7 @@ namespace CutTheRopeDX.GameMain
                 {
                     continue;
                 }
-                float lift = (gravityButton != null && !gravityNormal) ? -bubbleLift : bubbleLift;
+                float lift = gravityState.IsInverted ? -bubbleLift : bubbleLift;
                 body.Point.ApplyImpulseDelta(
                     Vect((0f - body.Point.v.X) / bubbleDamping, ((0f - body.Point.v.Y) / bubbleDamping) + lift),
                     delta);
@@ -1524,7 +1518,7 @@ namespace CutTheRopeDX.GameMain
                 ResetBungeeHighlight();
                 bool flag12 = false;
                 Vector p = VectAdd(slastTouch, camera.pos);
-                if (gravityButton != null && ((Button)gravityButton.GetChild(gravityButton.On() ? 1 : 0)).IsInTouchZoneXYforTouchDown(p.X, p.Y, true))
+                if (gravityState.IsInToggleTouchZone(p.X, p.Y))
                 {
                     flag12 = true;
                 }

--- a/CutTheRopeDX/GameMain/GameScene.cs
+++ b/CutTheRopeDX/GameMain/GameScene.cs
@@ -218,7 +218,7 @@ namespace CutTheRopeDX.GameMain
         /// <inheritdoc />
         public override void Hide()
         {
-            gravityState.RemoveButtonFrom(this);
+            gravityState.RemoveButtonsFrom(this);
             if (waterLayer != null)
             {
                 waterLayer.PrepareToRelease();

--- a/CutTheRopeDX/GameMain/GameScene.cs
+++ b/CutTheRopeDX/GameMain/GameScene.cs
@@ -218,10 +218,7 @@ namespace CutTheRopeDX.GameMain
         /// <inheritdoc />
         public override void Hide()
         {
-            if (gravityButton != null)
-            {
-                RemoveChild(gravityButton);
-            }
+            gravityState.RemoveButtonFrom(this);
             if (waterLayer != null)
             {
                 waterLayer.PrepareToRelease();
@@ -1087,41 +1084,14 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         public bool nightLevel;
 
-        /// <summary>
-        /// Whether gravity is currently in the normal orientation.
-        /// </summary>
-        public bool gravityNormal;
-
-        /// <summary>
-        /// The UI button that toggles gravity orientation.
-        /// </summary>
-        public ToggleButton gravityButton;
-
-        /// <summary>
-        /// The touch index currently holding the gravity button, or an invalid marker.
-        /// </summary>
-        public int gravityTouchDown;
+        /// <summary>Single owner of authored gravity, orientation, input, physics, and presentation.</summary>
+        public readonly GravityState gravityState = new();
 
         /// <summary>
         /// Whether the loaded map declares a split candy. Level metadata, parsed before the split
         /// lifecycle exists, so the loader cannot ask the primary candy's lifecycle instead.
         /// </summary>
         private bool levelAuthorsSplitCandy;
-
-        /// <summary>
-        /// The X value for the global gravity.
-        /// </summary>
-        public float globalGravityX;
-
-        /// <summary>
-        /// The Y value for the global gravity.
-        /// </summary>
-        public float globalGravityY;
-
-        /// <summary>
-        /// Earth animation images used by gravity-switch levels.
-        /// </summary>
-        public List<Image> earthAnims;
 
         /// <summary>
         /// Optional string to load as a name for the level.

--- a/CutTheRopeDX/GameMain/GravityState.cs
+++ b/CutTheRopeDX/GameMain/GravityState.cs
@@ -13,7 +13,7 @@ namespace CutTheRopeDX.GameMain
     internal sealed class GravityState
     {
         private readonly List<Image> earthAnimations = [];
-        private ToggleButton button;
+        private readonly List<ToggleButton> buttons = [];
         private int toggleTouchIndex = -1;
 
         /// <summary>Authored gravity before orientation is applied.</summary>
@@ -31,7 +31,7 @@ namespace CutTheRopeDX.GameMain
             BaseVector = default;
             IsInverted = false;
             toggleTouchIndex = -1;
-            button = null;
+            buttons.Clear();
             earthAnimations.Clear();
         }
 
@@ -44,7 +44,10 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Attaches the toggle whose face is controlled by this state.</summary>
         public void AttachButton(ToggleButton button)
         {
-            this.button = button;
+            if (button != null && !buttons.Contains(button))
+            {
+                buttons.Add(button);
+            }
         }
 
         /// <summary>Adds one earth image whose timeline is controlled by this state.</summary>
@@ -95,20 +98,30 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Checks the active toggle face against a world-space pointer position.</summary>
         public bool IsInToggleTouchZone(float x, float y)
         {
-            return button != null
-                && ((Button)button.GetChild(button.On() ? 1 : 0)).IsInTouchZoneXYforTouchDown(x, y, true);
+            foreach (ToggleButton button in buttons)
+            {
+                if (((Button)button.GetChild(button.On() ? 1 : 0)).IsInTouchZoneXYforTouchDown(x, y, true))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
-        /// <summary>Draws the gravity toggle when the loaded level provides one.</summary>
-        public void DrawButton()
+        /// <summary>Draws every gravity toggle provided by the loaded level.</summary>
+        public void DrawButtons()
         {
-            button?.Draw();
+            foreach (ToggleButton button in buttons)
+            {
+                button.Draw();
+            }
         }
 
-        /// <summary>Removes the gravity toggle from its scene parent when present.</summary>
-        public void RemoveButtonFrom(BaseElement parent)
+        /// <summary>Removes every gravity toggle from its scene parent.</summary>
+        public void RemoveButtonsFrom(BaseElement parent)
         {
-            if (button != null)
+            foreach (ToggleButton button in buttons)
             {
                 parent.RemoveChild(button);
             }
@@ -138,9 +151,12 @@ namespace CutTheRopeDX.GameMain
             MaterialPoint.globalGravity = current;
             MaterialPoint.globalDisableGravity = current.X == 0f && current.Y == 0f;
 
-            if (button != null && button.On() != IsInverted)
+            foreach (ToggleButton button in buttons)
             {
-                button.Toggle();
+                if (button.On() != IsInverted)
+                {
+                    button.Toggle();
+                }
             }
 
             foreach (Image earthAnimation in earthAnimations)

--- a/CutTheRopeDX/GameMain/GravityState.cs
+++ b/CutTheRopeDX/GameMain/GravityState.cs
@@ -1,0 +1,163 @@
+using System.Collections.Generic;
+
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.Framework.Physics;
+using CutTheRopeDX.Framework.Visual;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// Single owner of authored gravity, live orientation, toggle-touch ownership, and gravity
+    /// presentation. Every orientation transition synchronizes physics and visuals atomically.
+    /// </summary>
+    internal sealed class GravityState
+    {
+        private readonly List<Image> earthAnimations = [];
+        private ToggleButton button;
+        private int toggleTouchIndex = -1;
+
+        /// <summary>Authored gravity before orientation is applied.</summary>
+        public Vector BaseVector { get; private set; }
+
+        /// <summary>Whether gravity currently points opposite its authored vertical direction.</summary>
+        public bool IsInverted { get; private set; }
+
+        /// <summary>Gravity vector derived from <see cref="BaseVector"/> and <see cref="IsInverted"/>.</summary>
+        public Vector CurrentVector => new(BaseVector.X, IsInverted ? -BaseVector.Y : BaseVector.Y);
+
+        /// <summary>Clears level-owned configuration and presentation before loading another map.</summary>
+        public void BeginLoad()
+        {
+            BaseVector = default;
+            IsInverted = false;
+            toggleTouchIndex = -1;
+            button = null;
+            earthAnimations.Clear();
+        }
+
+        /// <summary>Stores the authored gravity vector without changing live physics yet.</summary>
+        public void ConfigureBase(Vector baseVector)
+        {
+            BaseVector = baseVector;
+        }
+
+        /// <summary>Attaches the toggle whose face is controlled by this state.</summary>
+        public void AttachButton(ToggleButton button)
+        {
+            this.button = button;
+        }
+
+        /// <summary>Adds one earth image whose timeline is controlled by this state.</summary>
+        public void AddEarthAnimation(Image earthAnimation)
+        {
+            if (earthAnimation != null)
+            {
+                earthAnimations.Add(earthAnimation);
+            }
+        }
+
+        /// <summary>Starts live play in the authored orientation and synchronizes every representation.</summary>
+        public void Activate()
+        {
+            IsInverted = false;
+            toggleTouchIndex = -1;
+            Synchronize(animateEarth: false);
+        }
+
+        /// <summary>Atomically flips orientation, live physics, and visual presentation.</summary>
+        public void Toggle()
+        {
+            IsInverted = !IsInverted;
+            Synchronize(animateEarth: true);
+        }
+
+        /// <summary>Records the pointer that pressed the gravity toggle.</summary>
+        public void CaptureToggleTouch(int pointerIndex)
+        {
+            toggleTouchIndex = pointerIndex;
+        }
+
+        /// <summary>
+        /// Releases toggle ownership when <paramref name="pointerIndex"/> owns it.
+        /// </summary>
+        /// <returns><see langword="true"/> only for the owning pointer's first release.</returns>
+        public bool ReleaseToggleTouch(int pointerIndex)
+        {
+            if (toggleTouchIndex != pointerIndex)
+            {
+                return false;
+            }
+
+            toggleTouchIndex = -1;
+            return true;
+        }
+
+        /// <summary>Checks the active toggle face against a world-space pointer position.</summary>
+        public bool IsInToggleTouchZone(float x, float y)
+        {
+            return button != null
+                && ((Button)button.GetChild(button.On() ? 1 : 0)).IsInTouchZoneXYforTouchDown(x, y, true);
+        }
+
+        /// <summary>Draws the gravity toggle when the loaded level provides one.</summary>
+        public void DrawButton()
+        {
+            button?.Draw();
+        }
+
+        /// <summary>Removes the gravity toggle from its scene parent when present.</summary>
+        public void RemoveButtonFrom(BaseElement parent)
+        {
+            if (button != null)
+            {
+                parent.RemoveChild(button);
+            }
+        }
+
+        /// <summary>Advances all gravity-owned earth animations.</summary>
+        public void UpdateEarthAnimations(float delta)
+        {
+            foreach (Image earthAnimation in earthAnimations)
+            {
+                earthAnimation.Update(delta);
+            }
+        }
+
+        /// <summary>Draws all gravity-owned earth animations.</summary>
+        public void DrawEarthAnimations()
+        {
+            foreach (Image earthAnimation in earthAnimations)
+            {
+                earthAnimation.Draw();
+            }
+        }
+
+        private void Synchronize(bool animateEarth)
+        {
+            Vector current = CurrentVector;
+            MaterialPoint.globalGravity = current;
+            MaterialPoint.globalDisableGravity = current.X == 0f && current.Y == 0f;
+
+            if (button != null && button.On() != IsInverted)
+            {
+                button.Toggle();
+            }
+
+            foreach (Image earthAnimation in earthAnimations)
+            {
+                if (animateEarth)
+                {
+                    earthAnimation.PlayTimeline(IsInverted ? 1 : 0);
+                }
+                else
+                {
+                    if (earthAnimation.GetCurrentTimeline() != null)
+                    {
+                        earthAnimation.StopCurrentTimeline();
+                    }
+                    earthAnimation.rotation = IsInverted ? 180f : 0f;
+                }
+            }
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadGravityButton.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadGravityButton.cs
@@ -1,5 +1,7 @@
 using System.Xml.Linq;
 
+using CutTheRopeDX.Framework.Visual;
+
 using static CutTheRopeDX.Helpers.ParsingHelpers;
 
 namespace CutTheRopeDX.GameMain
@@ -18,11 +20,12 @@ namespace CutTheRopeDX.GameMain
         /// <param name="mapOffsetY">The additional map Y offset applied during loading.</param>
         private void LoadGravityButton(XElement xmlNode, float scale, float offsetX, float offsetY, int mapOffsetX, int mapOffsetY)
         {
-            if (globalGravityY == 0f)
+            if (gravityState.BaseVector.Y == 0f)
             {
                 return;
             }
-            gravityButton = CreateGravityButtonWithDelegate(this);
+            ToggleButton gravityButton = CreateGravityButtonWithDelegate(this);
+            gravityState.AttachButton(gravityButton);
             gravityButton.visible = false;
             gravityButton.touchable = false;
             _ = AddChild(gravityButton);


### PR DESCRIPTION
## Description

- Add `GravityState` as the authoritative owner of:
  - Authored base gravity
  - Current gravity vector and orientation
  - Gravity-toggle touch ownership
  - Gravity-button presentation
  - Earth animation presentation
  - `MaterialPoint.globalGravity`
- Remove the parallel `gravityNormal`, `globalGravityX/Y`, `gravityTouchDown`, `gravityButton`, and `earthAnims` state from `GameScene`
- Route all gravity-dependent systems through `GravityState.IsInverted`
- Synchronize physics, every gravity button, and earth presentation atomically
- Support multiple gravity buttons in one level:
  - Pressing any button updates every registered button
  - Hit-testing, drawing, and teardown include all registered buttons
  - Duplicate button registration is prevented
- Initialize earth visuals directly at the normal orientation without playing a rotation animation
- Reserve earth rotation timelines for actual gravity toggles
- Keep gravity presentation objects private to prevent mutations outside `GravityState`