### PR TITLE
Refactor: Centralize Om Nom behavior state

### DIFF
--- a/CutTheRopeDX.Tests/GameWinChewingTests.cs
+++ b/CutTheRopeDX.Tests/GameWinChewingTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.IO;
+
 using CutTheRopeDX.GameMain;
 
 using Xunit;
@@ -6,16 +9,6 @@ namespace CutTheRopeDX.Tests
 {
     public class GameWinChewingTests
     {
-        [Theory]
-        [InlineData(0, true)]
-        [InlineData(1, true)]
-        [InlineData(2, false)]
-        [InlineData(3, false)]
-        public void ShouldPlayPrimaryChewingOnGameWonOnlyForLegacySingleTargetWin(int targetCount, bool expected)
-        {
-            Assert.Equal(expected, GameWinChewing.ShouldPlayPrimaryChewingOnGameWon(targetCount));
-        }
-
         [Theory]
         [InlineData(2, false, true, true)]
         [InlineData(3, false, true, true)]

--- a/CutTheRopeDX.Tests/GameWinChewingTests.cs
+++ b/CutTheRopeDX.Tests/GameWinChewingTests.cs
@@ -1,6 +1,3 @@
-using System;
-using System.IO;
-
 using CutTheRopeDX.GameMain;
 
 using Xunit;

--- a/CutTheRopeDX.Tests/Interactions/Act.cs
+++ b/CutTheRopeDX.Tests/Interactions/Act.cs
@@ -156,9 +156,9 @@ namespace CutTheRopeDX.Tests.Interactions
                 scene,
                 candy,
                 position => MoveMouthTo(target.targetObject, position),
-                // Falling asleep is what only eating does; candy-gone alone would also be true of a
+                // Becoming fed is what only eating does; candy-gone alone would also be true of a
                 // candy that drifted off screen while Om Nom was chasing it.
-                () => target.asleep,
+                () => target.Feeding.IsFed,
                 "Om Nom never ate the candy");
         }
 

--- a/CutTheRopeDX.Tests/NightSleepStateTests.cs
+++ b/CutTheRopeDX.Tests/NightSleepStateTests.cs
@@ -1,0 +1,114 @@
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class NightSleepStateTests
+    {
+        [Fact]
+        public void DarknessStartsFallingAsleepWithAllTimingOwnedTogether()
+        {
+            NightSleepState sleep = new();
+
+            Assert.Equal(NightSleepTransition.FellAsleep, sleep.ObserveAwake(
+                isAwake: false,
+                pulseDelay: 0.75f,
+                pulseBaseY: 42f));
+
+            Assert.Equal(NightSleepPhase.FallingAsleep, sleep.Phase);
+            Assert.False(sleep.IsAwake);
+            Assert.Equal(0.75f, sleep.PulseDelay);
+            Assert.Equal(0f, sleep.PulseTime);
+            Assert.Equal(42f, sleep.PulseBaseY);
+            Assert.Equal(0.9f, sleep.SoundTime);
+        }
+
+        [Fact]
+        public void FallingAsleepAdvancesIntoPulsing()
+        {
+            NightSleepState sleep = new();
+            _ = sleep.ObserveAwake(false, pulseDelay: 0.5f, pulseBaseY: 42f);
+
+            sleep.AdvancePulse(0.25f);
+            Assert.Equal(NightSleepPhase.FallingAsleep, sleep.Phase);
+            sleep.AdvancePulse(0.25f);
+
+            Assert.Equal(NightSleepPhase.Pulsing, sleep.Phase);
+            Assert.Equal(0f, sleep.PulseDelay);
+            Assert.Equal(0.25f, sleep.PulseTime);
+
+            sleep.AdvancePulse(0.1f);
+            Assert.Equal(0.35f, sleep.PulseTime, precision: 3);
+        }
+
+        [Fact]
+        public void WakingAtomicallyClearsSleepPresentationData()
+        {
+            NightSleepState sleep = new();
+            _ = sleep.ObserveAwake(false, pulseDelay: 0f, pulseBaseY: 42f);
+            sleep.AdvancePulse(0.1f);
+            _ = sleep.SetOverlayVisible(true, feedingAsleep: false);
+            _ = sleep.AdvanceSound(4.1f, interval: 4f);
+
+            Assert.Equal(NightSleepTransition.Woke, sleep.ObserveAwake(
+                isAwake: true,
+                pulseDelay: 0f,
+                pulseBaseY: 0f));
+
+            Assert.Equal(NightSleepPhase.Waking, sleep.Phase);
+            Assert.True(sleep.IsAwake);
+            Assert.Equal(0f, sleep.PulseDelay);
+            Assert.Equal(0f, sleep.PulseTime);
+            Assert.Equal(0f, sleep.PulseBaseY);
+            Assert.Equal(0f, sleep.SoundTime);
+            Assert.False(sleep.OverlayVisible);
+
+            Assert.Equal(NightSleepTransition.None, sleep.ObserveAwake(true, 0f, 0f));
+            Assert.Equal(NightSleepPhase.Awake, sleep.Phase);
+        }
+
+        [Fact]
+        public void TerminalPresentationCleanupPreservesDarkSleepPhase()
+        {
+            NightSleepState sleep = new();
+            _ = sleep.ObserveAwake(false, pulseDelay: 0f, pulseBaseY: 42f);
+            sleep.AdvancePulse(0.1f);
+            _ = sleep.SetOverlayVisible(true, feedingAsleep: false);
+            _ = sleep.AdvanceSound(1f, interval: 4f);
+
+            sleep.ClearPresentation();
+
+            Assert.Equal(NightSleepPhase.Pulsing, sleep.Phase);
+            Assert.False(sleep.IsAwake);
+            Assert.Equal(0f, sleep.PulseTime);
+            Assert.Equal(0f, sleep.PulseDelay);
+            Assert.Equal(0f, sleep.PulseBaseY);
+            Assert.Equal(0f, sleep.SoundTime);
+            Assert.False(sleep.OverlayVisible);
+        }
+
+        [Fact]
+        public void OverlayAndSoundUpdatesAreEdgeTriggered()
+        {
+            NightSleepState sleep = new();
+
+            Assert.False(sleep.SetOverlayVisible(true, feedingAsleep: false));
+            _ = sleep.ObserveAwake(false, pulseDelay: 0f, pulseBaseY: 0f);
+            Assert.True(sleep.SetOverlayVisible(true, feedingAsleep: false));
+            Assert.False(sleep.SetOverlayVisible(true, feedingAsleep: false));
+            Assert.False(sleep.AdvanceSound(3f, interval: 4f));
+            Assert.True(sleep.AdvanceSound(1.1f, interval: 4f));
+            Assert.Equal(0f, sleep.SoundTime);
+        }
+
+        [Fact]
+        public void FeedingSleepCanOwnTheOverlayOutsideANightSleepPhase()
+        {
+            NightSleepState sleep = new();
+
+            Assert.True(sleep.SetOverlayVisible(true, feedingAsleep: true));
+            Assert.True(sleep.OverlayVisible);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/TargetFeedingStateTests.cs
+++ b/CutTheRopeDX.Tests/TargetFeedingStateTests.cs
@@ -1,0 +1,87 @@
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class TargetFeedingStateTests
+    {
+        [Fact]
+        public void NewTargetStartsIdleAndUnfed()
+        {
+            TargetFeedingState feeding = new();
+
+            Assert.Equal(TargetFeedingPhase.Idle, feeding.Phase);
+            Assert.False(feeding.IsFed);
+            Assert.False(feeding.IsAsleep);
+        }
+
+        [Fact]
+        public void MouthTimerBelongsToTheMouthOpenPhase()
+        {
+            TargetFeedingState feeding = new();
+
+            Assert.True(feeding.TryOpenMouth(closeDelay: 1f));
+            Assert.Equal(TargetFeedingPhase.MouthOpen, feeding.Phase);
+            Assert.Equal(1f, feeding.MouthCloseTime);
+
+            Assert.False(feeding.AdvanceMouthClose(0.5f, candyNearby: false, refreshDelay: 1f));
+            Assert.Equal(0.5f, feeding.MouthCloseTime);
+            Assert.True(feeding.AdvanceMouthClose(0.5f, candyNearby: false, refreshDelay: 1f));
+            Assert.Equal(TargetFeedingPhase.Idle, feeding.Phase);
+            Assert.Equal(0f, feeding.MouthCloseTime);
+        }
+
+        [Fact]
+        public void NearbyCandyRefreshesMouthWithoutCreatingAnotherState()
+        {
+            TargetFeedingState feeding = new();
+            _ = feeding.TryOpenMouth(closeDelay: 1f);
+
+            Assert.False(feeding.AdvanceMouthClose(1f, candyNearby: true, refreshDelay: 1f));
+
+            Assert.Equal(TargetFeedingPhase.MouthOpen, feeding.Phase);
+            Assert.Equal(1f, feeding.MouthCloseTime);
+        }
+
+        [Fact]
+        public void EatingAtomicallyClosesTheMouthAndBeginsChewing()
+        {
+            TargetFeedingState feeding = new();
+            _ = feeding.TryOpenMouth(closeDelay: 1f);
+
+            Assert.True(feeding.TryBeginChewing());
+
+            Assert.Equal(TargetFeedingPhase.Chewing, feeding.Phase);
+            Assert.True(feeding.IsFed);
+            Assert.False(feeding.IsAsleep);
+            Assert.Equal(0f, feeding.MouthCloseTime);
+            Assert.False(feeding.TryOpenMouth(closeDelay: 1f));
+        }
+
+        [Fact]
+        public void IdleTargetCannotSkipTheOpenMouthPhaseAndBeginChewing()
+        {
+            TargetFeedingState feeding = new();
+
+            Assert.False(feeding.TryBeginChewing());
+            Assert.Equal(TargetFeedingPhase.Idle, feeding.Phase);
+            Assert.False(feeding.IsFed);
+        }
+
+        [Fact]
+        public void OnlyChewingCanCompleteDelayedSleep()
+        {
+            TargetFeedingState feeding = new();
+            Assert.False(feeding.TryFallAsleep());
+
+            _ = feeding.TryOpenMouth(closeDelay: 1f);
+            Assert.True(feeding.TryBeginChewing());
+            Assert.True(feeding.TryFallAsleep());
+            Assert.False(feeding.TryFallAsleep());
+
+            Assert.Equal(TargetFeedingPhase.Asleep, feeding.Phase);
+            Assert.True(feeding.IsAsleep);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/TargetIdleStateTests.cs
+++ b/CutTheRopeDX.Tests/TargetIdleStateTests.cs
@@ -1,0 +1,68 @@
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class TargetIdleStateTests
+    {
+        [Fact]
+        public void CadenceCannotRunPastDueWhileAwaitingItsReaction()
+        {
+            TargetIdleState idle = new(blinkCountdown: 1, idleCountdown: 1);
+
+            TargetIdleStep first = idle.AdvanceCadence();
+            TargetIdleStep second = idle.AdvanceCadence();
+
+            Assert.True(first.BlinkDue);
+            Assert.True(first.IdleDue);
+            Assert.True(second.BlinkDue);
+            Assert.True(second.IdleDue);
+            Assert.Equal(0, idle.BlinkCountdown);
+            Assert.Equal(0, idle.IdleCountdown);
+        }
+
+        [Fact]
+        public void ConsumingDueCadenceAtomicallySchedulesTheNextOne()
+        {
+            TargetIdleState idle = new(blinkCountdown: 1, idleCountdown: 1);
+            _ = idle.AdvanceCadence();
+
+            Assert.True(idle.ConsumeBlink(nextCountdown: 3));
+            Assert.True(idle.ConsumeIdle(nextCountdown: 12));
+            Assert.False(idle.ConsumeBlink(nextCountdown: 3));
+            Assert.False(idle.ConsumeIdle(nextCountdown: 12));
+
+            Assert.Equal(3, idle.BlinkCountdown);
+            Assert.Equal(12, idle.IdleCountdown);
+        }
+
+        [Fact]
+        public void ChatCanRescheduleBothTargetsThroughTheSameOwner()
+        {
+            TargetIdleState first = new(blinkCountdown: 3, idleCountdown: 1);
+            TargetIdleState second = new(blinkCountdown: 3, idleCountdown: 2);
+
+            first.ScheduleIdle(10);
+            second.ScheduleIdle(15);
+
+            Assert.Equal(10, first.IdleCountdown);
+            Assert.Equal(15, second.IdleCountdown);
+        }
+
+        [Fact]
+        public void PendingChatIsScheduledAndConsumedAtomically()
+        {
+            TargetIdleState idle = new(blinkCountdown: 3, idleCountdown: 10);
+
+            Assert.True(idle.TryScheduleChat(TargetAnimationState.GreetLeft));
+            Assert.True(idle.HasPendingChat);
+            Assert.False(idle.TryScheduleChat(TargetAnimationState.GreetRight));
+
+            Assert.True(idle.TryConsumeChat(out TargetAnimationState state));
+            Assert.Equal(TargetAnimationState.GreetLeft, state);
+            Assert.False(idle.HasPendingChat);
+            Assert.False(idle.TryConsumeChat(out _));
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -456,14 +456,12 @@ namespace CutTheRopeDX.GameMain
             for (int ti = 0; ti < targets.Count; ti++)
             {
                 TargetContext t = targets[ti];
-                if (t.postEatSleepActive)
+                if (t.Feeding.IsAsleep)
                 {
                     continue;
                 }
-                SetNightSleepVisibility(t, false);
-                t.sleepPulseActive = false;
-                t.sleepSoundTimer = 0f;
-                t.postEatSleepScheduled = false;
+                t.NightSleep.ClearPresentation();
+                t.controller?.SetSleepOverlayVisible(false);
                 if (t.targetObject != null)
                 {
                     t.targetObject.scaleX = t.baseScaleX;
@@ -528,14 +526,12 @@ namespace CutTheRopeDX.GameMain
             for (int ti = 0; ti < targets.Count; ti++)
             {
                 TargetContext t = targets[ti];
-                if (t.postEatSleepActive)
+                if (t.Feeding.IsAsleep)
                 {
                     continue;
                 }
-                SetNightSleepVisibility(t, false);
-                t.sleepPulseActive = false;
-                t.sleepSoundTimer = 0f;
-                t.postEatSleepScheduled = false;
+                t.NightSleep.ClearPresentation();
+                t.controller?.SetSleepOverlayVisible(false);
                 if (t.targetObject != null)
                 {
                     t.targetObject.scaleX = t.baseScaleX;
@@ -551,7 +547,7 @@ namespace CutTheRopeDX.GameMain
             for (int ti = 0; ti < targets.Count; ti++)
             {
                 TargetContext t = targets[ti];
-                if (t.postEatSleepActive)
+                if (t.Feeding.IsAsleep)
                 {
                     continue;
                 }

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -471,11 +471,6 @@ namespace CutTheRopeDX.GameMain
                 }
             }
 
-            if (GameWinChewing.ShouldPlayPrimaryChewingOnGameWon(targets.Count))
-            {
-                targetAnimationController?.PlayChewing();
-                CTRSoundMgr.PlayOmNomSound(Resources.Snd.MonsterChewing, targetAnimationController?.SkinDefinition);
-            }
             PopCandyBubble(candies[0].WholeBody);
             // The primary is already Removed(Eaten) here: the single caller runs behind AllEaten,
             // which cannot pass while an eatable candy still has a body. So the win timeline below

--- a/CutTheRopeDX/GameMain/GameScene.NightLevel.cs
+++ b/CutTheRopeDX/GameMain/GameScene.NightLevel.cs
@@ -135,7 +135,7 @@ namespace CutTheRopeDX.GameMain
                     continue;
                 }
 
-                bool canUpdateSleepState = gameplayFlow.CanReactToCandy(t.asleep);
+                bool canUpdateSleepState = gameplayFlow.CanReactToCandy(t.Feeding.IsFed);
 
                 bool isAwake = false;
                 Vector targetPosition = Vect(t.targetObject.x, t.targetObject.y);
@@ -153,7 +153,7 @@ namespace CutTheRopeDX.GameMain
                     UpdateNightTargetAwake(t, isAwake);
                 }
 
-                bool isSleeping = t.isNightTargetAwake == false && hasCandyPresent && canUpdateSleepState;
+                bool isSleeping = !t.NightSleep.IsAwake && hasCandyPresent && canUpdateSleepState;
                 bool shouldShowSleepOverlay = isSleeping
                     && t.controller?.IsSleepingAnimationPlaying() == true;
                 SetNightSleepVisibility(t, shouldShowSleepOverlay);
@@ -167,21 +167,15 @@ namespace CutTheRopeDX.GameMain
                 // Handle sleeping state animations and sounds
                 if (isSleeping)
                 {
-                    // Wait for sleep animation to finish before starting pulse
-                    if (!t.sleepPulseActive)
-                    {
-                        t.sleepPulseDelay = MathF.Max(0f, t.sleepPulseDelay - delta);
-                        if (t.sleepPulseDelay == 0f)
-                        {
-                            t.sleepPulseActive = true;
-                        }
-                    }
+                    float pulseTime = t.NightSleep.PulseTime;
+                    t.NightSleep.AdvancePulse(delta);
 
                     // Apply breathing pulse effect using sine wave (classic backend only;
                     // the Flash backend has its own sleeping timeline that includes the pulse).
-                    if (t.sleepPulseActive && t.controller?.HandlesOwnSleepPulse != true)
+                    if (t.NightSleep.Phase == NightSleepPhase.Pulsing
+                        && t.controller?.HandlesOwnSleepPulse != true)
                     {
-                        float sinValue = MathF.Sin(t.sleepPulseTime * 2f);
+                        float sinValue = MathF.Sin(pulseTime * 2f);
                         float scaleY = 0.95f + ((sinValue + 1f) / 2f * 0.1f); // Scale between 0.95 and 1.05
 
                         if (t.controller?.IsSleepingAnimationPlaying() == true)
@@ -190,17 +184,10 @@ namespace CutTheRopeDX.GameMain
                             t.targetObject.scaleX = t.baseScaleX;
                             t.targetObject.scaleY = t.baseScaleY * scaleY;
                         }
-                        t.sleepPulseTime += delta;
-                    }
-                    else if (t.sleepPulseActive)
-                    {
-                        t.sleepPulseTime += delta;
                     }
 
-                    t.sleepSoundTimer += delta;
-                    if (t.sleepSoundTimer > NightSleepSoundInterval)
+                    if (t.NightSleep.AdvanceSound(delta, NightSleepSoundInterval))
                     {
-                        t.sleepSoundTimer = 0f;
                         CTRSoundMgr.PlayRandomOmNomSound(
                             t.controller?.SkinDefinition,
                             Resources.Snd.MonsterSleep1,
@@ -242,21 +229,19 @@ namespace CutTheRopeDX.GameMain
         /// </remarks>
         private void UpdateNightTargetAwake(TargetContext t, bool isAwake)
         {
-            if (t.isNightTargetAwake == isAwake)
+            float pulseDelay = t.controller?.GetSleepPulseDelaySeconds() ?? 0f;
+            float pulseBaseY = t.targetObject == null
+                ? 0f
+                : GetSleepPulsePivotOffsetY(t.targetObject.height);
+            NightSleepTransition transition = t.NightSleep.ObserveAwake(isAwake, pulseDelay, pulseBaseY);
+            if (transition == NightSleepTransition.None)
             {
                 return;
             }
 
-            t.isNightTargetAwake = isAwake;
-
             // Waking up: reset sleep state and play wake animation
-            if (isAwake)
+            if (transition == NightSleepTransition.Woke)
             {
-                t.sleepPulseActive = false;
-                t.sleepPulseTime = 0f;
-                t.sleepPulseDelay = 0f;
-                t.sleepSoundTimer = 0f;
-                t.sleepPulseBaseY = 0f;
                 if (t.targetObject != null && t.controller?.HandlesOwnSleepPulse != true)
                 {
                     t.targetObject.scaleX = t.baseScaleX;
@@ -264,7 +249,7 @@ namespace CutTheRopeDX.GameMain
                     t.targetObject.rotationCenterX = 0f;
                     t.targetObject.rotationCenterY = 0f;
                 }
-                SetNightSleepVisibility(t, false);
+                t.controller?.SetSleepOverlayVisible(false);
                 t.controller?.PlayExcited();
                 return;
             }
@@ -275,17 +260,12 @@ namespace CutTheRopeDX.GameMain
                 return;
             }
 
-            // Falling asleep: start sleep animation and prepare pulse effect
-            t.sleepPulseActive = false;
-            t.sleepPulseTime = 0f;
-            t.sleepPulseDelay = t.controller?.GetSleepPulseDelaySeconds() ?? 0f;
-            t.sleepSoundTimer = 0.9f;
-            SetNightSleepVisibility(t, false);
+            // Falling asleep: start sleep animation and prepare pulse effect.
+            t.controller?.SetSleepOverlayVisible(false);
             t.controller?.PlaySleeping();
             if (t.targetObject != null && t.controller?.HandlesOwnSleepPulse != true)
             {
-                t.sleepPulseBaseY = GetSleepPulsePivotOffsetY(t.targetObject.height);
-                t.targetObject.rotationCenterY = t.sleepPulseBaseY;
+                t.targetObject.rotationCenterY = t.NightSleep.PulseBaseY;
             }
         }
 
@@ -296,12 +276,11 @@ namespace CutTheRopeDX.GameMain
         /// <param name="visible">Whether the zzz animations should be visible.</param>
         private static void SetNightSleepVisibility(TargetContext t, bool visible)
         {
-            if (t.nightSleepOverlayVisible == visible)
+            if (!t.NightSleep.SetOverlayVisible(visible, t.Feeding.IsAsleep))
             {
                 return;
             }
 
-            t.nightSleepOverlayVisible = visible;
             t.controller?.SetSleepOverlayVisible(visible);
         }
 

--- a/CutTheRopeDX/GameMain/GameScene.PostEatSleep.cs
+++ b/CutTheRopeDX/GameMain/GameScene.PostEatSleep.cs
@@ -9,7 +9,7 @@ namespace CutTheRopeDX.GameMain
 
         private void SchedulePostEatSleep(TargetContext target)
         {
-            if (target.postEatSleepScheduled
+            if (target.Feeding.Phase != TargetFeedingPhase.Chewing
                 || !GameWinChewing.ShouldSchedulePostEatSleep(
                     targets.Count,
                     nightLevel,
@@ -18,7 +18,6 @@ namespace CutTheRopeDX.GameMain
                 return;
             }
 
-            target.postEatSleepScheduled = true;
             dd.CallObjectSelectorParamafterDelay(
                 new DelayedDispatcher.DispatchFunc(Selector_startPostEatSleep),
                 new PostEatSleepRequest(target),
@@ -34,7 +33,6 @@ namespace CutTheRopeDX.GameMain
 
             TargetContext target = request.Target;
             if (target == null
-                || !target.asleep
                 || gameplayFlow.TransitionActive
                 || !GameWinChewing.ShouldSchedulePostEatSleep(
                     targets.Count,
@@ -44,8 +42,12 @@ namespace CutTheRopeDX.GameMain
                 return;
             }
 
-            target.postEatSleepActive = true;
-            target.sleepSoundTimer = NightSleepSoundInterval;
+            if (!target.Feeding.TryFallAsleep())
+            {
+                return;
+            }
+
+            target.NightSleep.StartPostEatPresentation(NightSleepSoundInterval);
             SetNightSleepVisibility(target, false);
             target.controller?.PlaySleepingWithoutIdleToSleepTrim();
         }
@@ -60,7 +62,7 @@ namespace CutTheRopeDX.GameMain
             for (int ti = 0; ti < targets.Count; ti++)
             {
                 TargetContext target = targets[ti];
-                if (!target.postEatSleepActive || target.targetObject == null)
+                if (!target.Feeding.IsAsleep || target.targetObject == null)
                 {
                     continue;
                 }
@@ -75,10 +77,8 @@ namespace CutTheRopeDX.GameMain
                 target.controller?.UpdateSleepOverlays(delta);
                 target.controller?.SyncSleepOverlayPosition(target.targetObject.x, target.targetObject.y);
 
-                target.sleepSoundTimer += delta;
-                if (target.sleepSoundTimer > NightSleepSoundInterval)
+                if (target.NightSleep.AdvanceSound(delta, NightSleepSoundInterval))
                 {
-                    target.sleepSoundTimer = 0f;
                     CTRSoundMgr.PlayRandomOmNomSound(
                         target.controller?.SkinDefinition,
                         Resources.Snd.MonsterSleep1,

--- a/CutTheRopeDX/GameMain/GameScene.Show.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Show.cs
@@ -209,27 +209,25 @@ namespace CutTheRopeDX.GameMain
             {
                 return;
             }
-            if (nightLevel && owner.isNightTargetAwake == false)
+            if (nightLevel && !owner.NightSleep.IsAwake)
             {
                 return;
             }
             if (i == 1)
             {
-                owner.blinkTimer--;
-                if (owner.blinkTimer == 0)
+                TargetIdleStep idleStep = owner.Idle.AdvanceCadence();
+                if (idleStep.BlinkDue && owner.Idle.ConsumeBlink(3))
                 {
                     owner.controller?.TriggerBlink();
-                    owner.blinkTimer = 3;
                 }
-                owner.idlesTimer--;
-                if (owner.idlesTimer == 0)
+                if (idleStep.IdleDue)
                 {
                     // On two-Om-Nom levels the idle reaction may instead become a mutual chat
                     // greeting (Time Travel). When it does, both timers are reset by the chat.
                     if (!TryStartChatReaction())
                     {
                         owner.controller?.PlayRandomIdleVariant(RND_RANGE);
-                        owner.idlesTimer = RND_RANGE(5, 20);
+                        _ = owner.Idle.ConsumeIdle(RND_RANGE(5, 20));
                     }
                 }
                 return;

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1359,44 +1359,38 @@ namespace CutTheRopeDX.GameMain
                 TargetContext t = targets[ti];
                 // No mouth opening/closing once a win/loss transition is active: a sad Om Nom must
                 // not react to a remaining candy during the loss reaction.
-                if (t.targetObject == null || !gameplayFlow.CanReactToCandy(t.asleep))
+                if (t.targetObject == null || !gameplayFlow.CanReactToCandy(t.Feeding.IsFed))
                 {
                     continue;
                 }
                 Vector targetPos = Vect(t.targetObject.x, t.targetObject.y);
-                bool canInteractWithTarget = !nightLevel || t.isNightTargetAwake == true;
+                bool canInteractWithTarget = !nightLevel || t.NightSleep.IsAwake;
 
-                if (!t.mouthOpen && canInteractWithTarget)
+                if (t.Feeding.Phase == TargetFeedingPhase.Idle && canInteractWithTarget)
                 {
                     if (CandyDecisions.ShouldOpenMouth(targetPos, candyViews, ActivePhysicsConstants.MouthOpenDistance))
                     {
-                        t.mouthOpen = true;
-                        t.controller?.PlayMouthOpening();
-                        CTRSoundMgr.PlayOmNomSound(Resources.Snd.MonsterOpen, t.controller?.SkinDefinition);
-                        t.mouthCloseTimer = 1f;
+                        if (t.Feeding.TryOpenMouth(closeDelay: 1f))
+                        {
+                            t.controller?.PlayMouthOpening();
+                            CTRSoundMgr.PlayOmNomSound(Resources.Snd.MonsterOpen, t.controller?.SkinDefinition);
+                        }
                     }
                 }
-                else if (t.mouthCloseTimer > 0 && canInteractWithTarget)
+                else if (t.Feeding.Phase == TargetFeedingPhase.MouthOpen && canInteractWithTarget)
                 {
-                    float timer = t.mouthCloseTimer;
-                    _ = Mover.MoveVariableToTarget(ref timer, 0, 1, delta);
-                    t.mouthCloseTimer = timer;
-                    if (t.mouthCloseTimer <= 0)
+                    bool candyNearby = CandyDecisions.ShouldOpenMouth(
+                        targetPos,
+                        candyViews,
+                        ActivePhysicsConstants.MouthOpenDistance);
+                    if (t.Feeding.AdvanceMouthClose(delta, candyNearby, refreshDelay: 1f))
                     {
-                        if (!CandyDecisions.ShouldOpenMouth(targetPos, candyViews, ActivePhysicsConstants.MouthOpenDistance))
+                        t.controller?.PlayMouthClosing();
+                        CTRSoundMgr.PlayOmNomSound(Resources.Snd.MonsterClose, t.controller?.SkinDefinition);
+                        tummyTeasers++;
+                        if (tummyTeasers >= 10)
                         {
-                            t.mouthOpen = false;
-                            t.controller?.PlayMouthClosing();
-                            CTRSoundMgr.PlayOmNomSound(Resources.Snd.MonsterClose, t.controller?.SkinDefinition);
-                            tummyTeasers++;
-                            if (tummyTeasers >= 10)
-                            {
-                                CTRRootController.PostAchievementName("1058281905", ACHIEVEMENT_STRING("\"Tummy Teaser\""));
-                            }
-                        }
-                        else
-                        {
-                            t.mouthCloseTimer = 1f;
+                            CTRRootController.PostAchievementName("1058281905", ACHIEVEMENT_STRING("\"Tummy Teaser\""));
                         }
                     }
                 }
@@ -1409,8 +1403,11 @@ namespace CutTheRopeDX.GameMain
                 for (int ti = 0; ti < targets.Count; ti++)
                 {
                     TargetContext t = targets[ti];
-                    bool canInteractWithTarget = !nightLevel || t.isNightTargetAwake == true;
-                    if (!canInteractWithTarget || !gameplayFlow.CanReactToCandy(t.asleep) || !t.mouthOpen || t.targetObject == null)
+                    bool canInteractWithTarget = !nightLevel || t.NightSleep.IsAwake;
+                    if (!canInteractWithTarget
+                        || !gameplayFlow.CanReactToCandy(t.Feeding.IsFed)
+                        || t.Feeding.Phase != TargetFeedingPhase.MouthOpen
+                        || t.targetObject == null)
                     {
                         continue;
                     }
@@ -1431,8 +1428,7 @@ namespace CutTheRopeDX.GameMain
                             }
 
                             body.Visual.visible = false;
-                            t.asleep = true;
-                            t.mouthOpen = false;
+                            _ = t.Feeding.TryBeginChewing();
                             t.controller?.PlayChewing();
                             CTRSoundMgr.PlayOmNomSound(Resources.Snd.MonsterChewing, t.controller?.SkinDefinition);
                             SchedulePostEatSleep(t);

--- a/CutTheRopeDX/GameMain/GameScene.cs
+++ b/CutTheRopeDX/GameMain/GameScene.cs
@@ -133,10 +133,11 @@ namespace CutTheRopeDX.GameMain
         /// <returns><see langword="true"/> when a chat greeting was started; otherwise, <see langword="false"/>.</returns>
         private bool TryStartChatReaction()
         {
-            if (chatReactionActive
-                || targets.Count != 2
-                || targets[0].asleep
-                || targets[1].asleep
+            if (targets.Count != 2
+                || targets[0].Idle.HasPendingChat
+                || targets[1].Idle.HasPendingChat
+                || targets[0].Feeding.IsFed
+                || targets[1].Feeding.IsFed
                 || RND_RANGE(0, ChatReactionOdds - 1) != 0)
             {
                 return false;
@@ -147,8 +148,8 @@ namespace CutTheRopeDX.GameMain
                 return false;
             }
 
-            targets[0].idlesTimer = RND_RANGE(5, 20);
-            targets[1].idlesTimer = RND_RANGE(5, 20);
+            targets[0].Idle.ScheduleIdle(RND_RANGE(5, 20));
+            targets[1].Idle.ScheduleIdle(RND_RANGE(5, 20));
             return true;
         }
 
@@ -178,9 +179,12 @@ namespace CutTheRopeDX.GameMain
             int firstIndex = RND_RANGE(0, 1);
             int secondIndex = 1 - firstIndex;
             TargetAnimationState firstState = firstIndex == 0 ? states.Value.first : states.Value.second;
-            pendingChatGreetState = secondIndex == 0 ? states.Value.first : states.Value.second;
-            pendingChatGreetIndex = secondIndex;
-            chatReactionActive = true;
+            TargetContext secondTarget = targets[secondIndex];
+            TargetAnimationState secondState = secondIndex == 0 ? states.Value.first : states.Value.second;
+            if (!secondTarget.Idle.TryScheduleChat(secondState))
+            {
+                return false;
+            }
 
             // Initiator turns now; the other follows a fixed beat later.
             targets[firstIndex].controller?.PlayGreetingTurn(firstState);
@@ -198,20 +202,28 @@ namespace CutTheRopeDX.GameMain
         /// <param name="param">Unused timeline payload.</param>
         private void Selector_showSecondChatGreeting(FrameworkTypes param)
         {
-            chatReactionActive = false;
-
-            if (targets.Count != 2 || pendingChatGreetIndex >= targets.Count)
+            if (targets.Count != 2)
             {
                 return;
             }
 
-            TargetContext second = targets[pendingChatGreetIndex];
+            TargetContext second = null;
+            TargetAnimationState state = default;
+            for (int ti = 0; ti < targets.Count; ti++)
+            {
+                if (targets[ti].Idle.TryConsumeChat(out state))
+                {
+                    second = targets[ti];
+                    break;
+                }
+            }
+
             if (second?.targetObject == null)
             {
                 return;
             }
 
-            second.controller?.PlayGreetingTurn(pendingChatGreetState);
+            second.controller?.PlayGreetingTurn(state);
             CTRSoundMgr.PlayOmNomSound(Resources.Snd.MonsterGreeting, second.controller?.SkinDefinition);
         }
 
@@ -791,15 +803,6 @@ namespace CutTheRopeDX.GameMain
         /// One-in-N odds that an idle reaction on a two-Om-Nom level becomes a chat greeting.
         /// </summary>
         private const int ChatReactionOdds = 3;
-
-        /// <summary>Greet state queued for the second Om Nom in a staggered two-Om-Nom chat greeting.</summary>
-        private TargetAnimationState pendingChatGreetState;
-
-        /// <summary>Target index queued to greet second in a staggered two-Om-Nom chat greeting.</summary>
-        private int pendingChatGreetIndex;
-
-        /// <summary>Whether a two-Om-Nom chat greeting hand-off is currently in progress.</summary>
-        private bool chatReactionActive;
 
         /// <summary>
         /// All active razor objects in the loaded level.

--- a/CutTheRopeDX/GameMain/GameWinChewing.cs
+++ b/CutTheRopeDX/GameMain/GameWinChewing.cs
@@ -1,15 +1,10 @@
 namespace CutTheRopeDX.GameMain
 {
     /// <summary>
-    /// Decides whether the legacy singleton target should play chewing during the win sequence.
+    /// Decides whether an Om Nom should sleep after eating while other targets remain.
     /// </summary>
     internal static class GameWinChewing
     {
-        public static bool ShouldPlayPrimaryChewingOnGameWon(int targetCount)
-        {
-            return targetCount <= 1;
-        }
-
         public static bool ShouldSchedulePostEatSleep(int targetCount, bool isNightLevel, bool usesFlashXmlAnimations)
         {
             return targetCount > 1 && !isNightLevel && usesFlashXmlAnimations;

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadTarget.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadTarget.cs
@@ -64,18 +64,13 @@ namespace CutTheRopeDX.GameMain
             controller.Initialize(this);
 
             // Register this Om Nom as an independent target. targets[0] stays the primary.
-            targets.Add(new TargetContext
+            targets.Add(new TargetContext(BLINK_SKIP, RND_RANGE(5, 20))
             {
                 controller = controller,
                 targetObject = targetObj,
                 support = support,
                 baseScaleX = targetBaseScaleX,
                 baseScaleY = targetBaseScaleY,
-                mouthOpen = false,
-                mouthCloseTimer = 0f,
-                asleep = false,
-                blinkTimer = BLINK_SKIP,
-                idlesTimer = RND_RANGE(5, 20),
             });
 
             // Show greeting if needed (skip for night levels).

--- a/CutTheRopeDX/GameMain/NightSleepState.cs
+++ b/CutTheRopeDX/GameMain/NightSleepState.cs
@@ -1,0 +1,179 @@
+using System;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>Mutually exclusive night-sleep behavior for one Om Nom.</summary>
+    internal enum NightSleepPhase
+    {
+        /// <summary>Fully awake.</summary>
+        Awake,
+
+        /// <summary>Playing the transition into sleep and waiting to pulse.</summary>
+        FallingAsleep,
+
+        /// <summary>Sleeping with the breathing pulse active.</summary>
+        Pulsing,
+
+        /// <summary>Playing the wake transition.</summary>
+        Waking,
+    }
+
+    /// <summary>Observable edge produced by a night illumination update.</summary>
+    internal enum NightSleepTransition
+    {
+        /// <summary>No sleep/wake animation should start.</summary>
+        None,
+
+        /// <summary>The target began falling asleep.</summary>
+        FellAsleep,
+
+        /// <summary>The target began waking.</summary>
+        Woke,
+    }
+
+    /// <summary>
+    /// Single owner of night sleep phase, pulse timing, sound cadence, and shared sleep-overlay
+    /// visibility for one Om Nom.
+    /// </summary>
+    internal sealed class NightSleepState
+    {
+        private bool illuminationObserved;
+
+        /// <summary>Gets the current mutually exclusive night-sleep phase.</summary>
+        public NightSleepPhase Phase { get; private set; } = NightSleepPhase.Awake;
+
+        /// <summary>Gets whether illumination-dependent interactions are currently allowed.</summary>
+        public bool IsAwake => Phase is NightSleepPhase.Awake or NightSleepPhase.Waking;
+
+        /// <summary>Gets elapsed breathing-pulse time.</summary>
+        public float PulseTime { get; private set; }
+
+        /// <summary>Gets the remaining delay before breathing starts.</summary>
+        public float PulseDelay { get; private set; }
+
+        /// <summary>Gets the target-relative pulse pivot.</summary>
+        public float PulseBaseY { get; private set; }
+
+        /// <summary>Gets elapsed time toward the next sleep sound.</summary>
+        public float SoundTime { get; private set; }
+
+        /// <summary>Gets whether the controller's sleep overlay is currently presented.</summary>
+        public bool OverlayVisible { get; private set; }
+
+        /// <summary>Updates the authoritative phase from current illumination.</summary>
+        /// <param name="isAwake">Whether a light currently illuminates the target.</param>
+        /// <param name="pulseDelay">Backend-specific delay before pulsing.</param>
+        /// <param name="pulseBaseY">Target-relative pulse pivot.</param>
+        /// <returns>The animation edge caused by this observation.</returns>
+        public NightSleepTransition ObserveAwake(bool isAwake, float pulseDelay, float pulseBaseY)
+        {
+            if (isAwake)
+            {
+                if (!illuminationObserved || !IsAwake)
+                {
+                    illuminationObserved = true;
+                    Phase = NightSleepPhase.Waking;
+                    ClearPresentation();
+                    return NightSleepTransition.Woke;
+                }
+
+                if (Phase == NightSleepPhase.Waking)
+                {
+                    Phase = NightSleepPhase.Awake;
+                }
+
+                return NightSleepTransition.None;
+            }
+
+            if (!illuminationObserved || IsAwake)
+            {
+                illuminationObserved = true;
+                Phase = NightSleepPhase.FallingAsleep;
+                PulseTime = 0f;
+                PulseDelay = MathF.Max(0f, pulseDelay);
+                PulseBaseY = pulseBaseY;
+                SoundTime = 0.9f;
+                OverlayVisible = false;
+                return NightSleepTransition.FellAsleep;
+            }
+
+            return NightSleepTransition.None;
+        }
+
+        /// <summary>Advances falling-asleep delay or the active breathing-pulse clock.</summary>
+        /// <param name="delta">Elapsed seconds.</param>
+        public void AdvancePulse(float delta)
+        {
+            delta = MathF.Max(0f, delta);
+            if (Phase == NightSleepPhase.FallingAsleep)
+            {
+                PulseDelay = MathF.Max(0f, PulseDelay - delta);
+                if (PulseDelay == 0f)
+                {
+                    Phase = NightSleepPhase.Pulsing;
+                    PulseTime += delta;
+                }
+                return;
+            }
+
+            if (Phase == NightSleepPhase.Pulsing)
+            {
+                PulseTime += delta;
+            }
+        }
+
+        /// <summary>Changes overlay ownership and reports whether the controller needs synchronization.</summary>
+        /// <param name="visible">Desired overlay visibility.</param>
+        /// <param name="feedingAsleep">Whether feeding sleep, rather than night sleep, owns the overlay.</param>
+        /// <returns><see langword="true"/> when visibility changed.</returns>
+        public bool SetOverlayVisible(bool visible, bool feedingAsleep)
+        {
+            if (visible && IsAwake && !feedingAsleep)
+            {
+                return false;
+            }
+
+            if (OverlayVisible == visible)
+            {
+                return false;
+            }
+
+            OverlayVisible = visible;
+            return true;
+        }
+
+        /// <summary>Advances sleep-sound cadence and consumes a due sound edge.</summary>
+        /// <param name="delta">Elapsed seconds.</param>
+        /// <param name="interval">Seconds between sleep sounds.</param>
+        /// <returns><see langword="true"/> when a sound is due.</returns>
+        public bool AdvanceSound(float delta, float interval)
+        {
+            SoundTime += MathF.Max(0f, delta);
+            if (SoundTime <= interval)
+            {
+                return false;
+            }
+
+            SoundTime = 0f;
+            return true;
+        }
+
+        /// <summary>Sets the initial sound cadence used when post-eat sleep starts.</summary>
+        /// <param name="soundTime">Initial elapsed sound time.</param>
+        public void StartPostEatPresentation(float soundTime)
+        {
+            SoundTime = MathF.Max(0f, soundTime);
+            OverlayVisible = false;
+        }
+
+        /// <summary>Clears pulse, sound, and overlay presentation without changing logical sleep phase.</summary>
+        public void ClearPresentation()
+        {
+            PulseTime = 0f;
+            PulseDelay = 0f;
+            PulseBaseY = 0f;
+            SoundTime = 0f;
+            OverlayVisible = false;
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/TargetContext.cs
+++ b/CutTheRopeDX/GameMain/TargetContext.cs
@@ -3,10 +3,10 @@ using CutTheRopeDX.Framework.Visual;
 
 namespace CutTheRopeDX.GameMain
 {
-    /// <summary>
-    /// All per-Om-Nom state. Mouth state lives here because targeting is many-to-many.
-    /// </summary>
-    internal sealed class TargetContext
+    /// <summary>Composes all state owned by one independently targetable Om Nom.</summary>
+    /// <param name="blinkCountdown">Initial animation-frame blink countdown.</param>
+    /// <param name="idleCountdown">Initial animation-frame idle/chat countdown.</param>
+    internal sealed class TargetContext(int blinkCountdown, int idleCountdown)
     {
         public TargetAnimationController controller;
 
@@ -18,36 +18,13 @@ namespace CutTheRopeDX.GameMain
 
         public float baseScaleY = 1f;
 
-        /// <summary>Mouth currently open.</summary>
-        public bool mouthOpen;
+        /// <summary>Gets the authoritative feeding behavior.</summary>
+        public TargetFeedingState Feeding { get; } = new();
 
-        /// <summary>Countdown before the mouth closes again.</summary>
-        public float mouthCloseTimer;
+        /// <summary>Gets the authoritative night-sleep behavior and shared sleep presentation.</summary>
+        public NightSleepState NightSleep { get; } = new();
 
-        /// <summary>True once this Om Nom has eaten a candy; it will not reopen ("eats then sleeps").</summary>
-        public bool asleep;
-
-        // --- Night-level sleep state (per Om Nom; were scene singletons) ---
-        public bool? isNightTargetAwake;
-
-        public bool sleepPulseActive;
-
-        public float sleepPulseTime;
-
-        public float sleepPulseDelay;
-
-        public float sleepPulseBaseY;
-
-        public float sleepSoundTimer;
-
-        public bool nightSleepOverlayVisible;
-
-        public bool postEatSleepActive;
-
-        public bool postEatSleepScheduled;
-
-        public int blinkTimer;
-
-        public int idlesTimer;
+        /// <summary>Gets the authoritative blink, idle, and chat cadence.</summary>
+        public TargetIdleState Idle { get; } = new(blinkCountdown, idleCountdown);
     }
 }

--- a/CutTheRopeDX/GameMain/TargetFeedingState.cs
+++ b/CutTheRopeDX/GameMain/TargetFeedingState.cs
@@ -1,0 +1,106 @@
+using System;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>Mutually exclusive feeding behavior for one Om Nom.</summary>
+    internal enum TargetFeedingPhase
+    {
+        /// <summary>Waiting for a candy to approach.</summary>
+        Idle,
+
+        /// <summary>The mouth is open for a nearby candy.</summary>
+        MouthOpen,
+
+        /// <summary>A candy was eaten and the chewing animation is active.</summary>
+        Chewing,
+
+        /// <summary>Post-eat sleep is active.</summary>
+        Asleep,
+    }
+
+    /// <summary>Single owner of one Om Nom's feeding phase and mouth-close timer.</summary>
+    internal sealed class TargetFeedingState
+    {
+        /// <summary>Gets the current mutually exclusive feeding phase.</summary>
+        public TargetFeedingPhase Phase { get; private set; }
+
+        /// <summary>Gets the remaining time before an open mouth is reconsidered.</summary>
+        public float MouthCloseTime { get; private set; }
+
+        /// <summary>Gets whether this target has already consumed a candy.</summary>
+        public bool IsFed => Phase is TargetFeedingPhase.Chewing or TargetFeedingPhase.Asleep;
+
+        /// <summary>Gets whether post-eat sleep is active.</summary>
+        public bool IsAsleep => Phase == TargetFeedingPhase.Asleep;
+
+        /// <summary>Opens an idle target's mouth and starts its close countdown.</summary>
+        /// <param name="closeDelay">Seconds before proximity is checked again.</param>
+        /// <returns><see langword="true"/> when the mouth opened.</returns>
+        public bool TryOpenMouth(float closeDelay)
+        {
+            if (Phase != TargetFeedingPhase.Idle)
+            {
+                return false;
+            }
+
+            Phase = TargetFeedingPhase.MouthOpen;
+            MouthCloseTime = MathF.Max(0f, closeDelay);
+            return true;
+        }
+
+        /// <summary>Advances an open mouth and either refreshes or closes it when its timer expires.</summary>
+        /// <param name="delta">Elapsed seconds.</param>
+        /// <param name="candyNearby">Whether an eligible candy remains close enough.</param>
+        /// <param name="refreshDelay">Countdown restored while a candy remains nearby.</param>
+        /// <returns><see langword="true"/> only when the mouth closes on this call.</returns>
+        public bool AdvanceMouthClose(float delta, bool candyNearby, float refreshDelay)
+        {
+            if (Phase != TargetFeedingPhase.MouthOpen)
+            {
+                return false;
+            }
+
+            MouthCloseTime = MathF.Max(0f, MouthCloseTime - MathF.Max(0f, delta));
+            if (MouthCloseTime > 0f)
+            {
+                return false;
+            }
+
+            if (candyNearby)
+            {
+                MouthCloseTime = MathF.Max(0f, refreshDelay);
+                return false;
+            }
+
+            Phase = TargetFeedingPhase.Idle;
+            return true;
+        }
+
+        /// <summary>Atomically records consumption, closes the mouth, and begins chewing.</summary>
+        /// <returns><see langword="true"/> when an unfed target begins chewing.</returns>
+        public bool TryBeginChewing()
+        {
+            if (Phase != TargetFeedingPhase.MouthOpen)
+            {
+                return false;
+            }
+
+            Phase = TargetFeedingPhase.Chewing;
+            MouthCloseTime = 0f;
+            return true;
+        }
+
+        /// <summary>Completes the delayed transition from chewing to post-eat sleep.</summary>
+        /// <returns><see langword="true"/> only for the current chewing phase.</returns>
+        public bool TryFallAsleep()
+        {
+            if (Phase != TargetFeedingPhase.Chewing)
+            {
+                return false;
+            }
+
+            Phase = TargetFeedingPhase.Asleep;
+            return true;
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/TargetIdleState.cs
+++ b/CutTheRopeDX/GameMain/TargetIdleState.cs
@@ -1,0 +1,100 @@
+using System;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>Idle cadence edges due on a target animation frame.</summary>
+    /// <param name="BlinkDue">Whether the blink reaction is due.</param>
+    /// <param name="IdleDue">Whether the idle/chat reaction is due.</param>
+    internal readonly record struct TargetIdleStep(bool BlinkDue, bool IdleDue);
+
+    /// <summary>Single owner of one Om Nom's blink, random-idle, and chat cadence.</summary>
+    /// <param name="blinkCountdown">Initial animation-frame blink countdown.</param>
+    /// <param name="idleCountdown">Initial animation-frame idle countdown.</param>
+    internal sealed class TargetIdleState(int blinkCountdown, int idleCountdown)
+    {
+        private TargetAnimationState? pendingChatState;
+
+        /// <summary>Gets animation frames remaining before blink is due.</summary>
+        public int BlinkCountdown { get; private set; } = Math.Max(0, blinkCountdown);
+
+        /// <summary>Gets animation frames remaining before an idle/chat reaction is due.</summary>
+        public int IdleCountdown { get; private set; } = Math.Max(0, idleCountdown);
+
+        /// <summary>Gets whether this target owns the pending second half of a chat greeting.</summary>
+        public bool HasPendingChat => pendingChatState.HasValue;
+
+        /// <summary>Advances both cadence counters, holding them at zero until consumed.</summary>
+        /// <returns>The reactions currently due.</returns>
+        public TargetIdleStep AdvanceCadence()
+        {
+            BlinkCountdown = Math.Max(0, BlinkCountdown - 1);
+            IdleCountdown = Math.Max(0, IdleCountdown - 1);
+            return new TargetIdleStep(BlinkCountdown == 0, IdleCountdown == 0);
+        }
+
+        /// <summary>Consumes a due blink and atomically schedules the next one.</summary>
+        /// <param name="nextCountdown">Countdown for the next blink.</param>
+        /// <returns><see langword="true"/> when a due blink was consumed.</returns>
+        public bool ConsumeBlink(int nextCountdown)
+        {
+            if (BlinkCountdown != 0)
+            {
+                return false;
+            }
+
+            BlinkCountdown = Math.Max(0, nextCountdown);
+            return true;
+        }
+
+        /// <summary>Consumes a due idle/chat edge and atomically schedules the next one.</summary>
+        /// <param name="nextCountdown">Countdown for the next idle/chat reaction.</param>
+        /// <returns><see langword="true"/> when a due reaction was consumed.</returns>
+        public bool ConsumeIdle(int nextCountdown)
+        {
+            if (IdleCountdown != 0)
+            {
+                return false;
+            }
+
+            IdleCountdown = Math.Max(0, nextCountdown);
+            return true;
+        }
+
+        /// <summary>Reschedules idle/chat cadence, including the other participant in a chat.</summary>
+        /// <param name="nextCountdown">Countdown for the next idle/chat reaction.</param>
+        public void ScheduleIdle(int nextCountdown)
+        {
+            IdleCountdown = Math.Max(0, nextCountdown);
+        }
+
+        /// <summary>Schedules this target as the second participant in a chat greeting.</summary>
+        /// <param name="state">Directional greeting animation to play.</param>
+        /// <returns><see langword="true"/> when no chat was already pending.</returns>
+        public bool TryScheduleChat(TargetAnimationState state)
+        {
+            if (pendingChatState.HasValue)
+            {
+                return false;
+            }
+
+            pendingChatState = state;
+            return true;
+        }
+
+        /// <summary>Atomically consumes the pending second chat greeting.</summary>
+        /// <param name="state">The directional greeting animation when one was pending.</param>
+        /// <returns><see langword="true"/> when a pending chat was consumed.</returns>
+        public bool TryConsumeChat(out TargetAnimationState state)
+        {
+            if (!pendingChatState.HasValue)
+            {
+                state = default;
+                return false;
+            }
+
+            state = pendingChatState.Value;
+            pendingChatState = null;
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Description

Om Nom behavior was previously represented by loosely related booleans and timers. Invalid combinations were possible, and every transition required manually resetting all related fields.

This refactor replace Om Nom's independent behavior flags and timers with composed, per-target state machines:

- `TargetFeedingState` owns idle, mouth-open, chewing, and post-eat sleep phases
- `NightSleepState` owns awake, falling-asleep, pulsing, and waking phases
- `TargetIdleState` owns blink, idle animation, and chat scheduling
- Each Om Nom maintains an independent idle cadence instead of sharing synchronized scene timers
- Remove the duplicate chewing animation and sound replay from the win transition