### PR TITLE
refactor: Consolidate delayed operations into atomic tickets

### DIFF
--- a/CutTheRopeDX.Tests/DelayedOperationOwnershipTests.cs
+++ b/CutTheRopeDX.Tests/DelayedOperationOwnershipTests.cs
@@ -1,0 +1,114 @@
+using System.Reflection;
+
+using CutTheRopeDX.Framework.Helpers;
+using CutTheRopeDX.GameMain;
+using CutTheRopeDX.Tests.Interactions;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class DelayedOperationOwnershipTests
+    {
+        private const BindingFlags Instance = BindingFlags.Instance | BindingFlags.NonPublic;
+
+        [Theory]
+        [InlineData("parkedGhostBubble", "ParkedGhostBubble")]
+        [InlineData("pendingLanternCapture", "PendingLanternCapture")]
+        public void GameSceneStoresEachDelayedOperationAsOneNullableTicket(
+            string fieldName,
+            string ticketTypeName)
+        {
+            FieldInfo field = typeof(GameScene).GetField(fieldName, Instance);
+
+            Assert.NotNull(field);
+            Assert.Equal(ticketTypeName, field.FieldType.Name);
+        }
+
+        [Theory]
+        [InlineData("pendingSecondGhostBubble")]
+        [InlineData("pendingSecondGhostBubbleOwner")]
+        [InlineData("pendingLanternCapturePoint")]
+        public void GameSceneHasNoIndependentlyAssignableDelayedOperationPayloadFields(string fieldName)
+        {
+            Assert.Null(typeof(GameScene).GetField(fieldName, Instance));
+        }
+
+        [Fact]
+        public void ParkedGhostBubbleCancellationReleasesItsExactBubble()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(160, 440)
+                .Bubble(20, 40)
+                .Build();
+            GameObject bubble = scene.Bubbles()[0];
+            ParkedGhostBubble parked = new(scene.Candy().WholeBody, bubble);
+            GameObject released = null;
+
+            parked.Cancel(candidate => released = candidate);
+
+            Assert.Same(bubble, released);
+        }
+
+        [Fact]
+        public void ReplacingAParkedGhostBubbleCancelsThePreviousTicket()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(160, 440)
+                .Bubble(20, 40)
+                .Bubble(40, 40)
+                .Build();
+            CandyBody owner = scene.Candy().WholeBody;
+            GameObject oldBubble = scene.Bubbles()[0];
+            ParkedGhostBubble replacement = new(owner, scene.Bubbles()[1]);
+            ParkedGhostBubble parked = new(owner, oldBubble);
+            GameObject released = null;
+
+            ParkedGhostBubble result = parked.ReplaceWith(
+                replacement,
+                candidate => released = candidate);
+
+            Assert.Same(oldBubble, released);
+            Assert.Same(replacement, result);
+        }
+
+        [Fact]
+        public void PoppingTheOwnerBubbleCancelsItsParkedGhostTicket()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(160, 440)
+                .Bubble(160, 200)
+                .Bubble(20, 40)
+                .Build();
+            CandyContext candy = scene.Candy();
+            _ = Act.CaptureInBubble(scene, candy, bubbleIndex: 0);
+            scene.ParkSecondGhostBubble(candy.WholeBody, scene.Bubbles()[1]);
+
+            scene.PopCandyBubble(candy.WholeBody);
+
+            Assert.Null(scene.PendingSecondGhostBubble());
+        }
+
+        [Fact]
+        public void ObsoleteLanternCallbackCannotCompleteAReplacementTicket()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(160, 440)
+                .Lantern(20, 40)
+                .Build();
+            CandyContext candy = scene.Candy();
+            Lantern lantern = Lantern.GetAllLanterns()[0];
+            PendingLanternCapture obsolete = new(candy.WholeBody.Point, lantern);
+            PendingLanternCapture replacement = new(candy.WholeBody.Point, lantern);
+            scene.SetPendingLanternCapture(replacement);
+
+            scene.CompletePendingLanternCapture(obsolete);
+
+            Assert.Same(replacement, scene.PendingLanternCapture());
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
+++ b/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
@@ -354,20 +354,43 @@ namespace CutTheRopeDX.Tests.Interactions
         /// </summary>
         public static void ParkSecondGhostBubble(this GameScene scene, CandyBody owner, GameObject bubble)
         {
-            FieldInfo bubbleField = typeof(GameScene).GetField("pendingSecondGhostBubble", Instance)
-                ?? throw new MissingFieldException(nameof(GameScene), "pendingSecondGhostBubble");
-            bubbleField.SetValue(scene, bubble);
-
-            // The owner field is introduced by the invariant fix. Keeping this setup compatible
-            // with the pre-fix shape lets the isolation test first demonstrate the failure.
-            FieldInfo ownerField = typeof(GameScene).GetField("pendingSecondGhostBubbleOwner", Instance);
-            ownerField?.SetValue(scene, owner);
+            FieldInfo field = typeof(GameScene).GetField("parkedGhostBubble", Instance)
+                ?? throw new MissingFieldException(nameof(GameScene), "parkedGhostBubble");
+            field.SetValue(scene, new ParkedGhostBubble(owner, bubble));
         }
 
         /// <summary>Gets the ghost bubble parked behind a merged candy's active ghost bubble.</summary>
         public static GameObject PendingSecondGhostBubble(this GameScene scene)
         {
-            return Field<GameObject>(scene, "pendingSecondGhostBubble");
+            return Field<ParkedGhostBubble>(scene, "parkedGhostBubble")?.Bubble;
+        }
+
+        /// <summary>Installs an exact lantern ticket for delayed-callback identity tests.</summary>
+        public static void SetPendingLanternCapture(
+            this GameScene scene,
+            PendingLanternCapture capture)
+        {
+            FieldInfo field = typeof(GameScene).GetField("pendingLanternCapture", Instance)
+                ?? throw new MissingFieldException(nameof(GameScene), "pendingLanternCapture");
+            field.SetValue(scene, capture);
+        }
+
+        /// <summary>Gets the scene's current delayed lantern-capture ticket.</summary>
+        public static PendingLanternCapture PendingLanternCapture(this GameScene scene)
+        {
+            return Field<PendingLanternCapture>(scene, "pendingLanternCapture");
+        }
+
+        /// <summary>Invokes the real delayed lantern completion callback with an exact ticket.</summary>
+        public static void CompletePendingLanternCapture(
+            this GameScene scene,
+            PendingLanternCapture capture)
+        {
+            MethodInfo method = typeof(GameScene).GetMethod(
+                "CompletePendingLanternCapture",
+                Instance)
+                ?? throw new MissingMethodException(nameof(GameScene), "CompletePendingLanternCapture");
+            _ = method.Invoke(scene, [capture]);
         }
 
         /// <summary>Whether any conveyor belt has bound the given grab.</summary>

--- a/CutTheRopeDX/GameMain/DelayedOperations.cs
+++ b/CutTheRopeDX/GameMain/DelayedOperations.cs
@@ -1,0 +1,59 @@
+using System;
+
+using CutTheRopeDX.Framework;
+using CutTheRopeDX.Framework.Helpers;
+using CutTheRopeDX.Framework.Physics;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>
+    /// Immutable payload for a lantern capture that is waiting for its delayed completion.
+    /// Passing the ticket itself through the dispatcher prevents an obsolete callback from
+    /// completing a newer capture for the same point.
+    /// </summary>
+    internal sealed class PendingLanternCapture(ConstraintedPoint point, Lantern lantern) : FrameworkTypes
+    {
+        /// <summary>Gets the candy point being captured.</summary>
+        public ConstraintedPoint Point { get; } = point ?? throw new ArgumentNullException(nameof(point));
+
+        /// <summary>Gets the lantern that will complete the capture.</summary>
+        public Lantern Lantern { get; } = lantern ?? throw new ArgumentNullException(nameof(lantern));
+
+        /// <summary>Completes the capture only while the candy still belongs to a lantern.</summary>
+        public void Complete(CandyContext candy)
+        {
+            if (candy?.Lifecycle.Attachments.InLantern == true)
+            {
+                Lantern.CaptureCandy(Point);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Immutable ownership ticket for the second ghost bubble retained across a candy merge.
+    /// </summary>
+    internal sealed class ParkedGhostBubble(CandyBody owner, GameObject bubble)
+    {
+        /// <summary>Gets the merged body whose active bubble hides this one.</summary>
+        public CandyBody Owner { get; } = owner ?? throw new ArgumentNullException(nameof(owner));
+
+        /// <summary>Gets the ghost bubble waiting to be released.</summary>
+        public GameObject Bubble { get; } = bubble ?? throw new ArgumentNullException(nameof(bubble));
+
+        /// <summary>Releases the parked bubble through the scene's ghost-cycle owner.</summary>
+        public void Cancel(Action<GameObject> releaseBubble)
+        {
+            ArgumentNullException.ThrowIfNull(releaseBubble);
+            releaseBubble(Bubble);
+        }
+
+        /// <summary>Cancels this ticket and returns the replacement to store atomically.</summary>
+        public ParkedGhostBubble ReplaceWith(
+            ParkedGhostBubble replacement,
+            Action<GameObject> releaseBubble)
+        {
+            Cancel(releaseBubble);
+            return replacement;
+        }
+    }
+}

--- a/CutTheRopeDX/GameMain/GameScene.CandyRemoval.cs
+++ b/CutTheRopeDX/GameMain/GameScene.CandyRemoval.cs
@@ -137,28 +137,22 @@ namespace CutTheRopeDX.GameMain
 
         private void CancelPendingLanternCaptureForRemoval(ConstraintedPoint point)
         {
-            if (pendingLanternCapturePoint == point)
+            if (pendingLanternCapture?.Point == point)
             {
-                pendingLanternCapturePoint = null;
                 pendingLanternCapture = null;
             }
         }
 
         private void CompletePendingLanternCapture(FrameworkTypes value)
         {
-            if (value is not ConstraintedPoint point || pendingLanternCapturePoint != point)
+            if (value is not PendingLanternCapture capture
+                || !ReferenceEquals(pendingLanternCapture, capture))
             {
                 return;
             }
 
-            Lantern lantern = pendingLanternCapture;
-            pendingLanternCapturePoint = null;
             pendingLanternCapture = null;
-            CandyContext ctx = CandyForPointOrNull(point);
-            if (lantern != null && ctx?.Lifecycle.Attachments.InLantern == true)
-            {
-                lantern.CaptureCandy(point);
-            }
+            capture.Complete(CandyForPointOrNull(capture.Point));
         }
 
         private void DetachRopeConstraintsForPoint(ConstraintedPoint point)
@@ -216,14 +210,17 @@ namespace CutTheRopeDX.GameMain
 
         private void ReleasePendingSecondGhostBubbleForBody(CandyBody body)
         {
-            if (pendingSecondGhostBubble == null || pendingSecondGhostBubbleOwner != body)
+            if (parkedGhostBubble?.Owner != body)
             {
                 return;
             }
 
-            EnableGhostCycleForBubble(pendingSecondGhostBubble);
-            pendingSecondGhostBubble = null;
-            pendingSecondGhostBubbleOwner = null;
+            CancelParkedGhostBubble();
+        }
+
+        private void CancelParkedGhostBubble()
+        {
+            parkedGhostBubble = parkedGhostBubble?.ReplaceWith(null, EnableGhostCycleForBubble);
         }
     }
 }

--- a/CutTheRopeDX/GameMain/GameScene.Initialize.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Initialize.cs
@@ -74,9 +74,7 @@ namespace CutTheRopeDX.GameMain
             mice = [];
             miceManager = null;
             pollenDrawer = new PollenDrawer();
-            pendingSecondGhostBubble = null;
-            pendingSecondGhostBubbleOwner = null;
-            pendingLanternCapturePoint = null;
+            parkedGhostBubble = null;
             pendingLanternCapture = null;
             targets.Clear();
             targetBaseScaleX = 1f;

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -355,8 +355,7 @@ namespace CutTheRopeDX.GameMain
                         CandyBody rightBody = merging.Right.Body;
                         GameObject leftBubble = leftBody.Bubble;
                         GameObject rightBubble = rightBody.Bubble;
-                        pendingSecondGhostBubble = null;
-                        pendingSecondGhostBubbleOwner = null;
+                        CancelParkedGhostBubble();
                         if (leftBubble != null || rightBubble != null)
                         {
                             bool leftHasGhost = leftBubble != null && DisableGhostCycleForBubble(leftBubble);
@@ -364,8 +363,7 @@ namespace CutTheRopeDX.GameMain
                             if (leftHasGhost && rightHasGhost)
                             {
                                 mergedBody.Bubble = leftBubble;
-                                pendingSecondGhostBubble = rightBubble;
-                                pendingSecondGhostBubbleOwner = mergedBody;
+                                parkedGhostBubble = new ParkedGhostBubble(mergedBody, rightBubble);
                             }
                             else if (leftHasGhost)
                             {
@@ -748,9 +746,11 @@ namespace CutTheRopeDX.GameMain
                         body.Point.SetWeight(SnailWeight.AfterForceDetach(body.Point.weight, lanternDetachedSnails));
                     }
                     PopCandyBubble(body);
-                    pendingLanternCapturePoint = body.Point;
-                    pendingLanternCapture = lantern;
-                    dd.CallObjectSelectorParamafterDelay(new DelayedDispatcher.DispatchFunc(CompletePendingLanternCapture), body.Point, 0.05f);
+                    pendingLanternCapture = new PendingLanternCapture(body.Point, lantern);
+                    dd.CallObjectSelectorParamafterDelay(
+                        new DelayedDispatcher.DispatchFunc(CompletePendingLanternCapture),
+                        pendingLanternCapture,
+                        0.05f);
 
                     // Trigger special tutorial for lantern
                     TriggerSpecialTutorial(3);

--- a/CutTheRopeDX/GameMain/GameScene.cs
+++ b/CutTheRopeDX/GameMain/GameScene.cs
@@ -1011,20 +1011,14 @@ namespace CutTheRopeDX.GameMain
         private bool fastenCamera;
 
         /// <summary>
-        /// The ghost bubble parked behind the merged candy's own bubble when both split halves were
-        /// carrying one. It is released when that bubble pops or is replaced, and is
+        /// Atomic ownership ticket for the ghost bubble parked behind a merged candy's own bubble.
+        /// It is released when that bubble pops or the ticket is replaced, and is
         /// <see langword="null"/> whenever no second ghost is waiting.
         /// </summary>
-        private GameObject pendingSecondGhostBubble;
+        private ParkedGhostBubble parkedGhostBubble;
 
-        /// <summary>The whole body that owns <see cref="pendingSecondGhostBubble"/>.</summary>
-        private CandyBody pendingSecondGhostBubbleOwner;
-
-        /// <summary>Candy point waiting for the lantern's delayed capture callback.</summary>
-        private ConstraintedPoint pendingLanternCapturePoint;
-
-        /// <summary>Lantern assigned to <see cref="pendingLanternCapturePoint"/>.</summary>
-        private Lantern pendingLanternCapture;
+        /// <summary>Atomic ticket waiting for the lantern's delayed capture callback.</summary>
+        private PendingLanternCapture pendingLanternCapture;
 
         /// <summary>
         /// The number of ropes cut within the active combo window.


### PR DESCRIPTION
## Description

- Replace the `pendingSecondGhostBubble` and `pendingSecondGhostBubbleOwner` field pair with an atomic `ParkedGhostBubble` ticket
- Replace the `pendingLanternCapturePoint` and `pendingLanternCapture` field pair with an atomic `PendingLanternCapture` ticket
- Pass lantern tickets through delayed callbacks so obsolete callbacks cannot complete replacement operations
- Cancel replaced parked-ghost tickets and restore the previous ghost's cycling state
- Clear each delayed operation through its single nullable ticket reference