### PR TITLE
refactor: Consolidate ghost apparition state

### DIFF
--- a/CutTheRopeDX.Tests/GhostOwnershipTests.cs
+++ b/CutTheRopeDX.Tests/GhostOwnershipTests.cs
@@ -1,7 +1,11 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
+using CutTheRopeDX.Framework;
 using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.Framework.Physics;
+using CutTheRopeDX.Framework.Visual;
 using CutTheRopeDX.GameMain;
 using CutTheRopeDX.Tests.Interactions;
 
@@ -181,6 +185,66 @@ namespace CutTheRopeDX.Tests
             Assert.DoesNotContain(outgoingGrab, scene.Grabs());
             Assert.Null(outgoingGrab.Rope);
             Assert.DoesNotContain(scene.RegisteredRopes(), entry => entry.Rope == outgoingRope);
+        }
+
+        [Fact]
+        public void TwoRapidAutoRopeToBouncerMorphsReleaseCandyPhysicsBeforePumpImpulse()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(20, 460)
+                .Ghost(80, 100, radius: -1, bouncer: true)
+                .Ghost(240, 100, radius: -1, bouncer: true)
+                .Pump(160, 300)
+                .Build();
+            CandyBody candy = scene.Candy().WholeBody;
+            int originalConstraintCount = candy.Point.constraints.Count;
+            List<Ghost> ghosts = scene.Ghosts();
+            Assert.Equal(2, ghosts.Count);
+
+            foreach (Ghost ghost in ghosts)
+            {
+                ghost.ResetToForm(GhostForm.Grab);
+            }
+            List<GhostGrab> outgoingGrabs = [.. ghosts.Select(ghost => Assert.IsType<GhostGrab>(ghost.Apparition))];
+            List<Bungee> outgoingRopes = [.. outgoingGrabs.Select(grab => Assert.IsType<Bungee>(grab.Rope))];
+            Assert.Equal(originalConstraintCount + 2, candy.Point.constraints.Count);
+
+            foreach (Ghost ghost in ghosts)
+            {
+                ghost.ResetToForm(GhostForm.Bouncer);
+            }
+            foreach (GhostGrab outgoing in outgoingGrabs)
+            {
+                outgoing.Update(0.2f);
+            }
+            foreach (Ghost ghost in ghosts)
+            {
+                ghost.Update(0f);
+                Assert.Equal(GhostForm.Bouncer, ghost.Form);
+                _ = Assert.IsType<GhostBouncer>(ghost.Apparition);
+            }
+
+            Assert.Empty(scene.Grabs());
+            Assert.DoesNotContain(scene.RegisteredRopes(), entry => outgoingRopes.Contains(entry.Rope));
+            Assert.Equal(originalConstraintCount, candy.Point.constraints.Count);
+
+            Pump pump = Assert.Single(scene.Pumps());
+            BaseElement.CalculateTopLeft(candy.Visual);
+            Vector beforePump = candy.Point.pos;
+            float distanceBelowPump = pump.y - beforePump.Y;
+            float verticalImpulse = 2f * (ActivePhysicsConstants.PumpFlowLength - distanceBelowPump);
+            float expectedY = beforePump.Y - (verticalImpulse * 0.016f / ActivePhysicsConstants.TimeScale);
+
+            scene.OperatePump(pump);
+            for (int i = 0; i < Bungee.BUNGEE_RELAXION_TIMES; i++)
+            {
+                ConstraintedPoint.SatisfyConstraints(candy.Point);
+            }
+
+            Assert.Equal(beforePump.X, candy.Point.pos.X, 3);
+            Assert.Equal(expectedY, candy.Point.pos.Y, 3);
+            Assert.Equal(originalConstraintCount, candy.Point.constraints.Count);
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/GhostOwnershipTests.cs
+++ b/CutTheRopeDX.Tests/GhostOwnershipTests.cs
@@ -1,0 +1,149 @@
+using System.Collections.Generic;
+using System.Reflection;
+
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.GameMain;
+using CutTheRopeDX.Tests.Interactions;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class GhostOwnershipTests
+    {
+        private const BindingFlags Instance = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+        [Theory]
+        [InlineData("ghostState")]
+        [InlineData("bubble")]
+        [InlineData("grab")]
+        [InlineData("bouncer")]
+        [InlineData("cyclingEnabled")]
+        [InlineData("candyBreak")]
+        public void GhostHasNoIndependentlyAssignableLegacyState(string fieldName)
+        {
+            Assert.Null(typeof(Ghost).GetField(fieldName, Instance));
+        }
+
+        [Fact]
+        public void GhostStoresOneCurrentApparitionAcrossForms()
+        {
+            (Ghost ghost, List<Bubble> bubbles, List<Grab> grabs, List<Bouncer> bouncers) = CreateGhost();
+
+            Assert.Equal(GhostForm.Idle, ghost.Form);
+            Assert.Null(ghost.Apparition);
+
+            ghost.ResetToForm(GhostForm.Bubble);
+            GhostBubble bubble = Assert.IsType<GhostBubble>(ghost.Apparition);
+
+            ghost.ResetToForm(GhostForm.Grab);
+            GhostGrab grab = Assert.IsType<GhostGrab>(ghost.Apparition);
+
+            ghost.ResetToForm(GhostForm.Bouncer);
+
+            Assert.Equal(GhostForm.Bouncer, ghost.Form);
+            _ = Assert.IsType<GhostBouncer>(ghost.Apparition);
+            Assert.Same(bubble, Assert.Single(bubbles));
+            Assert.Same(grab, Assert.Single(grabs));
+            _ = Assert.Single(bouncers);
+            _ = Assert.Single(
+                typeof(Ghost).GetFields(Instance),
+                field => field.FieldType == typeof(IGhostApparition));
+        }
+
+        [Fact]
+        public void RapidMorphsRetireEveryOutgoingApparition()
+        {
+            (Ghost ghost, List<Bubble> bubbles, List<Grab> grabs, List<Bouncer> _) = CreateGhost();
+            ghost.ResetToForm(GhostForm.Bubble);
+            ghost.ResetToForm(GhostForm.Grab);
+            ghost.ResetToForm(GhostForm.Bouncer);
+
+            bubbles[0].Update(0.2f);
+            grabs[0].Update(0.2f);
+            ghost.Update(0f);
+
+            Assert.Empty(bubbles);
+            Assert.Empty(grabs);
+            _ = Assert.IsType<GhostBouncer>(ghost.Apparition);
+        }
+
+        [Fact]
+        public void MorphPhaseNamesOutgoingAndIncomingFormsUntilAppearanceFinishes()
+        {
+            (Ghost ghost, _, _, _) = CreateGhost();
+
+            ghost.ResetToForm(GhostForm.Bubble);
+
+            Assert.Equal(new GhostMorphPhase(GhostForm.Idle, GhostForm.Bubble), ghost.MorphPhase);
+
+            ghost.Apparition.Element.Update(0.4f);
+            ghost.Update(0f);
+
+            Assert.Null(ghost.MorphPhase);
+        }
+
+        [Fact]
+        public void CapturedBubbleItselfBlocksCyclingUntilReleased()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(20, 460)
+                .Ghost(20, 40)
+                .Build();
+            CandyContext candy = scene.Candy();
+            Ghost ghost = Assert.Single(scene.Ghosts());
+            ghost.ResetToForm(GhostForm.Bubble);
+            Bubble bubble = Act.CaptureInBubble(scene, candy);
+
+            Assert.Same(ghost.Apparition, bubble);
+            Assert.False(ghost.OnTouchDownXY(ghost.x, ghost.y));
+            Assert.Equal(GhostForm.Bubble, ghost.Form);
+
+            scene.PopCandyBubble(candy.WholeBody);
+
+            Assert.Equal(GhostForm.Idle, ghost.Form);
+            Assert.Null(ghost.Apparition);
+        }
+
+        [Fact]
+        public void RocketConsumedBubbleDoesNotBlockGhostCycling()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(20, 460)
+                .Rocket(160, 200, impulse: 0f)
+                .Ghost(20, 40)
+                .Build();
+            CandyContext candy = scene.Candy();
+            Ghost ghost = Assert.Single(scene.Ghosts());
+            ghost.ResetToForm(GhostForm.Bubble);
+            _ = Act.BindRocket(scene, candy);
+
+            Bubble consumed = Act.PushBubbleAgainst(scene, candy);
+
+            Assert.True(consumed.popped);
+            Assert.Null(candy.WholeBody.Bubble);
+            Assert.True(ghost.OnTouchDownXY(ghost.x, ghost.y));
+            Assert.Equal(GhostForm.Grab, ghost.Form);
+        }
+
+        private static (Ghost Ghost, List<Bubble> Bubbles, List<Grab> Grabs, List<Bouncer> Bouncers) CreateGhost()
+        {
+            _ = HeadlessGame.Boot();
+            List<Bubble> bubbles = [];
+            List<Grab> grabs = [];
+            List<Bouncer> bouncers = [];
+            Ghost ghost = new Ghost().InitWithPositionPossibleFormsGrabRadiusBouncerAngleBubblesBungeesBouncers(
+                new Vector(100f, 100f),
+                GhostForm.Bubble | GhostForm.Grab | GhostForm.Bouncer,
+                80f,
+                0f,
+                bubbles,
+                grabs,
+                bouncers,
+                null);
+            return (ghost, bubbles, grabs, bouncers);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/GhostOwnershipTests.cs
+++ b/CutTheRopeDX.Tests/GhostOwnershipTests.cs
@@ -69,6 +69,28 @@ namespace CutTheRopeDX.Tests
         }
 
         [Fact]
+        public void BubbleToGrabImmediatelyChangesOwnershipThenRetiresTheOutgoingBubble()
+        {
+            (Ghost ghost, List<Bubble> bubbles, List<Grab> grabs, _) = CreateGhost();
+            ghost.ResetToForm(GhostForm.Bubble);
+            GhostBubble outgoingBubble = Assert.IsType<GhostBubble>(ghost.Apparition);
+
+            ghost.ResetToForm(GhostForm.Grab);
+
+            Assert.Equal(GhostForm.Grab, ghost.Form);
+            GhostGrab currentGrab = Assert.IsType<GhostGrab>(ghost.Apparition);
+            Assert.Same(currentGrab, Assert.Single(grabs));
+            Assert.Same(outgoingBubble, Assert.Single(bubbles));
+
+            outgoingBubble.Update(0.2f);
+            ghost.Update(0f);
+
+            Assert.Empty(bubbles);
+            Assert.Equal(GhostForm.Grab, ghost.Form);
+            Assert.Same(currentGrab, ghost.Apparition);
+        }
+
+        [Fact]
         public void MorphPhaseNamesOutgoingAndIncomingFormsUntilAppearanceFinishes()
         {
             (Ghost ghost, _, _, _) = CreateGhost();
@@ -104,6 +126,61 @@ namespace CutTheRopeDX.Tests
 
             Assert.Equal(GhostForm.Idle, ghost.Form);
             Assert.Null(ghost.Apparition);
+        }
+
+        [Fact]
+        public void PoppedGhostBubbleClearsCandyOwnershipAndRetiresWithoutLeaking()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(20, 460)
+                .Ghost(20, 40)
+                .Build();
+            CandyContext candy = scene.Candy();
+            Ghost ghost = Assert.Single(scene.Ghosts());
+            ghost.ResetToForm(GhostForm.Bubble);
+            Bubble poppedBubble = Act.CaptureInBubble(scene, candy);
+
+            scene.PopCandyBubble(candy.WholeBody);
+
+            Assert.Null(candy.WholeBody.Bubble);
+            Assert.Equal(GhostForm.Idle, ghost.Form);
+            Assert.Null(ghost.Apparition);
+            Assert.Contains(poppedBubble, scene.Bubbles());
+
+            poppedBubble.Update(0.2f);
+            ghost.Update(0f);
+
+            Assert.DoesNotContain(poppedBubble, scene.Bubbles());
+        }
+
+        [Fact]
+        public void CutAutoRopeReturnsGhostToIdleAndRetiresTheGrabAndRope()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(20, 460)
+                .Ghost(20, 40, radius: -1)
+                .Build();
+            Ghost ghost = Assert.Single(scene.Ghosts());
+            ghost.ResetToForm(GhostForm.Grab);
+            GhostGrab outgoingGrab = Assert.IsType<GhostGrab>(ghost.Apparition);
+            Bungee outgoingRope = outgoingGrab.Rope;
+            Assert.NotNull(outgoingRope);
+            Assert.Contains(scene.RegisteredRopes(), entry => entry.Rope == outgoingRope);
+
+            outgoingRope.cut = 0;
+            ghost.Update(0f);
+
+            Assert.Equal(GhostForm.Idle, ghost.Form);
+            Assert.Null(ghost.Apparition);
+
+            outgoingGrab.Update(0.2f);
+            ghost.Update(0f);
+
+            Assert.DoesNotContain(outgoingGrab, scene.Grabs());
+            Assert.Null(outgoingGrab.Rope);
+            Assert.DoesNotContain(scene.RegisteredRopes(), entry => entry.Rope == outgoingRope);
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/Interactions/Scenario.cs
+++ b/CutTheRopeDX.Tests/Interactions/Scenario.cs
@@ -262,13 +262,14 @@ namespace CutTheRopeDX.Tests.Interactions
         /// <summary>Adds a ghost that can morph into a bubble and a grab.</summary>
         /// <param name="x">Level-space X.</param>
         /// <param name="y">Level-space Y.</param>
+        /// <param name="radius">Grab radius, or -1 for an automatically attached rope.</param>
         /// <returns>This scenario.</returns>
-        public Scenario Ghost(int x, int y)
+        public Scenario Ghost(int x, int y, int radius = 80)
         {
             XElement ghost = Node("ghost", x, y);
             ghost.SetAttributeValue("bubble", "true");
             ghost.SetAttributeValue("grab", "true");
-            ghost.SetAttributeValue("radius", Num(80));
+            ghost.SetAttributeValue("radius", Num(radius));
             return Add(ghost);
         }
 

--- a/CutTheRopeDX.Tests/Interactions/Scenario.cs
+++ b/CutTheRopeDX.Tests/Interactions/Scenario.cs
@@ -259,6 +259,19 @@ namespace CutTheRopeDX.Tests.Interactions
             return Add(Node("bubble", x, y));
         }
 
+        /// <summary>Adds a ghost that can morph into a bubble and a grab.</summary>
+        /// <param name="x">Level-space X.</param>
+        /// <param name="y">Level-space Y.</param>
+        /// <returns>This scenario.</returns>
+        public Scenario Ghost(int x, int y)
+        {
+            XElement ghost = Node("ghost", x, y);
+            ghost.SetAttributeValue("bubble", "true");
+            ghost.SetAttributeValue("grab", "true");
+            ghost.SetAttributeValue("radius", Num(80));
+            return Add(ghost);
+        }
+
         /// <summary>Adds a snail.</summary>
         /// <param name="x">Level-space X.</param>
         /// <param name="y">Level-space Y.</param>

--- a/CutTheRopeDX.Tests/Interactions/Scenario.cs
+++ b/CutTheRopeDX.Tests/Interactions/Scenario.cs
@@ -263,14 +263,28 @@ namespace CutTheRopeDX.Tests.Interactions
         /// <param name="x">Level-space X.</param>
         /// <param name="y">Level-space Y.</param>
         /// <param name="radius">Grab radius, or -1 for an automatically attached rope.</param>
+        /// <param name="bouncer">Whether the ghost can also morph into a bouncer.</param>
         /// <returns>This scenario.</returns>
-        public Scenario Ghost(int x, int y, int radius = 80)
+        public Scenario Ghost(int x, int y, int radius = 80, bool bouncer = false)
         {
             XElement ghost = Node("ghost", x, y);
             ghost.SetAttributeValue("bubble", "true");
             ghost.SetAttributeValue("grab", "true");
+            ghost.SetAttributeValue("bouncer", Flag(bouncer));
             ghost.SetAttributeValue("radius", Num(radius));
             return Add(ghost);
+        }
+
+        /// <summary>Adds a directional air pump.</summary>
+        /// <param name="x">Level-space X.</param>
+        /// <param name="y">Level-space Y.</param>
+        /// <param name="angle">Authored pump angle in degrees; -90 blows upward.</param>
+        /// <returns>This scenario.</returns>
+        public Scenario Pump(int x, int y, float angle = -90f)
+        {
+            XElement pump = Node("pump", x, y);
+            pump.SetAttributeValue("angle", Num(angle));
+            return Add(pump);
         }
 
         /// <summary>Adds a snail.</summary>

--- a/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
+++ b/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
@@ -71,6 +71,14 @@ namespace CutTheRopeDX.Tests.Interactions
             return Field<List<Ghost>>(scene, "ghosts");
         }
 
+        /// <summary>All air pumps.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns>The pump list.</returns>
+        public static List<Pump> Pumps(this GameScene scene)
+        {
+            return Field<List<Pump>>(scene, "pumps");
+        }
+
         /// <summary>All rockets.</summary>
         /// <param name="scene">Scene to read.</param>
         /// <returns>The rocket list.</returns>

--- a/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
+++ b/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
@@ -55,6 +55,14 @@ namespace CutTheRopeDX.Tests.Interactions
             return Field<List<Bubble>>(scene, "bubbles");
         }
 
+        /// <summary>All ghosts.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns>The ghost list.</returns>
+        public static List<Ghost> Ghosts(this GameScene scene)
+        {
+            return Field<List<Ghost>>(scene, "ghosts");
+        }
+
         /// <summary>All rockets.</summary>
         /// <param name="scene">Scene to read.</param>
         /// <returns>The rocket list.</returns>

--- a/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
+++ b/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
@@ -47,6 +47,14 @@ namespace CutTheRopeDX.Tests.Interactions
             return Field<List<Grab>>(scene, "bungees");
         }
 
+        /// <summary>All ropes currently registered with the scene.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns>The registered rope entries.</returns>
+        public static IReadOnlyList<RopeEntry> RegisteredRopes(this GameScene scene)
+        {
+            return Field<RopeRegistry>(scene, "ropes").All;
+        }
+
         /// <summary>All free bubbles loaded into the scene.</summary>
         /// <param name="scene">Scene to read.</param>
         /// <returns>The bubble list.</returns>

--- a/CutTheRopeDX/GameMain/Bungee.cs
+++ b/CutTheRopeDX/GameMain/Bungee.cs
@@ -1071,6 +1071,16 @@ namespace CutTheRopeDX.GameMain
             {
                 if (parts != null)
                 {
+                    if (!ownsTail && tail != null)
+                    {
+                        foreach (ConstraintedPoint part in parts)
+                        {
+                            if (part != tail)
+                            {
+                                tail.RemoveConstraint(part);
+                            }
+                        }
+                    }
                     foreach (ConstraintedPoint part in parts)
                     {
                         bool ownsPart = (part == bungeeAnchor && ownsAnchor) || (part == tail && ownsTail) || (part != bungeeAnchor && part != tail);

--- a/CutTheRopeDX/GameMain/GameScene.CandyRemoval.cs
+++ b/CutTheRopeDX/GameMain/GameScene.CandyRemoval.cs
@@ -194,7 +194,7 @@ namespace CutTheRopeDX.GameMain
             }
 
             GameObject released = body.Bubble;
-            EnableGhostCycleForBubble(released);
+            ReleaseGhostForBubble(released);
             ReleasePendingSecondGhostBubbleForBody(body);
 
             if (released is Bubble bubble)
@@ -220,7 +220,7 @@ namespace CutTheRopeDX.GameMain
 
         private void CancelParkedGhostBubble()
         {
-            parkedGhostBubble = parkedGhostBubble?.ReplaceWith(null, EnableGhostCycleForBubble);
+            parkedGhostBubble = parkedGhostBubble?.ReplaceWith(null, ReleaseGhostForBubble);
         }
     }
 }

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -102,6 +102,15 @@ namespace CutTheRopeDX.GameMain
         }
 
         /// <summary>
+        /// Whether a candy body or the merged-candy parking ticket currently owns a bubble.
+        /// </summary>
+        internal bool IsBubbleClaimedByCandy(GameObject bubbleObj)
+        {
+            return CandyBodyForBubbleOrNull(bubbleObj) != null
+                || parkedGhostBubble?.Bubble == bubbleObj;
+        }
+
+        /// <summary>
         /// The point the camera follows: the primary candy's first active body, which is its left
         /// half while it is split and its whole body otherwise. Falls back to the whole body's point
         /// when the primary has no active body at all, so the camera never loses its target.
@@ -629,7 +638,7 @@ namespace CutTheRopeDX.GameMain
             }
 
             GameObject popped = body.Bubble;
-            EnableGhostCycleForBubble(popped);
+            ReleaseGhostForBubble(popped);
 
             // A merge can fold both halves' ghost bubbles onto the merged candy, parking the second
             // one behind the first. Popping the survivor releases the ghost that was parked with it.
@@ -814,22 +823,6 @@ namespace CutTheRopeDX.GameMain
         }
 
         /// <summary>
-        /// Flags every ghost so its captured-candy reacts to a candy break this frame.
-        /// </summary>
-        private void MarkGhostsCandyBreak()
-        {
-            if (ghosts == null)
-            {
-                return;
-            }
-            foreach (object objGhost in ghosts)
-            {
-                Ghost ghost = (Ghost)objGhost;
-                _ = (ghost?.candyBreak = true);
-            }
-        }
-
-        /// <summary>
         /// Schedules the loss sequence after a delay (e.g. while a candy-break animation plays) and
         /// immediately marks the outcome transition active. A destroyed candy is removed at once but
         /// defers <see cref="GameLost"/>; without marking the transition, another candy eaten during
@@ -845,8 +838,8 @@ namespace CutTheRopeDX.GameMain
         /// <summary>
         /// Destroys one candy body that touched a hazard (spike, axe, ...): pops its bubble, removes
         /// it as a hazard loss, releases its ropes, detaches its carriers, schedules the loss, and
-        /// flags ghosts. A split half loses only itself; its sibling keeps playing until the
-        /// scheduled loss lands.
+        /// begins the authoritative loss transition. A split half loses only itself; its sibling
+        /// keeps playing until the scheduled loss lands.
         /// </summary>
         /// <param name="body">The body being destroyed.</param>
         private void BreakCandyBody(CandyBody body)
@@ -864,7 +857,6 @@ namespace CutTheRopeDX.GameMain
             {
                 ScheduleGameLost(0.3f);
             }
-            MarkGhostsCandyBreak();
         }
 
         /// <summary>
@@ -1107,48 +1099,40 @@ namespace CutTheRopeDX.GameMain
         }
 
         /// <summary>
-        /// Re-enables ghost cycling for any ghost that owns the specified bubble.
+        /// Returns the ghost that owns the specified apparition bubble.
         /// </summary>
-        /// <param name="bubbleObj">Bubble object whose owning ghost should resume cycling.</param>
-        private void EnableGhostCycleForBubble(GameObject bubbleObj)
+        private Ghost GhostForBubble(GameObject bubbleObj)
         {
             if (bubbleObj is not Bubble bubble || ghosts == null)
             {
-                return;
+                return null;
             }
             foreach (object obj in ghosts)
             {
                 Ghost ghost = (Ghost)obj;
-                if (ghost != null && ghost.bubble == bubble)
+                if (ghost?.OwnsBubble(bubble) == true)
                 {
-                    ghost.cyclingEnabled = true;
-                    ghost.ResetToState(1);
+                    return ghost;
                 }
             }
+            return null;
         }
 
         /// <summary>
-        /// Disables ghost cycling for any ghost that owns the specified bubble.
+        /// Releases the ghost that owns a captured or parked apparition bubble.
         /// </summary>
-        /// <param name="bubbleObj">Bubble object whose owning ghost should stop cycling.</param>
-        /// <returns><see langword="true"/> if at least one ghost was affected; otherwise, <see langword="false"/>.</returns>
-        private bool DisableGhostCycleForBubble(GameObject bubbleObj)
+        private void ReleaseGhostForBubble(GameObject bubbleObj)
         {
-            if (bubbleObj is not Bubble bubble || ghosts == null)
+            if (bubbleObj is Bubble bubble)
             {
-                return false;
+                _ = GhostForBubble(bubble)?.ReleaseBubble(bubble);
             }
-            bool affected = false;
-            foreach (object obj in ghosts)
-            {
-                Ghost ghost = (Ghost)obj;
-                if (ghost != null && ghost.bubble == bubble)
-                {
-                    ghost.cyclingEnabled = false;
-                    affected = true;
-                }
-            }
-            return affected;
+        }
+
+        /// <summary>Whether the specified bubble is the current apparition of a ghost.</summary>
+        private bool IsGhostApparitionBubble(GameObject bubbleObj)
+        {
+            return GhostForBubble(bubbleObj) != null;
         }
     }
 }

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -358,8 +358,8 @@ namespace CutTheRopeDX.GameMain
                         CancelParkedGhostBubble();
                         if (leftBubble != null || rightBubble != null)
                         {
-                            bool leftHasGhost = leftBubble != null && DisableGhostCycleForBubble(leftBubble);
-                            bool rightHasGhost = rightBubble != null && DisableGhostCycleForBubble(rightBubble);
+                            bool leftHasGhost = leftBubble != null && IsGhostApparitionBubble(leftBubble);
+                            bool rightHasGhost = rightBubble != null && IsGhostApparitionBubble(rightBubble);
                             if (leftHasGhost && rightHasGhost)
                             {
                                 mergedBody.Bubble = leftBubble;
@@ -376,8 +376,8 @@ namespace CutTheRopeDX.GameMain
                             else
                             {
                                 mergedBody.Bubble = leftBubble ?? rightBubble;
-                                EnableGhostCycleForBubble(leftBubble);
-                                EnableGhostCycleForBubble(rightBubble);
+                                ReleaseGhostForBubble(leftBubble);
+                                ReleaseGhostForBubble(rightBubble);
                             }
                             mergedBody.BubbleHasGhost = leftHasGhost || rightHasGhost;
                             mergedBody.BubbleAnimation.visible = !mergedBody.BubbleHasGhost;
@@ -577,11 +577,11 @@ namespace CutTheRopeDX.GameMain
                     if (body.Bubble != null && body.Bubble != bubble3)
                     {
                         PopBubbleAtXY(bubble3.x, bubble3.y);
-                        EnableGhostCycleForBubble(body.Bubble);
+                        ReleaseGhostForBubble(body.Bubble);
                         ReleasePendingSecondGhostBubbleForBody(body);
                     }
 
-                    bool hasGhost = DisableGhostCycleForBubble(bubble3);
+                    bool hasGhost = IsGhostApparitionBubble(bubble3);
                     body.Bubble = bubble3;
                     body.BubbleHasGhost = hasGhost;
                     if (ctx.LightBulb != null)

--- a/CutTheRopeDX/GameMain/Ghost.cs
+++ b/CutTheRopeDX/GameMain/Ghost.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using CutTheRopeDX.Framework;
@@ -16,7 +17,7 @@ namespace CutTheRopeDX.GameMain
         /// Initializes a ghost and its morphing visuals at a level position.
         /// </summary>
         /// <param name="position">World position of the ghost.</param>
-        /// <param name="possibleStateMask">Bitmask of ghost states that this ghost may cycle through.</param>
+        /// <param name="possibleForms">Ghost forms that this ghost may cycle through.</param>
         /// <param name="grabRadius">Grab radius used when the ghost morphs into a grab.</param>
         /// <param name="bouncerAngle">Bouncer angle used when the ghost morphs into a bouncer.</param>
         /// <param name="bubbles">Scene bubble collection that receives ghost-created bubbles.</param>
@@ -24,9 +25,9 @@ namespace CutTheRopeDX.GameMain
         /// <param name="bouncers">Scene bouncer collection that receives ghost-created bouncers.</param>
         /// <param name="owner">Owning game scene.</param>
         /// <returns>The initialized ghost.</returns>
-        public Ghost InitWithPositionPossibleStatesMaskGrabRadiusBouncerAngleBubblesBungeesBouncers(
+        public Ghost InitWithPositionPossibleFormsGrabRadiusBouncerAngleBubblesBungeesBouncers(
             Vector position,
-            int possibleStateMask,
+            GhostForm possibleForms,
             float grabRadius,
             float bouncerAngle,
             List<Bubble> bubbles,
@@ -35,8 +36,11 @@ namespace CutTheRopeDX.GameMain
             GameScene owner)
         {
             hostScene = owner;
-            possibleStatesMask = possibleStateMask | 1;
-            ghostState = 1;
+            this.possibleForms = possibleForms | GhostForm.Idle;
+            Form = GhostForm.Idle;
+            Apparition = null;
+            MorphPhase = null;
+            retiringApparitions.Clear();
             this.bouncerAngle = bouncerAngle;
             this.grabRadius = grabRadius;
             gsBubbles = bubbles;
@@ -90,11 +94,6 @@ namespace CutTheRopeDX.GameMain
             ghostImageFace.AddTimelinewithID(faceFloat, 13);
             ghostImageFace.PlayTimeline(13);
 
-            bubble = null;
-            grab = null;
-            bouncer = null;
-            cyclingEnabled = true;
-            candyBreak = false;
             return this;
         }
 
@@ -103,9 +102,9 @@ namespace CutTheRopeDX.GameMain
         {
             if (disposing)
             {
-                bubble = null;
-                grab = null;
-                bouncer = null;
+                Apparition = null;
+                MorphPhase = null;
+                retiringApparitions.Clear();
                 ghostImageBody = null;
                 ghostImageFace = null;
                 ghostImage = null;
@@ -118,113 +117,51 @@ namespace CutTheRopeDX.GameMain
         /// <inheritdoc />
         public override void Update(float delta)
         {
-            if (bubble != null && bubble.GetCurrentTimelineIndex() == 11 && bubble.GetCurrentTimeline().state == Timeline.TimelineState.TIMELINE_STOPPED)
-            {
-                _ = gsBubbles.Remove(bubble);
-                bubble = null;
-            }
-            if (bouncer != null && bouncer.GetCurrentTimelineIndex() == 11 && bouncer.GetCurrentTimeline().state == Timeline.TimelineState.TIMELINE_STOPPED)
-            {
-                _ = gsBouncers.Remove(bouncer);
-                bouncer = null;
-            }
-            if (grab != null && grab.GetCurrentTimelineIndex() == 11 && grab.GetCurrentTimeline().state == Timeline.TimelineState.TIMELINE_STOPPED)
-            {
-                hostScene?.UnregisterRope(grab.Rope);
-                grab.DestroyRope();
-                _ = gsBungees.Remove(grab);
-                grab = null;
-            }
+            RetireFinishedApparitions();
             base.Update(delta);
-            if (grab != null && grab.Rope != null && grab.Rope.cut != -1 && grab.GetCurrentTimelineIndex() == 10)
+            CompleteMorphIfFinished();
+            if (Apparition is GhostGrab grab
+                && grab.Rope != null
+                && grab.Rope.cut != -1
+                && grab.GetCurrentTimelineIndex() == 10)
             {
-                cyclingEnabled = true;
-                ResetToState(1);
+                ResetToForm(GhostForm.Idle);
             }
         }
 
         /// <summary>
         /// Morphs the ghost into a specific allowed state.
         /// </summary>
-        /// <param name="newState">Ghost state bit to activate.</param>
-        public void ResetToState(int newState)
+        /// <param name="newForm">Ghost form to activate.</param>
+        public void ResetToForm(GhostForm newForm)
         {
-            if ((newState & possibleStatesMask) == 0)
+            if (!IsSingleForm(newForm) || (newForm & possibleForms) == 0)
             {
                 return;
             }
-            ghostState = newState;
-            Timeline morphOut = new Timeline().InitWithMaxKeyFramesOnTrack(2);
-            morphOut.AddKeyFrame(KeyFrame.MakeColor(RGBAColor.solidOpaqueRGBA, KeyFrame.TransitionType.FRAME_TRANSITION_IMMEDIATE, 0));
-            morphOut.AddKeyFrame(KeyFrame.MakeColor(RGBAColor.transparentRGBA, KeyFrame.TransitionType.FRAME_TRANSITION_LINEAR, GHOST_MORPHING_DISAPPEAR_TIME));
-            morphOut.delegateTimelineDelegate = this;
-            if (bubble != null)
+
+            GhostForm outgoingForm = Form;
+            IGhostApparition outgoing = Apparition;
+            MorphPhase = new GhostMorphPhase(outgoingForm, newForm);
+            Apparition = null;
+            if (outgoing != null)
             {
-                if (bubble.GetCurrentTimelineIndex() == 11)
-                {
-                    _ = gsBubbles.Remove(bubble);
-                    bubble = null;
-                }
-                else
-                {
-                    bubble.AddTimelinewithID(morphOut, 11);
-                    bubble.PlayTimeline(11);
-                    bubble.popped = true;
-                }
+                BeginRetiringApparition(outgoing);
+                retiringApparitions.Add(new RetiringGhostApparition(outgoingForm, newForm, outgoing));
             }
-            if (grab != null)
-            {
-                Bungee rope = grab.Rope;
-                if (rope != null)
-                {
-                    grab.Rope.forceWhite = true;
-                    rope.cutTime = GHOST_MORPHING_APPEAR_TIME;
-                    if (rope.cut == -1)
-                    {
-                        rope.cut = 0;
-                    }
-                }
-                if (grab.GetCurrentTimelineIndex() == 11)
-                {
-                    hostScene?.UnregisterRope(grab.Rope);
-                    grab.DestroyRope();
-                    _ = gsBungees.Remove(grab);
-                    grab = null;
-                }
-                else
-                {
-                    grab.AddTimelinewithID(morphOut, 11);
-                    grab.PlayTimeline(11);
-                }
-            }
-            if (bouncer != null)
-            {
-                if (bouncer.GetCurrentTimelineIndex() == 11)
-                {
-                    _ = gsBouncers.Remove(bouncer);
-                    bouncer = null;
-                }
-                else
-                {
-                    bouncer.AddTimelinewithID(morphOut, 11);
-                    bouncer.PlayTimeline(11);
-                }
-            }
-            if (ghostImage.GetCurrentTimelineIndex() == 10)
+            else if (ghostImage.GetCurrentTimelineIndex() == 10)
             {
                 ghostImage.PlayTimeline(11);
             }
 
-            Timeline morphIn = new Timeline().InitWithMaxKeyFramesOnTrack(2);
-            morphIn.AddKeyFrame(KeyFrame.MakeColor(RGBAColor.transparentRGBA, KeyFrame.TransitionType.FRAME_TRANSITION_IMMEDIATE, 0));
-            morphIn.AddKeyFrame(KeyFrame.MakeColor(RGBAColor.solidOpaqueRGBA, KeyFrame.TransitionType.FRAME_TRANSITION_LINEAR, GHOST_MORPHING_APPEAR_TIME));
-
-            switch (ghostState)
+            Form = newForm;
+            Timeline morphIn = CreateMorphTimeline(appearing: true);
+            switch (newForm)
             {
-                case 1:
+                case GhostForm.Idle:
                     ghostImage.PlayTimeline(10);
                     break;
-                case 2:
+                case GhostForm.Bubble:
                     {
                         GhostBubble ghostBubble = GhostBubble.CreateWithResIDQuad(Resources.Img.ObjBubble, RND_RANGE(1, 3));
                         ghostBubble.DoRestoreCutTransparency();
@@ -237,7 +174,7 @@ namespace CutTheRopeDX.GameMain
                         image.DoRestoreCutTransparency();
                         image.parentAnchor = image.anchor = 18;
                         _ = ghostBubble.AddChild(image);
-                        bubble = ghostBubble;
+                        Apparition = ghostBubble;
                         gsBubbles.Add(ghostBubble);
                         ghostBubble.passColorToChilds = true;
                         ghostBubble.AddTimelinewithID(morphIn, 10);
@@ -245,10 +182,8 @@ namespace CutTheRopeDX.GameMain
                         ghostBubble.AddSupportingCloudsTimelines();
                         break;
                     }
-                case 3:
-                    break;
-                case 4:
-                    grab = new GhostGrab().InitWithPosition(x, y);
+                case GhostForm.Grab:
+                    GhostGrab grab = new GhostGrab().InitWithPosition(x, y);
                     grab.Wheel = null;
                     grab.Spider = null;
                     // A ghost apparition is only ever a plain or auto-radius hook, so it goes
@@ -284,17 +219,20 @@ namespace CutTheRopeDX.GameMain
                         }
                     }
                     gsBungees.Add(grab);
+                    Apparition = grab;
                     grab.AddTimelinewithID(morphIn, 10);
                     grab.PlayTimeline(10);
                     break;
-                case 8:
-                    bouncer = new GhostBouncer().InitWithPosXYWidthAndAngle(x, y, 1, bouncerAngle);
+                case GhostForm.Bouncer:
+                    GhostBouncer bouncer = (GhostBouncer)new GhostBouncer().InitWithPosXYWidthAndAngle(x, y, 1, bouncerAngle);
                     gsBouncers.Add(bouncer);
+                    Apparition = bouncer;
                     bouncer.AddTimelinewithID(morphIn, 10);
                     bouncer.PlayTimeline(10);
                     break;
+                case GhostForm.None:
                 default:
-                    break;
+                    throw new InvalidOperationException($"Unsupported ghost form {newForm}.");
             }
 
             morphingBubbles.StartSystem(GHOST_MORPHING_BUBBLES_COUNT);
@@ -307,38 +245,59 @@ namespace CutTheRopeDX.GameMain
         public void ResetToNextState()
         {
             // No non-idle states available; nothing to cycle to.
-            if ((possibleStatesMask & ~1) == 0)
+            if ((possibleForms & ~GhostForm.Idle) == 0)
             {
                 return;
             }
 
-            int state = ghostState;
+            GhostForm nextForm = Form;
             do
             {
-                state <<= 1;
-                if (state == 16)
+                nextForm = (GhostForm)((int)nextForm << 1);
+                if ((int)nextForm == 16)
                 {
-                    state = 2;
+                    nextForm = GhostForm.Bubble;
                 }
             }
-            while ((state & possibleStatesMask) == 0);
+            while ((nextForm & possibleForms) == 0);
 
             // With only 1 non-idle property, the cycle wraps back to the current state.
-            // Calling ResetToState would orphan the existing object in its list before
-            // its disappear animation completes, so bail out instead.
-            if (state == ghostState)
+            // Re-entering the only form would produce a visual puff without changing behavior,
+            // so bail out instead.
+            if (nextForm == Form)
             {
                 return;
             }
 
-            ResetToState(state);
+            ResetToForm(nextForm);
+        }
+
+        /// <summary>Whether this ghost's current apparition is <paramref name="candidate"/>.</summary>
+        public bool OwnsBubble(Bubble candidate)
+        {
+            return Apparition is GhostBubble bubble && ReferenceEquals(bubble, candidate);
+        }
+
+        /// <summary>
+        /// Releases the exact ghost bubble claimed by candy and returns the ghost to its idle form.
+        /// </summary>
+        /// <returns><see langword="true"/> when this ghost owned the supplied bubble.</returns>
+        public bool ReleaseBubble(Bubble candidate)
+        {
+            if (!OwnsBubble(candidate))
+            {
+                return false;
+            }
+
+            ResetToForm(GhostForm.Idle);
+            return true;
         }
 
         /// <inheritdoc />
         public override bool OnTouchDownXY(float tx, float ty)
         {
             float distance = VectLength(VectSub(Vect(tx, ty), Vect(x, y)));
-            if (cyclingEnabled && !candyBreak && distance < GHOST_TOUCH_RADIUS)
+            if (!IsBubbleCaptured && distance < GHOST_TOUCH_RADIUS)
             {
                 ResetToNextState();
                 return true;
@@ -380,6 +339,104 @@ namespace CutTheRopeDX.GameMain
             }
         }
 
+        private bool IsBubbleCaptured => Apparition is GhostBubble bubble
+            && hostScene?.IsBubbleClaimedByCandy(bubble) == true;
+
+        private static bool IsSingleForm(GhostForm candidate)
+        {
+            int value = (int)candidate;
+            return value > 0 && (value & (value - 1)) == 0;
+        }
+
+        private static Timeline CreateMorphTimeline(bool appearing)
+        {
+            Timeline timeline = new Timeline().InitWithMaxKeyFramesOnTrack(2);
+            timeline.AddKeyFrame(KeyFrame.MakeColor(
+                appearing ? RGBAColor.transparentRGBA : RGBAColor.solidOpaqueRGBA,
+                KeyFrame.TransitionType.FRAME_TRANSITION_IMMEDIATE,
+                0));
+            timeline.AddKeyFrame(KeyFrame.MakeColor(
+                appearing ? RGBAColor.solidOpaqueRGBA : RGBAColor.transparentRGBA,
+                KeyFrame.TransitionType.FRAME_TRANSITION_LINEAR,
+                appearing ? GHOST_MORPHING_APPEAR_TIME : GHOST_MORPHING_DISAPPEAR_TIME));
+            return timeline;
+        }
+
+        private void BeginRetiringApparition(IGhostApparition outgoing)
+        {
+            if (outgoing is GhostBubble bubble)
+            {
+                bubble.popped = true;
+            }
+            else if (outgoing is GhostGrab grab && grab.Rope != null)
+            {
+                grab.Rope.forceWhite = true;
+                grab.Rope.cutTime = GHOST_MORPHING_APPEAR_TIME;
+                if (grab.Rope.cut == -1)
+                {
+                    grab.Rope.cut = 0;
+                }
+            }
+
+            BaseElement element = outgoing.Element;
+            Timeline morphOut = CreateMorphTimeline(appearing: false);
+            morphOut.delegateTimelineDelegate = this;
+            element.AddTimelinewithID(morphOut, 11);
+            element.PlayTimeline(11);
+        }
+
+        private void RetireFinishedApparitions()
+        {
+            for (int i = retiringApparitions.Count - 1; i >= 0; i--)
+            {
+                RetiringGhostApparition retirement = retiringApparitions[i];
+                BaseElement element = retirement.Apparition.Element;
+                if (element.GetCurrentTimelineIndex() != 11
+                    || element.GetCurrentTimeline()?.state != Timeline.TimelineState.TIMELINE_STOPPED)
+                {
+                    continue;
+                }
+
+                RetireApparition(retirement.Apparition);
+                retiringApparitions.RemoveAt(i);
+            }
+        }
+
+        private void RetireApparition(IGhostApparition retired)
+        {
+            switch (retired)
+            {
+                case GhostBubble bubble:
+                    _ = gsBubbles.Remove(bubble);
+                    break;
+                case GhostGrab grab:
+                    hostScene?.UnregisterRope(grab.Rope);
+                    grab.DestroyRope();
+                    _ = gsBungees.Remove(grab);
+                    break;
+                case GhostBouncer bouncer:
+                    _ = gsBouncers.Remove(bouncer);
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unsupported ghost apparition {retired.GetType().Name}.");
+            }
+        }
+
+        private void CompleteMorphIfFinished()
+        {
+            if (MorphPhase == null)
+            {
+                return;
+            }
+
+            BaseElement incoming = Apparition?.Element ?? ghostImage;
+            if (incoming.GetCurrentTimelineIndex() == 10
+                && incoming.GetCurrentTimeline()?.state == Timeline.TimelineState.TIMELINE_STOPPED)
+            {
+                MorphPhase = null;
+            }
+        }
+
         /// <summary>Duration of the ghost morph-in fade, in seconds.</summary>
         private const float GHOST_MORPHING_APPEAR_TIME = 0.36f;
 
@@ -392,29 +449,17 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Touch radius used for cycling ghost state.</summary>
         private const float GHOST_TOUCH_RADIUS = 80f;
 
-        /// <summary>Current ghost state bit.</summary>
-        public int ghostState;
+        /// <summary>Authoritative current form.</summary>
+        internal GhostForm Form { get; private set; }
 
-        /// <summary>Bubble object currently owned by the ghost state.</summary>
-        public Bubble bubble;
+        /// <summary>The one current non-idle apparition, if any.</summary>
+        internal IGhostApparition Apparition { get; private set; }
 
-        /// <summary>Grab object currently owned by the ghost state.</summary>
-        public Grab grab;
-
-        /// <summary>Bouncer object currently owned by the ghost state.</summary>
-        public Bouncer bouncer;
-
-        /// <summary>Whether touch input may cycle this ghost to another state.</summary>
-        public bool cyclingEnabled;
+        /// <summary>The outgoing/incoming form pair while the newest morph-in is active.</summary>
+        internal GhostMorphPhase? MorphPhase { get; private set; }
 
         /// <summary>Grab radius used when the ghost morphs into a grab.</summary>
         public float grabRadius;
-
-        /// <summary>Whether the candy has broken and should block ghost cycling.</summary>
-        public bool candyBreak;
-
-        /// <summary>Bitmask of ghost states this ghost may cycle through.</summary>
-        public int possibleStatesMask;
 
         /// <summary>Bouncer angle used when the ghost morphs into a bouncer.</summary>
         public float bouncerAngle;
@@ -445,5 +490,11 @@ namespace CutTheRopeDX.GameMain
 
         /// <summary>Owning game scene used for ghost-created rope anchors.</summary>
         private GameScene hostScene;
+
+        /// <summary>Allowed forms for this ghost, including idle.</summary>
+        private GhostForm possibleForms;
+
+        /// <summary>Outgoing apparitions waiting for safe post-iteration retirement.</summary>
+        private readonly List<RetiringGhostApparition> retiringApparitions = [];
     }
 }

--- a/CutTheRopeDX/GameMain/GhostBouncer.cs
+++ b/CutTheRopeDX/GameMain/GhostBouncer.cs
@@ -11,6 +11,9 @@ namespace CutTheRopeDX.GameMain
     internal sealed class GhostBouncer : Bouncer, IGhostApparition
     {
         /// <inheritdoc />
+        BaseElement IGhostApparition.Element => this;
+
+        /// <inheritdoc />
         public override Bouncer InitWithPosXYWidthAndAngle(float px, float py, int width, float angle)
         {
             if (base.InitWithPosXYWidthAndAngle(px, py, width, angle) != null)

--- a/CutTheRopeDX/GameMain/GhostBubble.cs
+++ b/CutTheRopeDX/GameMain/GhostBubble.cs
@@ -8,6 +8,9 @@ namespace CutTheRopeDX.GameMain
     /// </summary>
     internal sealed class GhostBubble : Bubble, IGhostApparition
     {
+        /// <inheritdoc />
+        BaseElement IGhostApparition.Element => this;
+
         /// <summary>
         /// Creates a ghost bubble from a texture.
         /// </summary>

--- a/CutTheRopeDX/GameMain/GhostForm.cs
+++ b/CutTheRopeDX/GameMain/GhostForm.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>The mutually exclusive forms a ghost can present.</summary>
+    [Flags]
+    internal enum GhostForm
+    {
+        None = 0,
+        Idle = 1,
+        Bubble = 2,
+        Grab = 4,
+        Bouncer = 8
+    }
+
+    /// <summary>Identifies the forms on the two sides of the current morph.</summary>
+    internal readonly record struct GhostMorphPhase(GhostForm Outgoing, GhostForm Incoming);
+
+    /// <summary>Owns an outgoing apparition until its disappearance timeline has finished.</summary>
+    internal sealed record RetiringGhostApparition(
+        GhostForm Outgoing,
+        GhostForm Incoming,
+        IGhostApparition Apparition);
+}

--- a/CutTheRopeDX/GameMain/GhostGrab.cs
+++ b/CutTheRopeDX/GameMain/GhostGrab.cs
@@ -12,6 +12,9 @@ namespace CutTheRopeDX.GameMain
     /// </summary>
     internal sealed class GhostGrab : Grab, IGhostApparition
     {
+        /// <inheritdoc />
+        BaseElement IGhostApparition.Element => this;
+
         /// <summary>
         /// Initializes the ghost grab at a level position and creates its supporting cloud visuals.
         /// </summary>

--- a/CutTheRopeDX/GameMain/IGhostApparition.cs
+++ b/CutTheRopeDX/GameMain/IGhostApparition.cs
@@ -1,3 +1,5 @@
+using CutTheRopeDX.Framework.Visual;
+
 namespace CutTheRopeDX.GameMain
 {
     /// <summary>
@@ -12,5 +14,7 @@ namespace CutTheRopeDX.GameMain
     /// </remarks>
     internal interface IGhostApparition
     {
+        /// <summary>Visual element whose morph timeline controls this apparition's lifetime.</summary>
+        BaseElement Element { get; }
     }
 }

--- a/CutTheRopeDX/GameMain/LoadObjects/LoadGhosts.cs
+++ b/CutTheRopeDX/GameMain/LoadObjects/LoadGhosts.cs
@@ -28,10 +28,12 @@ namespace CutTheRopeDX.GameMain
             _ = bool.TryParse(xmlNode.Attribute("grab")?.Value, out bool useGrab);
             _ = bool.TryParse(xmlNode.Attribute("bubble")?.Value, out bool useBubble);
             _ = bool.TryParse(xmlNode.Attribute("bouncer")?.Value, out bool useBouncer);
-            int possibleStatesMask = (useBouncer ? 8 : 0) | (useBubble ? 2 : 0) | (useGrab ? 4 : 0);
-            Ghost ghost = new Ghost().InitWithPositionPossibleStatesMaskGrabRadiusBouncerAngleBubblesBungeesBouncers(
+            GhostForm possibleForms = (useBouncer ? GhostForm.Bouncer : GhostForm.None)
+                | (useBubble ? GhostForm.Bubble : GhostForm.None)
+                | (useGrab ? GhostForm.Grab : GhostForm.None);
+            Ghost ghost = new Ghost().InitWithPositionPossibleFormsGrabRadiusBouncerAngleBubblesBungeesBouncers(
                 Vect(px, py),
-                possibleStatesMask,
+                possibleForms,
                 grabRadius,
                 bouncerAngle,
                 bubbles,


### PR DESCRIPTION
## Description

Consolidate the ghost's redundant form state into one authoritative `GhostForm` and one current `IGhostApparition`.

Ghosts now act as morphing owners around the existing bubble, grab, and bouncer implementations instead of maintaining separate nullable references and synchronization flags.

## What's changed

- Replace `ghostState`, `bubble`, `grab`, and `bouncer` with:
  - one authoritative `GhostForm`
  - one current `IGhostApparition`
  - an explicit outgoing/incoming morph phase
- Track outgoing apparitions until their fade-out finishes, preserving overlapping morph animations.
- Centralize apparition registration and retirement.
- Derive captured-bubble state from authoritative candy and parked-bubble ownership.
- Remove the redundant `cyclingEnabled` and `candyBreak` fields.
- Reuse existing `Bubble`, `Grab`, and `Bouncer` mechanics through ghost-specific presentation subclasses.
- Ensure rocket-consumed ghost bubbles remain cyclable.
- Use typed `GhostForm` values during level loading.