### PR TITLE
refactor: Make level outcome an atomic state machine, allow skipping win/loss cutscenes

### DIFF
--- a/CutTheRopeDX.Tests/GameControllerInputTests.cs
+++ b/CutTheRopeDX.Tests/GameControllerInputTests.cs
@@ -58,9 +58,8 @@ namespace CutTheRopeDX.Tests
             {
                 foreach (GameControllerOverlayMode overlay in System.Enum.GetValues<GameControllerOverlayMode>())
                 {
-                    yield return [(int)input, (int)overlay, (int)RestartPhase.FadingOut, false];
-                    yield return [(int)input, (int)overlay, (int)RestartPhase.FadingIn, false];
-                    yield return [(int)input, (int)overlay, (int)RestartPhase.Playing, true];
+                    yield return [(int)input, (int)overlay, (int)RestartPhase.FadingOut];
+                    yield return [(int)input, (int)overlay, (int)RestartPhase.FadingIn];
                 }
             }
         }
@@ -78,17 +77,15 @@ namespace CutTheRopeDX.Tests
                     (GameControllerInputKind)input,
                     (GameControllerOverlayMode)overlay,
                     RestartPhase.Playing,
-                    outcomeTransitionActive: false,
                     resultExitAllowed: true));
         }
 
         [Theory]
         [MemberData(nameof(GatedInputCases))]
-        public void ResolveIgnoresInputDuringRestartOrOutcomeTransition(
+        public void ResolveIgnoresInputDuringRestart(
             int input,
             int overlay,
-            int restartPhase,
-            bool outcomeTransitionActive)
+            int restartPhase)
         {
             Assert.Equal(
                 GameControllerInputCommand.Ignore,
@@ -96,7 +93,6 @@ namespace CutTheRopeDX.Tests
                     (GameControllerInputKind)input,
                     (GameControllerOverlayMode)overlay,
                     (RestartPhase)restartPhase,
-                    outcomeTransitionActive,
                     resultExitAllowed: true));
         }
 
@@ -109,7 +105,6 @@ namespace CutTheRopeDX.Tests
                     GameControllerInputKind.Back,
                     GameControllerOverlayMode.Results,
                     RestartPhase.Playing,
-                    outcomeTransitionActive: false,
                     resultExitAllowed: false));
         }
 
@@ -213,7 +208,7 @@ namespace CutTheRopeDX.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void BackAndMenuAreIgnoredDuringOutcomeTransition(bool useBack)
+        public void BackAndMenuOpenPauseDuringOutcomeTransition(bool useBack)
         {
             (GameController controller, GameScene scene) = Load();
             HeadlessGame.StepFrames(scene, 60);
@@ -223,8 +218,8 @@ namespace CutTheRopeDX.Tests
                 ? controller.BackButtonPressed()
                 : controller.MenuButtonPressed();
 
-            Assert.True(scene.updateable);
-            Assert.False(PauseMenu(controller).IsEnabled());
+            Assert.False(scene.updateable);
+            Assert.True(PauseMenu(controller).IsEnabled());
             Assert.Equal(GameController.EXIT_CODE_FROM_PAUSE_MENU, controller.exitCode);
         }
 
@@ -275,7 +270,7 @@ namespace CutTheRopeDX.Tests
         [InlineData((int)GameControllerInputKind.Back)]
         [InlineData((int)GameControllerInputKind.Menu)]
         [InlineData((int)GameControllerInputKind.PauseButton)]
-        public void EveryPauseInputIsIgnoredDuringOutcomeTransition(int input)
+        public void EveryPauseInputOpensPauseDuringOutcomeTransition(int input)
         {
             (GameController controller, GameScene scene) = Load();
             HeadlessGame.StepFrames(scene, 60);
@@ -283,9 +278,9 @@ namespace CutTheRopeDX.Tests
 
             Press(controller, input);
 
-            Assert.True(scene.touchable);
-            Assert.True(scene.updateable);
-            Assert.False(PauseMenu(controller).IsEnabled());
+            Assert.False(scene.touchable);
+            Assert.False(scene.updateable);
+            Assert.True(PauseMenu(controller).IsEnabled());
         }
 
         [Theory]

--- a/CutTheRopeDX.Tests/GameControllerInputTests.cs
+++ b/CutTheRopeDX.Tests/GameControllerInputTests.cs
@@ -217,7 +217,7 @@ namespace CutTheRopeDX.Tests
         {
             (GameController controller, GameScene scene) = Load();
             HeadlessGame.StepFrames(scene, 60);
-            scene.gameplayFlow.MarkTransitionActive();
+            Assert.True(scene.gameplayFlow.TryScheduleLoss());
 
             _ = useBack
                 ? controller.BackButtonPressed()
@@ -226,6 +226,19 @@ namespace CutTheRopeDX.Tests
             Assert.True(scene.updateable);
             Assert.False(PauseMenu(controller).IsEnabled());
             Assert.Equal(GameController.EXIT_CODE_FROM_PAUSE_MENU, controller.exitCode);
+        }
+
+        [Fact]
+        public void RestartIsIgnoredDuringWinningTransition()
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+            Assert.True(scene.gameplayFlow.TryBeginWin());
+
+            controller.OnButtonPressed(GameControllerButtonId.Restart);
+
+            Assert.Equal(LevelOutcomeState.Winning, scene.gameplayFlow.Outcome);
+            Assert.Equal(RestartPhase.Playing, scene.gameplayFlow.Phase);
         }
 
         [Theory]
@@ -254,7 +267,7 @@ namespace CutTheRopeDX.Tests
         {
             (GameController controller, GameScene scene) = Load();
             HeadlessGame.StepFrames(scene, 60);
-            scene.gameplayFlow.MarkTransitionActive();
+            Assert.True(scene.gameplayFlow.TryScheduleLoss());
 
             Press(controller, input);
 

--- a/CutTheRopeDX.Tests/GameControllerInputTests.cs
+++ b/CutTheRopeDX.Tests/GameControllerInputTests.cs
@@ -229,7 +229,7 @@ namespace CutTheRopeDX.Tests
         }
 
         [Fact]
-        public void RestartIsIgnoredDuringWinningTransition()
+        public void RestartBailsOutOfTheWinPresentation()
         {
             (GameController controller, GameScene scene) = Load();
             HeadlessGame.StepFrames(scene, 60);
@@ -237,8 +237,20 @@ namespace CutTheRopeDX.Tests
 
             controller.OnButtonPressed(GameControllerButtonId.Restart);
 
-            Assert.Equal(LevelOutcomeState.Winning, scene.gameplayFlow.Outcome);
-            Assert.Equal(RestartPhase.Playing, scene.gameplayFlow.Phase);
+            Assert.Equal(RestartPhase.FadingOut, scene.gameplayFlow.Phase);
+            Assert.False(scene.gameplayFlow.CompleteWinTransition());
+        }
+
+        [Fact]
+        public void RestartBailsOutOfTheLossPresentation()
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+            Assert.True(scene.gameplayFlow.TryScheduleLoss());
+
+            controller.OnButtonPressed(GameControllerButtonId.Restart);
+
+            Assert.Equal(RestartPhase.FadingOut, scene.gameplayFlow.Phase);
         }
 
         [Theory]

--- a/CutTheRopeDX.Tests/LevelFlowInputRaceTests.cs
+++ b/CutTheRopeDX.Tests/LevelFlowInputRaceTests.cs
@@ -1,0 +1,167 @@
+using CutTheRopeDX.Framework.Visual;
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    /// <summary>
+    /// Verification tests for pause/restart races around outcome and restart-dim boundaries.
+    /// These characterize behavior that already holds; they exist so lifting the pause and restart
+    /// blockers cannot silently reintroduce a race.
+    /// </summary>
+    public class LevelFlowInputRaceTests
+    {
+        private static (GameController Controller, GameScene Scene) Load()
+        {
+            _ = HeadlessGame.Boot();
+            GameController controller = HeadlessGame.LoadLevelWithController(pack: 1, level: 4);
+            return (controller, (GameScene)controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_GAME_SCENE));
+        }
+
+        private static BaseElement PauseMenu(GameController controller)
+        {
+            return controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_PAUSE_MENU);
+        }
+
+        /// <summary>
+        /// Advances the scene the way its parent does: <c>BaseElement.Update</c> only recurses into
+        /// children whose <c>updateable</c> is set, so a paused scene must not tick. The harness's
+        /// <c>StepFrames</c> calls <c>Update</c> directly and would bypass that gate.
+        /// </summary>
+        private static void StepHonoringUpdateable(GameScene scene, int frames)
+        {
+            for (int i = 0; i < frames; i++)
+            {
+                if (scene.updateable)
+                {
+                    scene.Update(0.016f);
+                }
+            }
+        }
+
+        [Fact]
+        public void PauseRequestedAfterRestartInTheSameFrameIsIgnored()
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+
+            controller.OnButtonPressed(GameControllerButtonId.Restart);
+            controller.OnButtonPressed(GameControllerButtonId.Pause);
+
+            Assert.Equal(RestartPhase.FadingOut, scene.gameplayFlow.Phase);
+            Assert.False(PauseMenu(controller).IsEnabled());
+            Assert.True(scene.updateable);
+        }
+
+        [Fact]
+        public void RestartRequestedAfterPauseInTheSameFrameIsIgnored()
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+
+            controller.OnButtonPressed(GameControllerButtonId.Pause);
+            controller.OnButtonPressed(GameControllerButtonId.Restart);
+
+            Assert.Equal(RestartPhase.Playing, scene.gameplayFlow.Phase);
+            Assert.True(PauseMenu(controller).IsEnabled());
+        }
+
+        [Fact]
+        public void PauseSpammedThroughAWholeDimNeverOpensAndTheDimStillCompletes()
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+            controller.OnButtonPressed(GameControllerButtonId.Restart);
+
+            for (int i = 0; i < 120 && scene.gameplayFlow.Phase != RestartPhase.Playing; i++)
+            {
+                controller.OnButtonPressed(GameControllerButtonId.Pause);
+                Assert.False(PauseMenu(controller).IsEnabled());
+                StepHonoringUpdateable(scene, 1);
+            }
+
+            Assert.Equal(RestartPhase.Playing, scene.gameplayFlow.Phase);
+            Assert.Equal(LevelOutcomeState.Playing, scene.gameplayFlow.Outcome);
+        }
+
+        [Fact]
+        public void RestartSpammedThroughADimCannotExtendIt()
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+            controller.OnButtonPressed(GameControllerButtonId.Restart);
+            float previousDim = scene.gameplayFlow.DimTime;
+
+            while (scene.gameplayFlow.Phase == RestartPhase.FadingOut)
+            {
+                controller.OnButtonPressed(GameControllerButtonId.Restart);
+                Assert.True(scene.gameplayFlow.DimTime <= previousDim);
+                previousDim = scene.gameplayFlow.DimTime;
+                StepHonoringUpdateable(scene, 1);
+            }
+
+            Assert.NotEqual(RestartPhase.FadingOut, scene.gameplayFlow.Phase);
+        }
+
+        [Fact]
+        public void PausingDuringALossStopsTheSceneSoItsCutsceneCannotAdvance()
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+            Assert.True(scene.gameplayFlow.TryBeginLoss());
+
+            controller.OnButtonPressed(GameControllerButtonId.Pause);
+            StepHonoringUpdateable(scene, 300);
+
+            Assert.False(scene.updateable);
+            Assert.Equal(LevelOutcomeState.Losing, scene.gameplayFlow.Outcome);
+            Assert.Equal(RestartPhase.Playing, scene.gameplayFlow.Phase);
+        }
+
+        [Fact]
+        public void ResumingAfterPausingDuringALossKeepsTheLevelLost()
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+            Assert.True(scene.gameplayFlow.TryBeginLoss());
+            controller.OnButtonPressed(GameControllerButtonId.Pause);
+
+            _ = controller.BackButtonPressed();
+
+            // The outcome must survive the round trip. If it reset to Playing the level would be
+            // lost while Om Nom went back to reacting to candy.
+            Assert.Equal(LevelOutcomeState.Losing, scene.gameplayFlow.Outcome);
+            Assert.False(scene.gameplayFlow.CanReactToCandy());
+            Assert.True(scene.updateable);
+        }
+
+        [Fact]
+        public void ResumingAfterPausingDuringAWinKeepsTheWinPending()
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+            Assert.True(scene.gameplayFlow.TryBeginWin());
+            controller.OnButtonPressed(GameControllerButtonId.Pause);
+
+            _ = controller.BackButtonPressed();
+
+            Assert.Equal(LevelOutcomeState.Winning, scene.gameplayFlow.Outcome);
+            Assert.True(scene.gameplayFlow.CompleteWinTransition());
+        }
+
+        [Fact]
+        public void ADimStartedByALossStillRefusesPause()
+        {
+            (GameController controller, GameScene scene) = Load();
+            HeadlessGame.StepFrames(scene, 60);
+            Assert.True(scene.gameplayFlow.TryBeginLoss());
+            Assert.True(scene.gameplayFlow.TryBeginRestartDim());
+
+            controller.OnButtonPressed(GameControllerButtonId.Pause);
+
+            Assert.False(PauseMenu(controller).IsEnabled());
+            Assert.Equal(LevelOutcomeState.Lost, scene.gameplayFlow.Outcome);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/LevelFlowStateTests.cs
+++ b/CutTheRopeDX.Tests/LevelFlowStateTests.cs
@@ -14,8 +14,9 @@ namespace CutTheRopeDX.Tests
             LevelFlowState gameplayFlow = new();
 
             Assert.Equal(RestartPhase.Playing, gameplayFlow.Phase);
+            Assert.Equal(LevelOutcomeState.Playing, gameplayFlow.Outcome);
             Assert.True(gameplayFlow.CanTriggerOutcome);
-            Assert.True(gameplayFlow.CanTriggerTerminalOutcome);
+            Assert.True(gameplayFlow.CanRestart);
             Assert.True(gameplayFlow.CanReactToCandy());
         }
 
@@ -24,17 +25,32 @@ namespace CutTheRopeDX.Tests
         {
             LevelFlowState gameplayFlow = new();
 
-            gameplayFlow.BeginRestartDim();
+            Assert.True(gameplayFlow.TryBeginRestartDim());
 
             Assert.Equal(RestartPhase.FadingOut, gameplayFlow.Phase);
             Assert.False(gameplayFlow.CanTriggerOutcome);
         }
 
         [Fact]
+        public void FadingOutAtomicallyRejectsEveryOutcomeTransition()
+        {
+            LevelFlowState winFlow = new();
+            LevelFlowState immediateLossFlow = new();
+            LevelFlowState scheduledLossFlow = new();
+            Assert.True(winFlow.TryBeginRestartDim());
+            Assert.True(immediateLossFlow.TryBeginRestartDim());
+            Assert.True(scheduledLossFlow.TryBeginRestartDim());
+
+            Assert.False(winFlow.TryBeginWin());
+            Assert.False(immediateLossFlow.TryBeginLoss());
+            Assert.False(scheduledLossFlow.TryScheduleLoss());
+        }
+
+        [Fact]
         public void AdvanceFadingOutRequestsSceneSwapThenCompletes()
         {
             LevelFlowState gameplayFlow = new();
-            gameplayFlow.BeginRestartDim();
+            Assert.True(gameplayFlow.TryBeginRestartDim());
 
             RestartStep step = RestartStep.None;
             for (int i = 0; i < 60 && step != RestartStep.SwapScene; i++)
@@ -59,7 +75,7 @@ namespace CutTheRopeDX.Tests
             // Level-triggered, not edge-triggered: a delta large enough to consume the whole dim
             // must advance the phase in the same call.
             LevelFlowState gameplayFlow = new();
-            gameplayFlow.BeginRestartDim();
+            Assert.True(gameplayFlow.TryBeginRestartDim());
 
             Assert.Equal(RestartStep.SwapScene, gameplayFlow.Advance(1f));
         }
@@ -68,7 +84,7 @@ namespace CutTheRopeDX.Tests
         public void AdvanceIsIdempotentOncePlaying()
         {
             LevelFlowState gameplayFlow = new();
-            gameplayFlow.BeginRestartDim();
+            Assert.True(gameplayFlow.TryBeginRestartDim());
             _ = gameplayFlow.Advance(1f);
             _ = gameplayFlow.Advance(1f);
             Assert.Equal(RestartPhase.Playing, gameplayFlow.Phase);
@@ -87,48 +103,141 @@ namespace CutTheRopeDX.Tests
         }
 
         [Fact]
-        public void MarkWonBlocksFurtherTerminalOutcomes()
+        public void BeginWinBlocksFurtherTerminalOutcomes()
         {
             LevelFlowState gameplayFlow = new();
 
-            gameplayFlow.MarkWon();
+            Assert.True(gameplayFlow.TryBeginWin());
 
             Assert.True(gameplayFlow.WonTriggered);
             Assert.True(gameplayFlow.TransitionActive);
-            Assert.False(gameplayFlow.CanTriggerTerminalOutcome);
             Assert.False(gameplayFlow.CanReactToCandy());
         }
 
         [Fact]
-        public void MarkLostBlocksFurtherTerminalOutcomes()
+        public void BeginLossBlocksFurtherTerminalOutcomes()
         {
             LevelFlowState gameplayFlow = new();
 
-            gameplayFlow.MarkLost();
+            Assert.True(gameplayFlow.TryBeginLoss());
 
             Assert.True(gameplayFlow.LostTriggered);
             Assert.True(gameplayFlow.TransitionActive);
-            Assert.False(gameplayFlow.CanTriggerTerminalOutcome);
             Assert.False(gameplayFlow.CanReactToCandy());
         }
 
         [Fact]
         public void ScheduledLossBlocksCandyReactionsBeforeLossFires()
         {
-            // Spider and hazard losses wait for their visual animation before MarkLost. The
+            // Spider and hazard losses wait for their visual animation before TryBeginLoss. The
             // transition gate must close immediately so candy cannot produce a win meanwhile.
             LevelFlowState gameplayFlow = new();
 
-            gameplayFlow.MarkTransitionActive();
+            Assert.True(gameplayFlow.TryScheduleLoss());
 
             Assert.True(gameplayFlow.TransitionActive);
             Assert.False(gameplayFlow.LostTriggered);
             Assert.False(gameplayFlow.CanReactToCandy());
 
-            gameplayFlow.MarkLost();
+            Assert.True(gameplayFlow.TryBeginLoss());
 
             Assert.True(gameplayFlow.LostTriggered);
-            Assert.False(gameplayFlow.CanTriggerTerminalOutcome);
+        }
+
+        [Fact]
+        public void PendingLossRejectsDuplicateSchedulingAndACompetingWin()
+        {
+            LevelFlowState gameplayFlow = new();
+
+            Assert.True(gameplayFlow.TryScheduleLoss());
+
+            Assert.Equal(LevelOutcomeState.PendingLoss, gameplayFlow.Outcome);
+            Assert.False(gameplayFlow.TryScheduleLoss());
+            Assert.False(gameplayFlow.TryBeginWin());
+            Assert.Equal(LevelOutcomeState.PendingLoss, gameplayFlow.Outcome);
+        }
+
+        [Fact]
+        public void NonPlayingOutcomesCannotTriggerAnotherOutcome()
+        {
+            LevelFlowState pendingLoss = new();
+            LevelFlowState winning = new();
+            LevelFlowState losing = new();
+            LevelFlowState won = new();
+            LevelFlowState lost = new();
+            Assert.True(pendingLoss.TryScheduleLoss());
+            Assert.True(winning.TryBeginWin());
+            Assert.True(losing.TryBeginLoss());
+            Assert.True(won.TryBeginWin());
+            Assert.True(won.CompleteWinTransition());
+            Assert.True(lost.TryBeginLoss());
+            Assert.True(lost.TryBeginRestartDim());
+
+            Assert.False(pendingLoss.CanTriggerOutcome);
+            Assert.False(winning.CanTriggerOutcome);
+            Assert.False(losing.CanTriggerOutcome);
+            Assert.False(won.CanTriggerOutcome);
+            Assert.False(lost.CanTriggerOutcome);
+        }
+
+        [Fact]
+        public void PendingLossAndWinningRejectRestart()
+        {
+            LevelFlowState pendingLoss = new();
+            LevelFlowState winning = new();
+            Assert.True(pendingLoss.TryScheduleLoss());
+            Assert.True(winning.TryBeginWin());
+
+            Assert.False(pendingLoss.CanRestart);
+            Assert.False(winning.CanRestart);
+            Assert.False(pendingLoss.TryBeginRestartDim());
+            Assert.False(winning.TryBeginRestartDim());
+            Assert.Equal(RestartPhase.Playing, pendingLoss.Phase);
+            Assert.Equal(RestartPhase.Playing, winning.Phase);
+        }
+
+        [Fact]
+        public void PendingLossCanOnlyAdvanceToLosing()
+        {
+            LevelFlowState gameplayFlow = new();
+            Assert.True(gameplayFlow.TryScheduleLoss());
+
+            Assert.True(gameplayFlow.TryBeginLoss());
+
+            Assert.Equal(LevelOutcomeState.Losing, gameplayFlow.Outcome);
+            Assert.True(gameplayFlow.LostTriggered);
+            Assert.False(gameplayFlow.WonTriggered);
+        }
+
+        [Fact]
+        public void WinningCannotChangeToLosingAndCompletesAsWon()
+        {
+            LevelFlowState gameplayFlow = new();
+            Assert.True(gameplayFlow.TryBeginWin());
+
+            Assert.False(gameplayFlow.TryBeginLoss());
+            Assert.True(gameplayFlow.CompleteWinTransition());
+
+            Assert.Equal(LevelOutcomeState.Won, gameplayFlow.Outcome);
+            Assert.True(gameplayFlow.WonTriggered);
+            Assert.False(gameplayFlow.LostTriggered);
+            Assert.False(gameplayFlow.TransitionActive);
+            Assert.False(gameplayFlow.CanReactToCandy());
+        }
+
+        [Fact]
+        public void LosingCompletesAsLostWhenRestartBegins()
+        {
+            LevelFlowState gameplayFlow = new();
+            Assert.True(gameplayFlow.TryBeginLoss());
+
+            Assert.True(gameplayFlow.TryBeginRestartDim());
+
+            Assert.Equal(LevelOutcomeState.Lost, gameplayFlow.Outcome);
+            Assert.True(gameplayFlow.LostTriggered);
+            Assert.False(gameplayFlow.WonTriggered);
+            Assert.False(gameplayFlow.TransitionActive);
+            Assert.False(gameplayFlow.CanReactToCandy());
         }
 
         [Fact]
@@ -140,13 +249,13 @@ namespace CutTheRopeDX.Tests
         }
 
         [Fact]
-        public void BeginRestartDimAlwaysSetsANonZeroDim()
+        public void TryBeginRestartDimAlwaysSetsANonZeroDim()
         {
             // This invariant is what makes a stranded restart unreachable: the phase is never
             // FadingOut with no dim left, so Advance always has something to consume.
             LevelFlowState gameplayFlow = new();
 
-            gameplayFlow.BeginRestartDim();
+            Assert.True(gameplayFlow.TryBeginRestartDim());
 
             Assert.Equal(RestartPhase.FadingOut, gameplayFlow.Phase);
             Assert.True(gameplayFlow.DimTime > 0f);
@@ -156,8 +265,8 @@ namespace CutTheRopeDX.Tests
         public void ResetClearsStrandedRestartPhase()
         {
             LevelFlowState gameplayFlow = new();
-            gameplayFlow.BeginRestartDim();
-            gameplayFlow.MarkLost();
+            Assert.True(gameplayFlow.TryBeginLoss());
+            Assert.True(gameplayFlow.TryBeginRestartDim());
 
             gameplayFlow.Reset();
 
@@ -173,10 +282,10 @@ namespace CutTheRopeDX.Tests
             // Show() runs in the middle of a restart, between the two dim phases. Clearing the
             // phase there would wipe the in-flight restart.
             LevelFlowState gameplayFlow = new();
-            gameplayFlow.BeginRestartDim();
+            Assert.True(gameplayFlow.TryBeginRestartDim());
             _ = gameplayFlow.Advance(1f);
             Assert.Equal(RestartPhase.FadingIn, gameplayFlow.Phase);
-            gameplayFlow.MarkLost();
+            Assert.True(gameplayFlow.TryBeginLoss());
 
             gameplayFlow.ResetOutcome();
 

--- a/CutTheRopeDX.Tests/LevelFlowStateTests.cs
+++ b/CutTheRopeDX.Tests/LevelFlowStateTests.cs
@@ -181,19 +181,49 @@ namespace CutTheRopeDX.Tests
         }
 
         [Fact]
-        public void PendingLossAndWinningRejectRestart()
+        public void EveryOutcomePresentationAllowsRestart()
         {
             LevelFlowState pendingLoss = new();
             LevelFlowState winning = new();
+            LevelFlowState losing = new();
             Assert.True(pendingLoss.TryScheduleLoss());
             Assert.True(winning.TryBeginWin());
+            Assert.True(losing.TryBeginLoss());
 
-            Assert.False(pendingLoss.CanRestart);
-            Assert.False(winning.CanRestart);
-            Assert.False(pendingLoss.TryBeginRestartDim());
-            Assert.False(winning.TryBeginRestartDim());
-            Assert.Equal(RestartPhase.Playing, pendingLoss.Phase);
-            Assert.Equal(RestartPhase.Playing, winning.Phase);
+            Assert.True(pendingLoss.CanRestart);
+            Assert.True(winning.CanRestart);
+            Assert.True(losing.CanRestart);
+            Assert.True(pendingLoss.TryBeginRestartDim());
+            Assert.True(winning.TryBeginRestartDim());
+            Assert.True(losing.TryBeginRestartDim());
+            Assert.Equal(RestartPhase.FadingOut, pendingLoss.Phase);
+            Assert.Equal(RestartPhase.FadingOut, winning.Phase);
+            Assert.Equal(RestartPhase.FadingOut, losing.Phase);
+        }
+
+        [Fact]
+        public void RestartInFlightPreventsAWinFromCompleting()
+        {
+            LevelFlowState gameplayFlow = new();
+            Assert.True(gameplayFlow.TryBeginWin());
+            Assert.True(gameplayFlow.TryBeginRestartDim());
+
+            Assert.False(gameplayFlow.CompleteWinTransition());
+            Assert.NotEqual(LevelOutcomeState.Won, gameplayFlow.Outcome);
+        }
+
+        [Fact]
+        public void RestartDuringADimIsRejectedSoAPendingDispatchCannotResetIt()
+        {
+            LevelFlowState gameplayFlow = new();
+            Assert.True(gameplayFlow.TryBeginLoss());
+            Assert.True(gameplayFlow.TryBeginRestartDim());
+            _ = gameplayFlow.Advance(LevelFlowState.DimDuration / 2f);
+            float dimAfterPartialFade = gameplayFlow.DimTime;
+
+            Assert.False(gameplayFlow.CanRestart);
+            Assert.False(gameplayFlow.TryBeginRestartDim());
+            Assert.Equal(dimAfterPartialFade, gameplayFlow.DimTime);
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/PauseDuringRestartTests.cs
+++ b/CutTheRopeDX.Tests/PauseDuringRestartTests.cs
@@ -158,7 +158,7 @@ namespace CutTheRopeDX.Tests
         {
             (GameController controller, GameScene scene) = Load();
             HeadlessGame.StepFrames(scene, 60);
-            scene.gameplayFlow.BeginRestartDim();
+            Assert.True(scene.gameplayFlow.TryBeginRestartDim());
             Assert.Equal(RestartStep.SwapScene, scene.gameplayFlow.Advance(1f));
 
             _ = controller.BackButtonPressed();
@@ -188,7 +188,7 @@ namespace CutTheRopeDX.Tests
         {
             (GameController controller, GameScene scene) = Load();
             HeadlessGame.StepFrames(scene, 60);
-            scene.gameplayFlow.BeginRestartDim();
+            Assert.True(scene.gameplayFlow.TryBeginRestartDim());
             Assert.Equal(RestartStep.SwapScene, scene.gameplayFlow.Advance(1f));
 
             _ = controller.MenuButtonPressed();
@@ -217,7 +217,7 @@ namespace CutTheRopeDX.Tests
         {
             (GameController controller, GameScene scene) = Load();
             HeadlessGame.StepFrames(scene, 60);
-            scene.gameplayFlow.BeginRestartDim();
+            Assert.True(scene.gameplayFlow.TryBeginRestartDim());
             Assert.Equal(RestartStep.SwapScene, scene.gameplayFlow.Advance(1f));
 
             controller.OnButtonPressed(GameControllerButtonId.Pause);

--- a/CutTheRopeDX.Tests/PointerGestureStateTests.cs
+++ b/CutTheRopeDX.Tests/PointerGestureStateTests.cs
@@ -134,12 +134,12 @@ namespace CutTheRopeDX.Tests
             PointerGestureState gesture = GetPointerGesture(scene, 0);
             if (won)
             {
-                scene.gameplayFlow.MarkWon();
-                scene.gameplayFlow.EndTransition();
+                Assert.True(scene.gameplayFlow.TryBeginWin());
+                Assert.True(scene.gameplayFlow.CompleteWinTransition());
             }
             else
             {
-                scene.gameplayFlow.MarkLost();
+                Assert.True(scene.gameplayFlow.TryBeginLoss());
             }
 
             Assert.True(scene.TouchDownXYIndex(10_000f, 10_000f, 0));
@@ -161,8 +161,8 @@ namespace CutTheRopeDX.Tests
             GameScene scene = (GameScene)controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_GAME_SCENE);
             HeadlessGame.StepFrames(scene, 60);
             PointerGestureState gesture = GetPointerGesture(scene, 0);
-            scene.gameplayFlow.MarkWon();
-            scene.gameplayFlow.EndTransition();
+            Assert.True(scene.gameplayFlow.TryBeginWin());
+            Assert.True(scene.gameplayFlow.CompleteWinTransition());
             controller.LevelWon(LevelResultCalculator.Calculate(elapsedTime: 20f, starsCollected: 2));
 
             _ = controller.TouchesBeganwithEvent([

--- a/CutTheRopeDX/GameMain/GameController.cs
+++ b/CutTheRopeDX/GameMain/GameController.cs
@@ -623,7 +623,6 @@ namespace CutTheRopeDX.GameMain
                 input,
                 overlayMode,
                 gameScene.gameplayFlow.Phase,
-                gameScene.gameplayFlow.TransitionActive,
                 resultExitAllowed: !CustomLevelSession.IsActive);
         }
 

--- a/CutTheRopeDX/GameMain/GameController.cs
+++ b/CutTheRopeDX/GameMain/GameController.cs
@@ -501,7 +501,7 @@ namespace CutTheRopeDX.GameMain
                 case var id when id == GameControllerButtonId.Restart:
                     GameScene restartScene = (GameScene)view.GetChild(GameView.VIEW_ELEMENT_GAME_SCENE);
                     if (overlayMode != GameControllerOverlayMode.Gameplay
-                        || restartScene.gameplayFlow.Phase != RestartPhase.Playing)
+                        || !restartScene.gameplayFlow.CanRestart)
                     {
                         return;
                     }

--- a/CutTheRopeDX/GameMain/GameControllerInput.cs
+++ b/CutTheRopeDX/GameMain/GameControllerInput.cs
@@ -38,17 +38,20 @@ namespace CutTheRopeDX.GameMain
         /// <param name="input">Input source.</param>
         /// <param name="overlay">Current controller overlay.</param>
         /// <param name="restartPhase">Authoritative restart phase.</param>
-        /// <param name="outcomeTransitionActive">Whether a win/loss transition is active.</param>
         /// <param name="resultExitAllowed">Whether Back may leave a stable result screen.</param>
         /// <returns>The semantic command allowed by the current state.</returns>
+        /// <remarks>
+        /// An outcome presentation does not gate input. Pausing mid-cutscene is safe because the
+        /// pause overlay clears <c>updateable</c>, and the scene's update is the only thing that
+        /// pumps the delayed dispatcher, so the win/loss sequence freezes with it.
+        /// </remarks>
         public static GameControllerInputCommand Resolve(
             GameControllerInputKind input,
             GameControllerOverlayMode overlay,
             RestartPhase restartPhase,
-            bool outcomeTransitionActive,
             bool resultExitAllowed)
         {
-            return restartPhase != RestartPhase.Playing || outcomeTransitionActive
+            return restartPhase != RestartPhase.Playing
                 ? GameControllerInputCommand.Ignore
                 : (overlay, input) switch
                 {

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -256,9 +256,17 @@ namespace CutTheRopeDX.GameMain
         /// <summary>
         /// Starts the level restart dimming animation.
         /// </summary>
+        /// <remarks>
+        /// Two callers: the loss timeline one second after <see cref="GameLost"/> (which converts
+        /// <c>Losing</c> into <c>Lost</c>), and the reload path when a manual restart set
+        /// <c>animateRestartDim</c>. The result is discarded because every rejection is a duplicate
+        /// request - a dim already in flight, or an outcome that already claimed the restart. Both
+        /// must be ignored rather than restarting the dim, which is what stops a pending loss
+        /// dispatch from resetting a player-initiated dim back to full.
+        /// </remarks>
         public void AnimateLevelRestart()
         {
-            gameplayFlow.BeginRestartDim();
+            _ = gameplayFlow.TryBeginRestartDim();
         }
 
         /// <summary>
@@ -448,11 +456,10 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         public void GameWon()
         {
-            if (!gameplayFlow.CanTriggerTerminalOutcome)
+            if (!gameplayFlow.TryBeginWin())
             {
                 return;
             }
-            gameplayFlow.MarkWon();
             pendingLevelResult = CalculateScore();
 
             EndActiveFingerTraces();
@@ -514,11 +521,10 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         public void GameLost()
         {
-            if (!gameplayFlow.CanTriggerTerminalOutcome)
+            if (!gameplayFlow.TryBeginLoss())
             {
                 return;
             }
-            gameplayFlow.MarkLost();
 
             EndActiveFingerTraces();
             conveyors?.CancelAllDrags();
@@ -831,7 +837,10 @@ namespace CutTheRopeDX.GameMain
         /// <param name="delay">Seconds to wait before running the loss sequence.</param>
         private void ScheduleGameLost(float delay)
         {
-            gameplayFlow.MarkTransitionActive();
+            if (!gameplayFlow.TryScheduleLoss())
+            {
+                return;
+            }
             dd.CallObjectSelectorParamafterDelay(new DelayedDispatcher.DispatchFunc(Selector_gameLost), null, delay);
         }
 

--- a/CutTheRopeDX/GameMain/GameScene.PostEatSleep.cs
+++ b/CutTheRopeDX/GameMain/GameScene.PostEatSleep.cs
@@ -32,8 +32,11 @@ namespace CutTheRopeDX.GameMain
             }
 
             TargetContext target = request.Target;
+            // Any outcome owning the level cancels the nap, including one that finished during the
+            // delay. Not CanReactToCandy: this target is mid-chew, so it is already fed, and that
+            // predicate answers a different question (may Om Nom react to a *new* candy).
             if (target == null
-                || gameplayFlow.TransitionActive
+                || gameplayFlow.HasOutcome
                 || !GameWinChewing.ShouldSchedulePostEatSleep(
                     targets.Count,
                     nightLevel,

--- a/CutTheRopeDX/GameMain/GameScene.cs
+++ b/CutTheRopeDX/GameMain/GameScene.cs
@@ -322,7 +322,13 @@ namespace CutTheRopeDX.GameMain
         private void Selector_gameWon(FrameworkTypes param)
         {
             CTRSoundMgr.EnableLoopedSounds(false);
-            _ = gameplayFlow.CompleteWinTransition();
+            if (!gameplayFlow.CompleteWinTransition())
+            {
+                // A restart claimed the level while the win was still presenting. Leave the result
+                // pending: Show clears it, so the abandoned win never reaches the results box.
+                return;
+            }
+
             if (pendingLevelResult is LevelResult result)
             {
                 pendingLevelResult = null;

--- a/CutTheRopeDX/GameMain/GameScene.cs
+++ b/CutTheRopeDX/GameMain/GameScene.cs
@@ -322,7 +322,7 @@ namespace CutTheRopeDX.GameMain
         private void Selector_gameWon(FrameworkTypes param)
         {
             CTRSoundMgr.EnableLoopedSounds(false);
-            gameplayFlow.EndTransition();
+            _ = gameplayFlow.CompleteWinTransition();
             if (pendingLevelResult is LevelResult result)
             {
                 pendingLevelResult = null;
@@ -944,9 +944,7 @@ namespace CutTheRopeDX.GameMain
         private readonly PointerGestureState[] pointerGestures = new PointerGestureState[PointerGestureCount];
 
         /// <summary>Whether an outcome allows visual-only pointer trails while gameplay input is blocked.</summary>
-        internal bool AcceptsVisualOnlyPointerInput => gameplayFlow.TransitionActive
-            || gameplayFlow.WonTriggered
-            || gameplayFlow.LostTriggered;
+        internal bool AcceptsVisualOnlyPointerInput => gameplayFlow.HasOutcome;
 
         /// <summary>
         /// Current rope physics time scale.

--- a/CutTheRopeDX/GameMain/LevelFlowState.cs
+++ b/CutTheRopeDX/GameMain/LevelFlowState.cs
@@ -81,9 +81,17 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Whether any win/loss outcome owns the level.</summary>
         public bool HasOutcome => Outcome != LevelOutcomeState.Playing;
 
-        /// <summary>Whether player input may start a restart.</summary>
-        public bool CanRestart => Phase == RestartPhase.Playing
-            && Outcome == LevelOutcomeState.Playing;
+        /// <summary>
+        /// Whether player input may start a restart. An outcome presentation is a skippable
+        /// cutscene, not a lock: the player may bail out of a sad Om Nom or a chewing animation
+        /// and retry immediately. Only a dim already in flight refuses.
+        /// </summary>
+        /// <remarks>
+        /// Must stay identical to <see cref="TryBeginRestartDim"/>'s precondition. The restart
+        /// button reloads the map and only then calls <c>AnimateLevelRestart</c>, so a state this
+        /// property accepts but that method rejects would reload the level and never re-show it.
+        /// </remarks>
+        public bool CanRestart => Phase == RestartPhase.Playing;
 
         /// <summary>True while the screen is dimming out, when the dim overlay renders inverted.</summary>
         public bool IsFadingOut => Phase == RestartPhase.FadingOut;
@@ -133,14 +141,21 @@ namespace CutTheRopeDX.GameMain
 
         /// <summary>Atomically starts a manual restart or completes an active loss into restart.</summary>
         /// <returns><see langword="true"/> when restart dimming started.</returns>
+        /// <remarks>
+        /// Rejecting a dim that is already in flight is what makes the restart button safe during
+        /// an outcome: the loss timeline's own delayed <c>AnimateLevelRestart</c> lands here after
+        /// a player-initiated dim has started and must not reset it back to full.
+        /// </remarks>
         public bool TryBeginRestartDim()
         {
-            if (Phase != RestartPhase.Playing
-                || Outcome is not (LevelOutcomeState.Playing or LevelOutcomeState.Losing))
+            if (Phase != RestartPhase.Playing)
             {
                 return false;
             }
 
+            // A loss that reaches the dim has finished presenting, whether its own timeline got
+            // there or the player skipped ahead. Winning is left alone: the player is abandoning
+            // the win rather than completing it, and Show resets the outcome moments later.
             if (Outcome == LevelOutcomeState.Losing)
             {
                 Outcome = LevelOutcomeState.Lost;
@@ -192,9 +207,13 @@ namespace CutTheRopeDX.GameMain
 
         /// <summary>Completes the active win presentation.</summary>
         /// <returns><see langword="true"/> when an active win became complete.</returns>
+        /// <remarks>
+        /// A restart in flight refuses the completion. The player skipped the chewing animation to
+        /// retry, so the win must not report itself and pop the results box over the dim.
+        /// </remarks>
         public bool CompleteWinTransition()
         {
-            if (Outcome != LevelOutcomeState.Winning)
+            if (Phase != RestartPhase.Playing || Outcome != LevelOutcomeState.Winning)
             {
                 return false;
             }

--- a/CutTheRopeDX/GameMain/LevelFlowState.cs
+++ b/CutTheRopeDX/GameMain/LevelFlowState.cs
@@ -28,10 +28,30 @@ namespace CutTheRopeDX.GameMain
         Completed,
     }
 
+    /// <summary>Where the level sits in its mutually exclusive win/loss lifecycle.</summary>
+    internal enum LevelOutcomeState
+    {
+        /// <summary>No outcome has started.</summary>
+        Playing,
+
+        /// <summary>A delayed loss owns the outcome, but its loss sequence has not started yet.</summary>
+        PendingLoss,
+
+        /// <summary>The win presentation is active.</summary>
+        Winning,
+
+        /// <summary>The loss presentation is active.</summary>
+        Losing,
+
+        /// <summary>The win presentation completed.</summary>
+        Won,
+
+        /// <summary>The loss presentation completed and restart dimming has begun.</summary>
+        Lost,
+    }
+
     /// <summary>
-    /// Single owner of a level's lifecycle: the restart-dim machine and the win/lose flags.
-    /// These were five public fields read from a dozen places; desync between them silently
-    /// disabled every terminal outcome in the game.
+    /// Single owner of a level's lifecycle: the independent restart-dim and outcome machines.
     /// </summary>
     internal sealed class LevelFlowState
     {
@@ -44,36 +64,46 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Remaining dim time for the current phase.</summary>
         public float DimTime { get; private set; }
 
-        /// <summary>Whether the win sequence has started.</summary>
-        public bool WonTriggered { get; private set; }
+        /// <summary>Current authoritative win/loss state.</summary>
+        public LevelOutcomeState Outcome { get; private set; } = LevelOutcomeState.Playing;
 
-        /// <summary>Whether the loss sequence has started.</summary>
-        public bool LostTriggered { get; private set; }
+        /// <summary>Whether the level reached either win state.</summary>
+        public bool WonTriggered => Outcome is LevelOutcomeState.Winning or LevelOutcomeState.Won;
+
+        /// <summary>Whether the level reached either loss state.</summary>
+        public bool LostTriggered => Outcome is LevelOutcomeState.Losing or LevelOutcomeState.Lost;
 
         /// <summary>Whether a win/loss transition is currently playing.</summary>
-        public bool TransitionActive { get; private set; }
+        public bool TransitionActive => Outcome is LevelOutcomeState.PendingLoss
+            or LevelOutcomeState.Winning
+            or LevelOutcomeState.Losing;
+
+        /// <summary>Whether any win/loss outcome owns the level.</summary>
+        public bool HasOutcome => Outcome != LevelOutcomeState.Playing;
+
+        /// <summary>Whether player input may start a restart.</summary>
+        public bool CanRestart => Phase == RestartPhase.Playing
+            && Outcome == LevelOutcomeState.Playing;
 
         /// <summary>True while the screen is dimming out, when the dim overlay renders inverted.</summary>
         public bool IsFadingOut => Phase == RestartPhase.FadingOut;
 
         /// <summary>
-        /// Whether a terminal outcome may fire. False only while dimming out, so a level being
-        /// torn down cannot also be won or lost.
+        /// Whether a new terminal outcome may claim the level. A level being torn down or already
+        /// owned by an outcome cannot also be won or lost.
         /// </summary>
-        public bool CanTriggerOutcome => Phase != RestartPhase.FadingOut;
-
-        /// <summary>Whether neither terminal outcome has started yet.</summary>
-        public bool CanTriggerTerminalOutcome => !WonTriggered && !LostTriggered;
+        public bool CanTriggerOutcome => Phase != RestartPhase.FadingOut
+            && Outcome == LevelOutcomeState.Playing;
 
         /// <summary>
-        /// Whether Om Nom may react to candy or light. Suppressed during a win/loss transition
-        /// so a sad Om Nom does not chase a surviving candy.
+        /// Whether Om Nom may react to candy or light. Suppressed after any outcome claims the
+        /// level so a sad Om Nom does not chase a surviving candy.
         /// </summary>
         /// <param name="targetAlreadyFed">Whether this Om Nom has already eaten.</param>
         /// <returns><see langword="true"/> when gameplay reactions are allowed.</returns>
         public bool CanReactToCandy(bool targetAlreadyFed = false)
         {
-            return !TransitionActive && !targetAlreadyFed;
+            return Outcome == LevelOutcomeState.Playing && !targetAlreadyFed;
         }
 
         /// <summary>
@@ -93,49 +123,84 @@ namespace CutTheRopeDX.GameMain
         }
 
         /// <summary>
-        /// Clears the win/lose flags and the transition flag, leaving the restart phase alone.
+        /// Returns the outcome machine to normal play, leaving the restart phase alone.
         /// Call from scene setup, which also runs in the middle of a restart.
         /// </summary>
         public void ResetOutcome()
         {
-            WonTriggered = false;
-            LostTriggered = false;
-            TransitionActive = false;
+            Outcome = LevelOutcomeState.Playing;
         }
 
-        /// <summary>Starts the restart dim animation.</summary>
-        public void BeginRestartDim()
+        /// <summary>Atomically starts a manual restart or completes an active loss into restart.</summary>
+        /// <returns><see langword="true"/> when restart dimming started.</returns>
+        public bool TryBeginRestartDim()
         {
+            if (Phase != RestartPhase.Playing
+                || Outcome is not (LevelOutcomeState.Playing or LevelOutcomeState.Losing))
+            {
+                return false;
+            }
+
+            if (Outcome == LevelOutcomeState.Losing)
+            {
+                Outcome = LevelOutcomeState.Lost;
+            }
             Phase = RestartPhase.FadingOut;
             DimTime = DimDuration;
+            return true;
         }
 
-        /// <summary>Marks the win sequence as started.</summary>
-        public void MarkWon()
+        /// <summary>Atomically claims a playing level for the win sequence.</summary>
+        /// <returns><see langword="true"/> when the win sequence claimed the outcome.</returns>
+        public bool TryBeginWin()
         {
-            WonTriggered = true;
-            TransitionActive = true;
+            if (!CanTriggerOutcome)
+            {
+                return false;
+            }
+
+            Outcome = LevelOutcomeState.Winning;
+            return true;
         }
 
-        /// <summary>Marks the loss sequence as started.</summary>
-        public void MarkLost()
+        /// <summary>Atomically starts an immediate or previously scheduled loss sequence.</summary>
+        /// <returns><see langword="true"/> when the loss sequence claimed the outcome.</returns>
+        public bool TryBeginLoss()
         {
-            LostTriggered = true;
-            TransitionActive = true;
+            if (Phase == RestartPhase.FadingOut
+                || Outcome is not (LevelOutcomeState.Playing or LevelOutcomeState.PendingLoss))
+            {
+                return false;
+            }
+
+            Outcome = LevelOutcomeState.Losing;
+            return true;
         }
 
-        /// <summary>Marks a transition active without committing to an outcome yet.</summary>
-        /// <remarks>Used when a loss is scheduled after a delay: without this, a candy eaten
-        /// during the delay would satisfy the win check and produce a false win.</remarks>
-        public void MarkTransitionActive()
+        /// <summary>Atomically reserves a playing level for a delayed loss.</summary>
+        /// <returns><see langword="true"/> when this call reserved the outcome.</returns>
+        public bool TryScheduleLoss()
         {
-            TransitionActive = true;
+            if (!CanTriggerOutcome)
+            {
+                return false;
+            }
+
+            Outcome = LevelOutcomeState.PendingLoss;
+            return true;
         }
 
-        /// <summary>Ends the transition without clearing the win/lose flags.</summary>
-        public void EndTransition()
+        /// <summary>Completes the active win presentation.</summary>
+        /// <returns><see langword="true"/> when an active win became complete.</returns>
+        public bool CompleteWinTransition()
         {
-            TransitionActive = false;
+            if (Outcome != LevelOutcomeState.Winning)
+            {
+                return false;
+            }
+
+            Outcome = LevelOutcomeState.Won;
+            return true;
         }
 
         /// <summary>
@@ -175,7 +240,6 @@ namespace CutTheRopeDX.GameMain
             }
 
             Phase = RestartPhase.Playing;
-            TransitionActive = false;
             return RestartStep.Completed;
         }
     }


### PR DESCRIPTION
## Description

Replace the independent level-flow flags with one `LevelOutcomeState` machine whose transitions are atomic try-methods. Every win, loss and restart decision now goes through a single owner that cannot represent contradictory state.

With the changes, outcome presentations become skippable: a player can restart out of a sad Om Nom or a chewing animation, and can pause during either, instead of sitting through an unskippable cutscene.