### PR TITLE
refactor: Consolidate mechanical hand state, scope rotation to a single hold

### DIFF
--- a/CutTheRopeDX.Tests/Interactions/Act.cs
+++ b/CutTheRopeDX.Tests/Interactions/Act.cs
@@ -389,11 +389,10 @@ namespace CutTheRopeDX.Tests.Interactions
         /// <returns><see langword="true"/> when the settle owed the drop sound.</returns>
         public static bool SettleOwedDropSound(MechanicalHand hand)
         {
-            Assert.Equal(MechanicalHand.STATE_HAND_RELEASE, hand.state);
-            bool owed = !hand.releaseSoundPlayed;
-            hand.state = MechanicalHand.STATE_HAND_IDLE;
-            hand.releaseSoundPlayed = false;
-            return owed;
+            Assert.Equal(MechanicalHandState.Releasing, hand.State);
+            HandSettle settle = hand.TrySettleToIdle(MechanicalHand.MH_RELEASE_DISTANCE + 1f);
+            Assert.NotEqual(HandSettle.Stayed, settle);
+            return settle == HandSettle.SettledOwingDropSound;
         }
 
         /// <summary>

--- a/CutTheRopeDX.Tests/Interactions/Act.cs
+++ b/CutTheRopeDX.Tests/Interactions/Act.cs
@@ -376,7 +376,7 @@ namespace CutTheRopeDX.Tests.Interactions
         /// <param name="hand">Hand to arm.</param>
         public static void ArmClap(MechanicalHand hand)
         {
-            hand.canPlayClap = true;
+            hand.ArmClap();
         }
 
         /// <summary>

--- a/CutTheRopeDX.Tests/Interactions/Act.cs
+++ b/CutTheRopeDX.Tests/Interactions/Act.cs
@@ -344,6 +344,58 @@ namespace CutTheRopeDX.Tests.Interactions
             hand.cPoint.pos = hand.ClawPosition();
         }
 
+        /// <summary>Taps a hand's claw, which is how a player makes it drop the candy.</summary>
+        /// <param name="scene">Scene under test.</param>
+        /// <param name="hand">Hand whose claw is tapped.</param>
+        public static void TapClaw(GameScene scene, MechanicalHand hand)
+        {
+            Vector claw = hand.ClawPosition();
+            Assert.True(scene.TouchDownXYIndex(claw.X, claw.Y, 0), "the claw tap was not handled");
+            HeadlessGame.StepFrames(scene, 1);
+        }
+
+        /// <summary>
+        /// Starts a segment rotation and makes it the hand's rotating segment, as a button press
+        /// would. The segment must have been created rotatable.
+        /// </summary>
+        /// <param name="scene">Scene under test.</param>
+        /// <param name="hand">Hand to rotate.</param>
+        /// <param name="segmentIndex">Segment to rotate.</param>
+        public static void RotateSegment(GameScene scene, MechanicalHand hand, int segmentIndex = 0)
+        {
+            MechanicalHandSegment segment = hand.SegmentAtIndex(segmentIndex);
+            segment.Rotate();
+            Assert.NotNull(segment.GetCurrentTimeline());
+            hand.rotatingSegment = segment;
+            HeadlessGame.StepFrames(scene, 2);
+        }
+
+        /// <summary>
+        /// Makes a hand eligible to clap, as pressing one of its rotate buttons does.
+        /// </summary>
+        /// <param name="hand">Hand to arm.</param>
+        public static void ArmClap(MechanicalHand hand)
+        {
+            hand.canPlayClap = true;
+        }
+
+        /// <summary>
+        /// Settles a releasing hand to idle and reports whether that settle still owed the drop
+        /// sound. Sounds are not observable headlessly, so this seam is the only way to pin that
+        /// axis; its body is rewritten when the settle transition lands, leaving every caller's
+        /// assertions untouched.
+        /// </summary>
+        /// <param name="hand">Hand to settle.</param>
+        /// <returns><see langword="true"/> when the settle owed the drop sound.</returns>
+        public static bool SettleOwedDropSound(MechanicalHand hand)
+        {
+            Assert.Equal(MechanicalHand.STATE_HAND_RELEASE, hand.state);
+            bool owed = !hand.releaseSoundPlayed;
+            hand.state = MechanicalHand.STATE_HAND_IDLE;
+            hand.releaseSoundPlayed = false;
+            return owed;
+        }
+
         /// <summary>
         /// Recomputes a tube's hole positions after it has been moved. The tube caches them and
         /// only refreshes on rotation, so a moved tube would otherwise keep catching candy at the

--- a/CutTheRopeDX.Tests/Interactions/BambooTubeEntryRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/BambooTubeEntryRowTests.cs
@@ -33,7 +33,7 @@ namespace CutTheRopeDX.Tests.Interactions
             Act.EnterBambooTube(scene, candy, TubeMouth.CatchesFalling);
 
             Assert.Null(candy.Lifecycle.Attachments.Hand);
-            Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, hand.state);
+            Assert.NotEqual(MechanicalHandState.HoldingCandy, hand.State);
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/Interactions/EatenRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/EatenRowTests.cs
@@ -29,7 +29,7 @@ namespace CutTheRopeDX.Tests.Interactions
             MechanicalHand hand = Act.GrabWithHand(scene, candy);
             Act.Eat(scene, candy);
             Assert.Null(candy.Lifecycle.Attachments.Hand);
-            Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, hand.state);
+            Assert.NotEqual(MechanicalHandState.HoldingCandy, hand.State);
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/Interactions/HandCandyPairingTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/HandCandyPairingTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Pins the one hand fact the hand cannot enforce on its own: a hand's
+    /// <see cref="MechanicalHandState"/> and the candy's <see cref="CandyAttachments.Hand"/> are two
+    /// separate records of the same hold, written by two separate statements at every grab and
+    /// release site. They must agree after every path, or a release can reach for the wrong candy -
+    /// which is what the <c>?? star</c> fallbacks at the release sites quietly paper over.
+    /// </summary>
+    public sealed class HandCandyPairingTests
+    {
+        [Fact]
+        public void AGrabPairsExactlyOneCandyToTheHand()
+        {
+            (GameScene scene, CandyContext candy) = DuoRig();
+
+            _ = Act.GrabWithHand(scene, candy);
+
+            AssertPairingConsistent(scene, "after a grab");
+        }
+
+        [Fact]
+        public void AStealMovesThePairingToTheNewHand()
+        {
+            (GameScene scene, CandyContext candy) = DuoRig();
+            MechanicalHand first = Act.GrabWithHand(scene, candy, handIndex: 0);
+
+            MechanicalHand second = Act.GrabWithHand(scene, candy, handIndex: 1);
+
+            Assert.NotSame(first, second);
+            AssertPairingConsistent(scene, "after a steal");
+        }
+
+        [Fact]
+        public void AClawTapClearsThePairing()
+        {
+            (GameScene scene, CandyContext candy) = DuoRig();
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            Act.TapClaw(scene, hand);
+
+            AssertPairingConsistent(scene, "after a claw tap");
+        }
+
+        [Fact]
+        public void DetachActiveHandsClearsEveryPairing()
+        {
+            (GameScene scene, CandyContext candy) = DuoRig();
+            _ = Act.GrabWithHand(scene, candy);
+
+            scene.DetachActiveHands();
+
+            AssertPairingConsistent(scene, "after detaching all hands");
+        }
+
+        [Fact]
+        public void DetachHandsForPointClearsOnlyThatCandysPairing()
+        {
+            (GameScene scene, CandyContext first) = DuoRig(s => s.Candy(60, 200, number: "2"));
+            CandyContext second = scene.Candies()[1];
+            Interaction.Hover(second);
+            MechanicalHand firstHand = Act.GrabWithHand(scene, first, handIndex: 0);
+            MechanicalHand secondHand = Act.GrabWithHand(scene, second, handIndex: 1);
+
+            scene.DetachHandsForPoint(first.WholeBody.Point);
+
+            Assert.Null(first.Lifecycle.Attachments.Hand);
+            Assert.Same(secondHand, second.Lifecycle.Attachments.Hand);
+            _ = firstHand;
+            AssertPairingConsistent(scene, "after detaching one candy's hand");
+        }
+
+        [Fact]
+        public void RemovingTheCandyClearsThePairing()
+        {
+            (GameScene scene, CandyContext candy) = DuoRig();
+            _ = Act.GrabWithHand(scene, candy);
+
+            scene.BreakCandyBody(candy.WholeBody);
+
+            AssertPairingConsistent(scene, "after the candy was removed");
+        }
+
+        [Fact]
+        public void SettlingBackToIdleLeavesNoPairing()
+        {
+            (GameScene scene, CandyContext candy) = DuoRig();
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+            Act.TapClaw(scene, hand);
+
+            Vector claw = hand.ClawPosition();
+            Interaction.PlaceCandyAt(candy, new Vector(claw.X + (MechanicalHand.MH_RELEASE_DISTANCE * 3f), claw.Y));
+            Assert.True(
+                Interaction.StepUntil(scene, () => hand.State == MechanicalHandState.Idle, maxFrames: 30),
+                "the hand never settled to idle");
+
+            AssertPairingConsistent(scene, "after settling to idle");
+        }
+
+        /// <summary>
+        /// Asserts the hand-side and candy-side records of every hold agree: a holding hand is
+        /// claimed by exactly one candy, any other hand by none, and every claimed candy names a
+        /// hand of this scene that agrees it is holding.
+        /// </summary>
+        /// <param name="scene">Scene to check.</param>
+        /// <param name="stage">What just happened, for the failure message.</param>
+        private static void AssertPairingConsistent(GameScene scene, string stage)
+        {
+            List<MechanicalHand> hands = scene.Hands();
+            List<CandyContext> candies = scene.Candies();
+
+            foreach (MechanicalHand hand in hands)
+            {
+                int claims = candies.Count(c => c.Lifecycle.Attachments.Hand == hand);
+                int expected = hand.State == MechanicalHandState.HoldingCandy ? 1 : 0;
+                Assert.True(
+                    claims == expected,
+                    $"{stage}: a {hand.State} hand is claimed by {claims} candies, expected {expected}");
+            }
+
+            foreach (CandyContext candy in candies)
+            {
+                MechanicalHand holder = candy.Lifecycle.Attachments.Hand;
+                if (holder == null)
+                {
+                    continue;
+                }
+
+                Assert.True(hands.Contains(holder), $"{stage}: a candy names a hand the scene does not own");
+                Assert.True(
+                    holder.State == MechanicalHandState.HoldingCandy,
+                    $"{stage}: a candy is held by a hand in state {holder.State}");
+            }
+        }
+
+        /// <summary>Two hands and a hovering candy, so steals and rivalry are reachable.</summary>
+        private static (GameScene Scene, CandyContext Candy) DuoRig(Func<Scenario, Scenario> extra = null)
+        {
+            Scenario scenario = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(20, 460)
+                .Hand(20, 40, segmentLength: 20, segmentAngle: 90f)
+                .Hand(300, 40, segmentLength: 20, segmentAngle: 90f);
+
+            GameScene scene = (extra?.Invoke(scenario) ?? scenario).Build();
+            CandyContext candy = scene.Candy();
+            Interaction.Hover(candy);
+            return (scene, candy);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/HandGrabRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/HandGrabRowTests.cs
@@ -32,7 +32,7 @@ namespace CutTheRopeDX.Tests.Interactions
             MechanicalHand claimant = Act.GrabWithHand(scene, candy, handIndex: 0);
 
             Assert.Same(claimant, candy.Lifecycle.Attachments.Hand);
-            Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, rival.state);
+            Assert.NotEqual(MechanicalHandState.HoldingCandy, rival.State);
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/Interactions/LanternCaptureRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/LanternCaptureRowTests.cs
@@ -32,7 +32,7 @@ namespace CutTheRopeDX.Tests.Interactions
             Act.CaptureInLantern(scene, candy);
 
             Assert.Null(candy.Lifecycle.Attachments.Hand);
-            Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, hand.state);
+            Assert.NotEqual(MechanicalHandState.HoldingCandy, hand.State);
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/Interactions/LostRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/LostRowTests.cs
@@ -36,7 +36,7 @@ namespace CutTheRopeDX.Tests.Interactions
             Act.BreakOnSpikes(scene, candy);
 
             Assert.Null(candy.Lifecycle.Attachments.Hand);
-            Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, hand.state);
+            Assert.NotEqual(MechanicalHandState.HoldingCandy, hand.State);
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/Interactions/MagicHatEntryRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/MagicHatEntryRowTests.cs
@@ -33,7 +33,7 @@ namespace CutTheRopeDX.Tests.Interactions
             Act.EnterHat(scene, candy);
 
             Assert.Null(candy.Lifecycle.Attachments.Hand);
-            Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, hand.state);
+            Assert.NotEqual(MechanicalHandState.HoldingCandy, hand.State);
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/Interactions/MechanicalHandStateTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/MechanicalHandStateTests.cs
@@ -238,8 +238,8 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Assert.Equal(MechanicalHandState.Idle, first.State);
             Assert.Equal(MechanicalHandState.Idle, second.State);
-            Assert.True(first.clapTimer > 0f, "the first hand's clap cooldown was not armed");
-            Assert.True(second.clapTimer > 0f, "the second hand's clap cooldown was not armed");
+            Assert.True(first.ClapTimer > 0f, "the first hand's clap cooldown was not armed");
+            Assert.True(second.ClapTimer > 0f, "the second hand's clap cooldown was not armed");
         }
 
         [Theory]
@@ -293,6 +293,45 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Assert.Equal(MechanicalHandState.HoldingCandy, hand.State);
             Assert.False(hand.DoRotateCandy);
+        }
+
+        [Theory]
+        [InlineData(true, true)]    // armed and cool: claps
+        [InlineData(false, false)]  // neither armed: no clap
+        public void ClapFiresOnlyWhenAHandIsArmed(bool armFirst, bool expectedClap)
+        {
+            (GameScene scene, CandyContext candy) = DuoRig();
+            MechanicalHand first = scene.Hands()[0];
+            MechanicalHand second = scene.Hands()[1];
+            if (armFirst)
+            {
+                first.ArmClap();
+            }
+
+            Vector meeting = new(candy.WholeBody.Point.pos.X + 400f, candy.WholeBody.Point.pos.Y);
+            Act.MoveClawTo(first, meeting);
+            Act.MoveClawTo(second, new Vector(meeting.X + 50f, meeting.Y));
+
+            Assert.Equal(expectedClap, first.TryClapWith(second));
+            Assert.True(first.ClapTimer > 0f, "the first hand's cooldown was not armed");
+            Assert.True(second.ClapTimer > 0f, "the second hand's cooldown was not armed");
+        }
+
+        [Fact]
+        public void ClapDoesNotFireOutOfRangeAndLeavesCooldownsAlone()
+        {
+            (GameScene scene, CandyContext candy) = DuoRig();
+            MechanicalHand first = scene.Hands()[0];
+            MechanicalHand second = scene.Hands()[1];
+            first.ArmClap();
+
+            Vector meeting = new(candy.WholeBody.Point.pos.X + 400f, candy.WholeBody.Point.pos.Y);
+            Act.MoveClawTo(first, meeting);
+            Act.MoveClawTo(second, new Vector(meeting.X + (MechanicalHand.MH_CLAP_DISTANCE * 2f), meeting.Y));
+
+            Assert.False(first.TryClapWith(second));
+            Assert.Equal(0f, first.ClapTimer);
+            Assert.Equal(0f, second.ClapTimer);
         }
 
         /// <summary>One rotatable hand, parked out of reach; the candy hovers where it loads.</summary>

--- a/CutTheRopeDX.Tests/Interactions/MechanicalHandStateTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/MechanicalHandStateTests.cs
@@ -38,6 +38,143 @@ namespace CutTheRopeDX.Tests.Interactions
             Assert.Null(candy.Lifecycle.Attachments.Hand);
         }
 
+        [Fact]
+        public void ClawTapReleasesAndOwesNoDropSound()
+        {
+            (GameScene scene, CandyContext candy) = SoloRig();
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            Act.TapClaw(scene, hand);
+
+            Assert.Equal(MechanicalHand.STATE_HAND_RELEASE, hand.state);
+            Assert.False(hand.doRotateCandy);
+            Assert.False(Act.SettleOwedDropSound(hand));
+        }
+
+        [Fact]
+        public void DetachActiveHandsReleasesAndStillOwesTheDropSound()
+        {
+            (GameScene scene, CandyContext candy) = SoloRig();
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            scene.DetachActiveHands();
+
+            Assert.Equal(MechanicalHand.STATE_HAND_RELEASE, hand.state);
+            Assert.False(hand.doRotateCandy);
+            Assert.True(Act.SettleOwedDropSound(hand));
+        }
+
+        [Fact]
+        public void DetachHandsForPointReleasesAndOwesNoDropSound()
+        {
+            (GameScene scene, CandyContext candy) = SoloRig();
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            scene.DetachHandsForPoint(candy.WholeBody.Point);
+
+            Assert.Equal(MechanicalHand.STATE_HAND_RELEASE, hand.state);
+            Assert.False(hand.doRotateCandy);
+            Assert.False(Act.SettleOwedDropSound(hand));
+        }
+
+        [Fact]
+        public void CandyRemovalReleasesAndOwesNoDropSound()
+        {
+            (GameScene scene, CandyContext candy) = SoloRig();
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            scene.BreakCandyBody(candy.WholeBody);
+
+            Assert.Equal(MechanicalHand.STATE_HAND_RELEASE, hand.state);
+            Assert.False(hand.doRotateCandy);
+            Assert.False(Act.SettleOwedDropSound(hand));
+        }
+
+        [Fact]
+        public void StealLeavesTheRivalHandsRotationFlagSet()
+        {
+            // PINS TODAY'S BEHAVIOR. Task 3 flips this assertion deliberately: both reference
+            // decompiles omit the clear here, but the omission was only safe under one candy.
+            (GameScene scene, CandyContext candy) = DuoRig(s => s.Rocket(160, 200, impulse: 0f));
+            _ = Act.BindRocket(scene, candy);
+            MechanicalHand first = Act.GrabWithHand(scene, candy, handIndex: 0);
+            Assert.True(
+                Interaction.StepUntil(scene, () => first.doRotateCandy, maxFrames: 10),
+                "the first hand never started rotating its rocket candy");
+
+            MechanicalHand second = Act.GrabWithHand(scene, candy, handIndex: 1);
+
+            Assert.Same(second, candy.Lifecycle.Attachments.Hand);
+            Assert.Equal(MechanicalHand.STATE_HAND_RELEASE, first.state);
+            Assert.True(first.doRotateCandy);
+        }
+
+        [Fact]
+        public void GrabbingAPlainCandyNeverStartsRotation()
+        {
+            (GameScene scene, CandyContext candy) = SoloRig();
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            HeadlessGame.StepFrames(scene, 10);
+
+            Assert.Equal(MechanicalHand.STATE_HAND_CANDY, hand.state);
+            Assert.False(hand.doRotateCandy);
+        }
+
+        [Fact]
+        public void GrabbingARocketCandyStartsRotation()
+        {
+            (GameScene scene, CandyContext candy) = SoloRig(s => s.Rocket(160, 200, impulse: 0f));
+            _ = Act.BindRocket(scene, candy);
+
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            Assert.True(
+                Interaction.StepUntil(scene, () => hand.doRotateCandy, maxFrames: 10),
+                "the hand never started rotating its rocket candy");
+        }
+
+        [Fact]
+        public void AReleasingHandSettlesOnlyOnceTheCandyIsClear()
+        {
+            (GameScene scene, CandyContext candy) = SoloRig();
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+            Act.TapClaw(scene, hand);
+            Assert.Equal(MechanicalHand.STATE_HAND_RELEASE, hand.state);
+
+            // Parked on the claw: inside MH_RELEASE_DISTANCE, so the hand must hold its state.
+            Vector claw = hand.ClawPosition();
+            Interaction.PlaceCandyAt(candy, claw);
+            HeadlessGame.StepFrames(scene, 5);
+            Assert.Equal(MechanicalHand.STATE_HAND_RELEASE, hand.state);
+
+            // Well clear of the claw, and far outside MH_GRAB_DISTANCE so it cannot be re-grabbed.
+            Interaction.PlaceCandyAt(candy, new Vector(claw.X + (MechanicalHand.MH_RELEASE_DISTANCE * 3f), claw.Y));
+            Assert.True(
+                Interaction.StepUntil(scene, () => hand.state == MechanicalHand.STATE_HAND_IDLE, maxFrames: 30),
+                "the hand never settled to idle");
+        }
+
+        [Fact]
+        public void IdleHandsInRangeArmBothClapCooldowns()
+        {
+            (GameScene scene, CandyContext candy) = DuoRig();
+            MechanicalHand first = scene.Hands()[0];
+            MechanicalHand second = scene.Hands()[1];
+            Act.ArmClap(first);
+
+            // Park the pair together, far enough from the candy that neither can grab it.
+            Vector meeting = new(candy.WholeBody.Point.pos.X + 400f, candy.WholeBody.Point.pos.Y);
+            Act.MoveClawTo(first, meeting);
+            Act.MoveClawTo(second, new Vector(meeting.X + 50f, meeting.Y));
+            HeadlessGame.StepFrames(scene, 1);
+
+            Assert.Equal(MechanicalHand.STATE_HAND_IDLE, first.state);
+            Assert.Equal(MechanicalHand.STATE_HAND_IDLE, second.state);
+            Assert.True(first.clapTimer > 0f, "the first hand's clap cooldown was not armed");
+            Assert.True(second.clapTimer > 0f, "the second hand's clap cooldown was not armed");
+        }
+
         /// <summary>One rotatable hand, parked out of reach; the candy hovers where it loads.</summary>
         private static (GameScene Scene, CandyContext Candy) SoloRig(Func<Scenario, Scenario> extra = null)
         {

--- a/CutTheRopeDX.Tests/Interactions/MechanicalHandStateTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/MechanicalHandStateTests.cs
@@ -1,6 +1,7 @@
 using System;
 
 using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.Framework.Helpers;
 using CutTheRopeDX.Framework.Visual;
 using CutTheRopeDX.GameMain;
 
@@ -91,10 +92,11 @@ namespace CutTheRopeDX.Tests.Interactions
         }
 
         [Fact]
-        public void StealLeavesTheRivalHandsRotationFlagSet()
+        public void StealClearsTheRivalHandsRotationFlag()
         {
-            // PINS TODAY'S BEHAVIOR. Task 3 flips this assertion deliberately: both reference
-            // decompiles omit the clear here, but the omission was only safe under one candy.
+            // Both reference decompiles omit this clear (iOS 38981, WP7 GameScene.cs:1569), which was
+            // safe only because Experiments had one candy per level. DX supports many, so rotation
+            // state must not outlive the hold it belongs to.
             (GameScene scene, CandyContext candy) = DuoRig(s => s.Rocket(160, 200, impulse: 0f));
             _ = Act.BindRocket(scene, candy);
             MechanicalHand first = Act.GrabWithHand(scene, candy, handIndex: 0);
@@ -106,7 +108,72 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Assert.Same(second, candy.Lifecycle.Attachments.Hand);
             Assert.Equal(MechanicalHand.STATE_HAND_RELEASE, first.state);
-            Assert.True(first.doRotateCandy);
+            Assert.False(first.doRotateCandy);
+        }
+
+        [Fact]
+        public void AStolenFromHandDoesNotSpinItsNextCandy()
+        {
+            // Rocket candy at 160,200; a second, plain candy parked away from it.
+            (GameScene scene, CandyContext rocketCandy) = DuoRig(s => s
+                .Rocket(160, 200, impulse: 0f)
+                .Candy(60, 200, number: "2"));
+            CandyContext plainCandy = scene.Candies()[1];
+            Interaction.Hover(plainCandy);
+            _ = Act.BindRocket(scene, rocketCandy);
+
+            MechanicalHand first = Act.GrabWithHand(scene, rocketCandy, handIndex: 0);
+            Assert.True(
+                Interaction.StepUntil(scene, () => first.doRotateCandy, maxFrames: 10),
+                "the first hand never started rotating its rocket candy");
+            _ = Act.GrabWithHand(scene, rocketCandy, handIndex: 1);
+
+            // The stolen-from hand settles, then takes the plain candy instead.
+            Interaction.PlaceCandyAt(rocketCandy, new Vector(2000f, 2000f));
+            Assert.True(
+                Interaction.StepUntil(scene, () => first.state == MechanicalHand.STATE_HAND_IDLE, maxFrames: 60),
+                "the stolen-from hand never settled to idle");
+            _ = Act.GrabWithHand(scene, plainCandy, handIndex: 0);
+
+            // The update loop rotates Main when present, falling back to Visual, so watch the same one.
+            GameObject spun = plainCandy.WholeBody.Main ?? plainCandy.WholeBody.Visual;
+            float before = spun.rotation;
+            Act.RotateSegment(scene, first);
+
+            Assert.False(first.doRotateCandy);
+            Assert.Equal(before, spun.rotation);
+        }
+
+        [Fact]
+        public void ARegrabbedRocketCandyStillRotates()
+        {
+            (GameScene scene, CandyContext candy) = DuoRig(s => s.Rocket(160, 200, impulse: 0f));
+            _ = Act.BindRocket(scene, candy);
+            MechanicalHand first = Act.GrabWithHand(scene, candy, handIndex: 0);
+            Assert.True(
+                Interaction.StepUntil(scene, () => first.doRotateCandy, maxFrames: 10),
+                "the first hand never started rotating its rocket candy");
+
+            MechanicalHand second = Act.GrabWithHand(scene, candy, handIndex: 1);
+            Act.TapClaw(scene, second);
+
+            // A releasing hand settles only once the candy is outside MH_RELEASE_DISTANCE, and the
+            // grab helper parks the claw on the candy, so the hand has to be walked clear first.
+            Vector parked = new(
+                candy.WholeBody.Point.pos.X + (MechanicalHand.MH_RELEASE_DISTANCE * 4f),
+                candy.WholeBody.Point.pos.Y);
+            Assert.True(
+                Interaction.StepUntil(
+                    scene,
+                    () => Act.MoveClawTo(first, parked),
+                    () => first.state == MechanicalHand.STATE_HAND_IDLE,
+                    maxFrames: 30),
+                "the stolen-from hand never settled to idle");
+            _ = Act.GrabWithHand(scene, candy, handIndex: 0);
+
+            Assert.True(
+                Interaction.StepUntil(scene, () => first.doRotateCandy, maxFrames: 10),
+                "rotation was not re-derived after the candy came back");
         }
 
         [Fact]

--- a/CutTheRopeDX.Tests/Interactions/MechanicalHandStateTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/MechanicalHandStateTests.cs
@@ -2,7 +2,6 @@ using System;
 
 using CutTheRopeDX.Framework.Core;
 using CutTheRopeDX.Framework.Helpers;
-using CutTheRopeDX.Framework.Visual;
 using CutTheRopeDX.GameMain;
 
 using Xunit;

--- a/CutTheRopeDX.Tests/Interactions/MechanicalHandStateTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/MechanicalHandStateTests.cs
@@ -47,8 +47,8 @@ namespace CutTheRopeDX.Tests.Interactions
 
             Act.TapClaw(scene, hand);
 
-            Assert.Equal(MechanicalHand.STATE_HAND_RELEASE, hand.state);
-            Assert.False(hand.doRotateCandy);
+            Assert.Equal(MechanicalHandState.Releasing, hand.State);
+            Assert.False(hand.DoRotateCandy);
             Assert.False(Act.SettleOwedDropSound(hand));
         }
 
@@ -60,8 +60,8 @@ namespace CutTheRopeDX.Tests.Interactions
 
             scene.DetachActiveHands();
 
-            Assert.Equal(MechanicalHand.STATE_HAND_RELEASE, hand.state);
-            Assert.False(hand.doRotateCandy);
+            Assert.Equal(MechanicalHandState.Releasing, hand.State);
+            Assert.False(hand.DoRotateCandy);
             Assert.True(Act.SettleOwedDropSound(hand));
         }
 
@@ -73,8 +73,8 @@ namespace CutTheRopeDX.Tests.Interactions
 
             scene.DetachHandsForPoint(candy.WholeBody.Point);
 
-            Assert.Equal(MechanicalHand.STATE_HAND_RELEASE, hand.state);
-            Assert.False(hand.doRotateCandy);
+            Assert.Equal(MechanicalHandState.Releasing, hand.State);
+            Assert.False(hand.DoRotateCandy);
             Assert.False(Act.SettleOwedDropSound(hand));
         }
 
@@ -86,8 +86,8 @@ namespace CutTheRopeDX.Tests.Interactions
 
             scene.BreakCandyBody(candy.WholeBody);
 
-            Assert.Equal(MechanicalHand.STATE_HAND_RELEASE, hand.state);
-            Assert.False(hand.doRotateCandy);
+            Assert.Equal(MechanicalHandState.Releasing, hand.State);
+            Assert.False(hand.DoRotateCandy);
             Assert.False(Act.SettleOwedDropSound(hand));
         }
 
@@ -101,14 +101,14 @@ namespace CutTheRopeDX.Tests.Interactions
             _ = Act.BindRocket(scene, candy);
             MechanicalHand first = Act.GrabWithHand(scene, candy, handIndex: 0);
             Assert.True(
-                Interaction.StepUntil(scene, () => first.doRotateCandy, maxFrames: 10),
+                Interaction.StepUntil(scene, () => first.DoRotateCandy, maxFrames: 10),
                 "the first hand never started rotating its rocket candy");
 
             MechanicalHand second = Act.GrabWithHand(scene, candy, handIndex: 1);
 
             Assert.Same(second, candy.Lifecycle.Attachments.Hand);
-            Assert.Equal(MechanicalHand.STATE_HAND_RELEASE, first.state);
-            Assert.False(first.doRotateCandy);
+            Assert.Equal(MechanicalHandState.Releasing, first.State);
+            Assert.False(first.DoRotateCandy);
         }
 
         [Fact]
@@ -124,14 +124,14 @@ namespace CutTheRopeDX.Tests.Interactions
 
             MechanicalHand first = Act.GrabWithHand(scene, rocketCandy, handIndex: 0);
             Assert.True(
-                Interaction.StepUntil(scene, () => first.doRotateCandy, maxFrames: 10),
+                Interaction.StepUntil(scene, () => first.DoRotateCandy, maxFrames: 10),
                 "the first hand never started rotating its rocket candy");
             _ = Act.GrabWithHand(scene, rocketCandy, handIndex: 1);
 
             // The stolen-from hand settles, then takes the plain candy instead.
             Interaction.PlaceCandyAt(rocketCandy, new Vector(2000f, 2000f));
             Assert.True(
-                Interaction.StepUntil(scene, () => first.state == MechanicalHand.STATE_HAND_IDLE, maxFrames: 60),
+                Interaction.StepUntil(scene, () => first.State == MechanicalHandState.Idle, maxFrames: 60),
                 "the stolen-from hand never settled to idle");
             _ = Act.GrabWithHand(scene, plainCandy, handIndex: 0);
 
@@ -140,7 +140,7 @@ namespace CutTheRopeDX.Tests.Interactions
             float before = spun.rotation;
             Act.RotateSegment(scene, first);
 
-            Assert.False(first.doRotateCandy);
+            Assert.False(first.DoRotateCandy);
             Assert.Equal(before, spun.rotation);
         }
 
@@ -151,7 +151,7 @@ namespace CutTheRopeDX.Tests.Interactions
             _ = Act.BindRocket(scene, candy);
             MechanicalHand first = Act.GrabWithHand(scene, candy, handIndex: 0);
             Assert.True(
-                Interaction.StepUntil(scene, () => first.doRotateCandy, maxFrames: 10),
+                Interaction.StepUntil(scene, () => first.DoRotateCandy, maxFrames: 10),
                 "the first hand never started rotating its rocket candy");
 
             MechanicalHand second = Act.GrabWithHand(scene, candy, handIndex: 1);
@@ -166,13 +166,13 @@ namespace CutTheRopeDX.Tests.Interactions
                 Interaction.StepUntil(
                     scene,
                     () => Act.MoveClawTo(first, parked),
-                    () => first.state == MechanicalHand.STATE_HAND_IDLE,
+                    () => first.State == MechanicalHandState.Idle,
                     maxFrames: 30),
                 "the stolen-from hand never settled to idle");
             _ = Act.GrabWithHand(scene, candy, handIndex: 0);
 
             Assert.True(
-                Interaction.StepUntil(scene, () => first.doRotateCandy, maxFrames: 10),
+                Interaction.StepUntil(scene, () => first.DoRotateCandy, maxFrames: 10),
                 "rotation was not re-derived after the candy came back");
         }
 
@@ -184,8 +184,8 @@ namespace CutTheRopeDX.Tests.Interactions
 
             HeadlessGame.StepFrames(scene, 10);
 
-            Assert.Equal(MechanicalHand.STATE_HAND_CANDY, hand.state);
-            Assert.False(hand.doRotateCandy);
+            Assert.Equal(MechanicalHandState.HoldingCandy, hand.State);
+            Assert.False(hand.DoRotateCandy);
         }
 
         [Fact]
@@ -197,7 +197,7 @@ namespace CutTheRopeDX.Tests.Interactions
             MechanicalHand hand = Act.GrabWithHand(scene, candy);
 
             Assert.True(
-                Interaction.StepUntil(scene, () => hand.doRotateCandy, maxFrames: 10),
+                Interaction.StepUntil(scene, () => hand.DoRotateCandy, maxFrames: 10),
                 "the hand never started rotating its rocket candy");
         }
 
@@ -207,18 +207,18 @@ namespace CutTheRopeDX.Tests.Interactions
             (GameScene scene, CandyContext candy) = SoloRig();
             MechanicalHand hand = Act.GrabWithHand(scene, candy);
             Act.TapClaw(scene, hand);
-            Assert.Equal(MechanicalHand.STATE_HAND_RELEASE, hand.state);
+            Assert.Equal(MechanicalHandState.Releasing, hand.State);
 
             // Parked on the claw: inside MH_RELEASE_DISTANCE, so the hand must hold its state.
             Vector claw = hand.ClawPosition();
             Interaction.PlaceCandyAt(candy, claw);
             HeadlessGame.StepFrames(scene, 5);
-            Assert.Equal(MechanicalHand.STATE_HAND_RELEASE, hand.state);
+            Assert.Equal(MechanicalHandState.Releasing, hand.State);
 
             // Well clear of the claw, and far outside MH_GRAB_DISTANCE so it cannot be re-grabbed.
             Interaction.PlaceCandyAt(candy, new Vector(claw.X + (MechanicalHand.MH_RELEASE_DISTANCE * 3f), claw.Y));
             Assert.True(
-                Interaction.StepUntil(scene, () => hand.state == MechanicalHand.STATE_HAND_IDLE, maxFrames: 30),
+                Interaction.StepUntil(scene, () => hand.State == MechanicalHandState.Idle, maxFrames: 30),
                 "the hand never settled to idle");
         }
 
@@ -236,10 +236,63 @@ namespace CutTheRopeDX.Tests.Interactions
             Act.MoveClawTo(second, new Vector(meeting.X + 50f, meeting.Y));
             HeadlessGame.StepFrames(scene, 1);
 
-            Assert.Equal(MechanicalHand.STATE_HAND_IDLE, first.state);
-            Assert.Equal(MechanicalHand.STATE_HAND_IDLE, second.state);
+            Assert.Equal(MechanicalHandState.Idle, first.State);
+            Assert.Equal(MechanicalHandState.Idle, second.State);
             Assert.True(first.clapTimer > 0f, "the first hand's clap cooldown was not armed");
             Assert.True(second.clapTimer > 0f, "the second hand's clap cooldown was not armed");
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void EveryReleaseLeavesTheSameState(bool afterDropSound)
+        {
+            (GameScene scene, CandyContext candy) = SoloRig();
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            if (afterDropSound)
+            {
+                hand.ReleaseCandyAfterDropSound();
+            }
+            else
+            {
+                hand.ReleaseCandy();
+            }
+
+            Assert.Equal(MechanicalHandState.Releasing, hand.State);
+            Assert.False(hand.DoRotateCandy);
+        }
+
+        [Fact]
+        public void SettleReportsWhoOwesTheDropSound()
+        {
+            (GameScene scene, CandyContext candy) = SoloRig();
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            hand.ReleaseCandy();
+            Assert.Equal(HandSettle.Stayed, hand.TrySettleToIdle(MechanicalHand.MH_RELEASE_DISTANCE));
+            Assert.Equal(HandSettle.SettledOwingDropSound, hand.TrySettleToIdle(MechanicalHand.MH_RELEASE_DISTANCE + 1f));
+            Assert.Equal(MechanicalHandState.Idle, hand.State);
+
+            hand.ReleaseCandyAfterDropSound();
+            Assert.Equal(HandSettle.Settled, hand.TrySettleToIdle(MechanicalHand.MH_RELEASE_DISTANCE + 1f));
+            Assert.Equal(MechanicalHandState.Idle, hand.State);
+        }
+
+        [Fact]
+        public void GrabbingStartsAHoldWithNoInheritedRotation()
+        {
+            (GameScene scene, CandyContext candy) = SoloRig(s => s.Rocket(160, 200, impulse: 0f));
+            _ = Act.BindRocket(scene, candy);
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+            Assert.True(
+                Interaction.StepUntil(scene, () => hand.DoRotateCandy, maxFrames: 10),
+                "the hand never started rotating its rocket candy");
+
+            hand.GrabCandy();
+
+            Assert.Equal(MechanicalHandState.HoldingCandy, hand.State);
+            Assert.False(hand.DoRotateCandy);
         }
 
         /// <summary>One rotatable hand, parked out of reach; the candy hovers where it loads.</summary>

--- a/CutTheRopeDX.Tests/Interactions/MechanicalHandStateTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/MechanicalHandStateTests.cs
@@ -1,0 +1,70 @@
+using System;
+
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.Framework.Visual;
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Pins mechanical hand state transitions: which fields each release path writes, when a
+    /// releasing hand settles, and how rotation state is scoped to a single hold.
+    /// </summary>
+    public sealed class MechanicalHandStateTests
+    {
+        [Fact]
+        public void ARotatableSegmentActuallyRotates()
+        {
+            (GameScene scene, CandyContext candy) = SoloRig();
+            MechanicalHand hand = scene.Hands()[0];
+            _ = candy;
+
+            Act.RotateSegment(scene, hand);
+
+            Assert.Same(hand.SegmentAtIndex(0), hand.rotatingSegment);
+            Assert.NotEqual(0f, hand.SegmentAtIndex(0).RotationDelta());
+        }
+
+        [Fact]
+        public void TappingTheClawReleasesTheHeldCandy()
+        {
+            (GameScene scene, CandyContext candy) = SoloRig();
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            Act.TapClaw(scene, hand);
+
+            Assert.Null(candy.Lifecycle.Attachments.Hand);
+        }
+
+        /// <summary>One rotatable hand, parked out of reach; the candy hovers where it loads.</summary>
+        private static (GameScene Scene, CandyContext Candy) SoloRig(Func<Scenario, Scenario> extra = null)
+        {
+            return Rig(extra, handCount: 1);
+        }
+
+        /// <summary>Two rotatable hands, both parked out of reach on opposite sides.</summary>
+        private static (GameScene Scene, CandyContext Candy) DuoRig(Func<Scenario, Scenario> extra = null)
+        {
+            return Rig(extra, handCount: 2);
+        }
+
+        private static (GameScene Scene, CandyContext Candy) Rig(Func<Scenario, Scenario> extra, int handCount)
+        {
+            Scenario scenario = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(20, 460)
+                .Hand(20, 40, segmentLength: 20, segmentAngle: 90f, rotatable: true);
+            if (handCount > 1)
+            {
+                scenario = scenario.Hand(300, 40, segmentLength: 20, segmentAngle: 90f, rotatable: true);
+            }
+
+            GameScene scene = (extra?.Invoke(scenario) ?? scenario).Build();
+            CandyContext candy = scene.Candy();
+            Interaction.Hover(candy);
+            return (scene, candy);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/MouseGrabRowTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/MouseGrabRowTests.cs
@@ -33,7 +33,7 @@ namespace CutTheRopeDX.Tests.Interactions
             _ = Act.CarryByMouse(scene, candy);
 
             Assert.Null(candy.Lifecycle.Attachments.Hand);
-            Assert.NotEqual(MechanicalHand.STATE_HAND_CANDY, hand.state);
+            Assert.NotEqual(MechanicalHandState.HoldingCandy, hand.State);
             Assert.True(scene.MouseCarries(candy));
         }
 

--- a/CutTheRopeDX.Tests/Interactions/Scenario.cs
+++ b/CutTheRopeDX.Tests/Interactions/Scenario.cs
@@ -301,14 +301,15 @@ namespace CutTheRopeDX.Tests.Interactions
         /// <param name="y">Level-space Y of the shoulder.</param>
         /// <param name="segmentLength">Segment length in level units.</param>
         /// <param name="segmentAngle">Segment angle in degrees (0 points right, 90 down).</param>
+        /// <param name="rotatable">Whether the segment carries a rotate button.</param>
         /// <returns>This scenario.</returns>
-        public Scenario Hand(int x, int y, int segmentLength, float segmentAngle)
+        public Scenario Hand(int x, int y, int segmentLength, float segmentAngle, bool rotatable = false)
         {
             XElement hand = Node("hand", x, y);
             hand.SetAttributeValue("segmentsCount", Num(1));
             hand.SetAttributeValue("segment1Length", Num(segmentLength));
             hand.SetAttributeValue("segment1Angle", Num(segmentAngle));
-            hand.SetAttributeValue("segment1Rotatable", Flag(false));
+            hand.SetAttributeValue("segment1Rotatable", Flag(rotatable));
             return Add(hand);
         }
 

--- a/CutTheRopeDX/GameMain/GameScene.CandyRemoval.cs
+++ b/CutTheRopeDX/GameMain/GameScene.CandyRemoval.cs
@@ -80,9 +80,7 @@ namespace CutTheRopeDX.GameMain
             }
 
             hand.cPoint.RemoveConstraint(point);
-            hand.state = MechanicalHand.STATE_HAND_RELEASE;
-            hand.doRotateCandy = false;
-            hand.releaseSoundPlayed = true;
+            hand.ReleaseCandyAfterDropSound();
             hand.AnimateReleaseWithAnimationsPool(aniPool);
             CTRSoundMgr.PlaySound(Resources.Snd.ExpHandDrop);
         }

--- a/CutTheRopeDX/GameMain/GameScene.Draw.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Draw.cs
@@ -147,7 +147,7 @@ namespace CutTheRopeDX.GameMain
                     if (hand != null)
                     {
                         hand.Draw();
-                        if (hand.state == MechanicalHand.STATE_HAND_CANDY)
+                        if (hand.State == MechanicalHandState.HoldingCandy)
                         {
                             activeHand = hand;
                         }
@@ -278,7 +278,7 @@ namespace CutTheRopeDX.GameMain
             {
                 foreach (MechanicalHand hand in hands)
                 {
-                    if (hand != null && hand.state == MechanicalHand.STATE_HAND_CANDY)
+                    if (hand != null && hand.State == MechanicalHandState.HoldingCandy)
                     {
                         hand.TheClaw().DrawFingers();
                     }

--- a/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
+++ b/CutTheRopeDX/GameMain/GameScene.GameLogic.cs
@@ -1020,14 +1020,12 @@ namespace CutTheRopeDX.GameMain
 
             foreach (MechanicalHand hand in hands)
             {
-                if (hand != null && hand.state == MechanicalHand.STATE_HAND_CANDY)
+                if (hand != null && hand.State == MechanicalHandState.HoldingCandy)
                 {
                     CandyContext held = HandHeldCandy(hand);
                     ConstraintedPoint heldPoint = held?.WholeBody.Point ?? star;
                     hand.cPoint.RemoveConstraint(heldPoint);
-                    hand.state = MechanicalHand.STATE_HAND_RELEASE;
-                    hand.doRotateCandy = false;
-                    hand.releaseSoundPlayed = false;
+                    hand.ReleaseCandy();
                     hand.AnimateReleaseWithAnimationsPool(aniPool);
                     _ = held?.Lifecycle.Attachments.TryReleaseHand(hand);
                 }
@@ -1054,7 +1052,7 @@ namespace CutTheRopeDX.GameMain
 
             foreach (MechanicalHand hand in hands)
             {
-                if (hand != null && hand.state == MechanicalHand.STATE_HAND_CANDY)
+                if (hand != null && hand.State == MechanicalHandState.HoldingCandy)
                 {
                     CandyContext held = HandHeldCandy(hand);
                     ConstraintedPoint heldPoint = held?.WholeBody.Point ?? star;
@@ -1063,9 +1061,7 @@ namespace CutTheRopeDX.GameMain
                         continue;
                     }
                     hand.cPoint.RemoveConstraint(heldPoint);
-                    hand.state = MechanicalHand.STATE_HAND_RELEASE;
-                    hand.doRotateCandy = false;
-                    hand.releaseSoundPlayed = true;
+                    hand.ReleaseCandyAfterDropSound();
                     hand.AnimateReleaseWithAnimationsPool(aniPool);
                     _ = held?.Lifecycle.Attachments.TryReleaseHand(hand);
                     CTRSoundMgr.PlaySound(Resources.Snd.ExpHandDrop);

--- a/CutTheRopeDX/GameMain/GameScene.Input.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Input.cs
@@ -261,13 +261,11 @@ namespace CutTheRopeDX.GameMain
                         continue;
                     }
 
-                    if (hand.state == MechanicalHand.STATE_HAND_CANDY && VectDistance(world, hand.ClawPosition()) < MechanicalHand.MH_CLAW_TOUCH_RADIUS)
+                    if (hand.State == MechanicalHandState.HoldingCandy && VectDistance(world, hand.ClawPosition()) < MechanicalHand.MH_CLAW_TOUCH_RADIUS)
                     {
                         CandyContext held = HandHeldCandy(hand);
                         hand.cPoint.RemoveConstraint(held?.WholeBody.Point ?? star);
-                        hand.state = MechanicalHand.STATE_HAND_RELEASE;
-                        hand.doRotateCandy = false;
-                        hand.releaseSoundPlayed = true;
+                        hand.ReleaseCandyAfterDropSound();
                         hand.AnimateReleaseWithAnimationsPool(aniPool);
                         _ = held?.Lifecycle.Attachments.TryReleaseHand(hand);
                         CTRSoundMgr.PlaySound(Resources.Snd.ExpHandDrop);

--- a/CutTheRopeDX/GameMain/GameScene.Input.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Input.cs
@@ -284,7 +284,7 @@ namespace CutTheRopeDX.GameMain
                         {
                             segment.Rotate();
                             hand.rotatingSegment = segment;
-                            hand.canPlayClap = true;
+                            hand.ArmClap();
                             handledHandInput = true;
                             CTRSoundMgr.PlaySound(Resources.Snd.ExpHandRotate);
                             break;

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1675,7 +1675,7 @@ namespace CutTheRopeDX.GameMain
 
                 hand.Update(delta);
                 CandyContext heldCandy = HandHeldCandy(hand);
-                if (hand.state == MechanicalHand.STATE_HAND_CANDY && heldCandy != null)
+                if (hand.State == MechanicalHandState.HoldingCandy && heldCandy != null)
                 {
                     CandyBody heldBody = heldCandy.WholeBody;
                     heldBody.Visual.drawX += hand.cPoint.pos.X - heldBody.Point.pos.X;
@@ -1688,7 +1688,7 @@ namespace CutTheRopeDX.GameMain
                     // at the claw amplifies that phantom velocity into a huge impulse and launches the candy.
                     heldBody.Point.prevPos = heldBody.Point.pos;
 
-                    if (hand.doRotateCandy)
+                    if (hand.DoRotateCandy)
                     {
                         if (hand.rotatingSegment != null)
                         {
@@ -1699,7 +1699,7 @@ namespace CutTheRopeDX.GameMain
                     else if (heldCandy.Lifecycle.Attachments.HasActiveRocket)
                     {
                         _ = hand.IsRotating();
-                        hand.doRotateCandy = true;
+                        hand.BeginCandyRotation();
                     }
                 }
 
@@ -1716,12 +1716,12 @@ namespace CutTheRopeDX.GameMain
                     // holds *this* hand's target candy (single-candy legacy measured hand-to-hand
                     // because the holder sat on the only candy). With multiple candies a hand
                     // holding a different candy must not corrupt our distance to our own candy.
-                    if (otherHand.state == MechanicalHand.STATE_HAND_CANDY && HandHeldCandy(otherHand) == nearestCandy)
+                    if (otherHand.State == MechanicalHandState.HoldingCandy && HandHeldCandy(otherHand) == nearestCandy)
                     {
                         distance = VectDistance(hand.cPoint.pos, otherHand.cPoint.pos);
                     }
 
-                    if (hand.state == MechanicalHand.STATE_HAND_IDLE && otherHand.state == MechanicalHand.STATE_HAND_IDLE)
+                    if (hand.State == MechanicalHandState.Idle && otherHand.State == MechanicalHandState.Idle)
                     {
                         float handDistance = VectDistance(hand.cPoint.pos, otherHand.cPoint.pos);
                         if (handDistance < MechanicalHand.MH_CLAP_DISTANCE)
@@ -1742,7 +1742,7 @@ namespace CutTheRopeDX.GameMain
 
                 if (nearestCandy != null
                     && HandGrab.ShouldGrab(
-                        hand.state == MechanicalHand.STATE_HAND_IDLE,
+                        hand.State == MechanicalHandState.Idle,
                         !nearestCandy.HasNoWholeBodyInPlay,
                         nearestCandy.Lifecycle.Attachments.InLantern,
                         nearestCandy.Lifecycle.Transport?.Sock != null,
@@ -1759,13 +1759,11 @@ namespace CutTheRopeDX.GameMain
                         {
                             if (otherHand != null && HandSteal.ShouldReleaseOtherHand(
                                     otherHand != hand,
-                                    otherHand.state == MechanicalHand.STATE_HAND_CANDY,
+                                    otherHand.State == MechanicalHandState.HoldingCandy,
                                     ctx.Lifecycle.Attachments.Hand == otherHand))
                             {
                                 otherHand.cPoint.RemoveConstraint(grabbedBody.Point);
-                                otherHand.state = MechanicalHand.STATE_HAND_RELEASE;
-                                otherHand.doRotateCandy = false;
-                                otherHand.releaseSoundPlayed = false;
+                                otherHand.ReleaseCandy();
                                 reorderHands = true;
                                 break;
                             }
@@ -1773,9 +1771,7 @@ namespace CutTheRopeDX.GameMain
                     }
 
                     hand.cPoint.AddConstraintwithRestLengthofType(grabbedBody.Point, 1f, Constraint.CONSTRAINT.NOT_MORE_THAN);
-                    hand.state = MechanicalHand.STATE_HAND_CANDY;
-                    hand.doRotateCandy = false;
-                    hand.releaseSoundPlayed = false;
+                    hand.GrabCandy();
                     selectedHandIndex = hands.IndexOf(hand);
                     _ = ctx.Lifecycle.Attachments.CaptureByHand(hand);
 
@@ -1813,14 +1809,9 @@ namespace CutTheRopeDX.GameMain
                     CTRSoundMgr.PlaySound(Resources.Snd.ExpHandCatch);
                 }
 
-                if (hand.state == MechanicalHand.STATE_HAND_RELEASE && distance > MechanicalHand.MH_RELEASE_DISTANCE)
+                if (hand.TrySettleToIdle(distance) == HandSettle.SettledOwingDropSound)
                 {
-                    hand.state = MechanicalHand.STATE_HAND_IDLE;
-                    if (!hand.releaseSoundPlayed)
-                    {
-                        CTRSoundMgr.PlaySound(Resources.Snd.ExpHandDrop);
-                    }
-                    hand.releaseSoundPlayed = false;
+                    CTRSoundMgr.PlaySound(Resources.Snd.ExpHandDrop);
                 }
             }
 

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1764,6 +1764,7 @@ namespace CutTheRopeDX.GameMain
                             {
                                 otherHand.cPoint.RemoveConstraint(grabbedBody.Point);
                                 otherHand.state = MechanicalHand.STATE_HAND_RELEASE;
+                                otherHand.doRotateCandy = false;
                                 otherHand.releaseSoundPlayed = false;
                                 reorderHands = true;
                                 break;
@@ -1773,6 +1774,7 @@ namespace CutTheRopeDX.GameMain
 
                     hand.cPoint.AddConstraintwithRestLengthofType(grabbedBody.Point, 1f, Constraint.CONSTRAINT.NOT_MORE_THAN);
                     hand.state = MechanicalHand.STATE_HAND_CANDY;
+                    hand.doRotateCandy = false;
                     hand.releaseSoundPlayed = false;
                     selectedHandIndex = hands.IndexOf(hand);
                     _ = ctx.Lifecycle.Attachments.CaptureByHand(hand);

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1698,7 +1698,6 @@ namespace CutTheRopeDX.GameMain
                     }
                     else if (heldCandy.Lifecycle.Attachments.HasActiveRocket)
                     {
-                        _ = hand.IsRotating();
                         hand.BeginCandyRotation();
                     }
                 }

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1721,22 +1721,12 @@ namespace CutTheRopeDX.GameMain
                         distance = VectDistance(hand.cPoint.pos, otherHand.cPoint.pos);
                     }
 
-                    if (hand.State == MechanicalHandState.Idle && otherHand.State == MechanicalHandState.Idle)
+                    if (hand.TryClapWith(otherHand))
                     {
-                        float handDistance = VectDistance(hand.cPoint.pos, otherHand.cPoint.pos);
-                        if (handDistance < MechanicalHand.MH_CLAP_DISTANCE)
-                        {
-                            if ((hand.clapTimer <= 0f || otherHand.clapTimer <= 0f) && (hand.canPlayClap || otherHand.canPlayClap))
-                            {
-                                PlayMechanicalHandClapEffectAt(otherHand.ClawPosition());
-                                hand.AnimateClap();
-                                otherHand.AnimateClap();
-                                CTRSoundMgr.PlaySound(Resources.Snd.ExpHandClap);
-                            }
-
-                            hand.clapTimer = MechanicalHand.MH_CLAP_COOLDOWN;
-                            otherHand.clapTimer = MechanicalHand.MH_CLAP_COOLDOWN;
-                        }
+                        PlayMechanicalHandClapEffectAt(otherHand.ClawPosition());
+                        hand.AnimateClap();
+                        otherHand.AnimateClap();
+                        CTRSoundMgr.PlaySound(Resources.Snd.ExpHandClap);
                     }
                 }
 

--- a/CutTheRopeDX/GameMain/MechanicalHand.cs
+++ b/CutTheRopeDX/GameMain/MechanicalHand.cs
@@ -7,6 +7,32 @@ using CutTheRopeDX.Framework.Visual;
 
 namespace CutTheRopeDX.GameMain
 {
+    /// <summary>The mutually exclusive states a mechanical hand can be in.</summary>
+    internal enum MechanicalHandState
+    {
+        /// <summary>Waiting, and free to grab a candy in reach.</summary>
+        Idle,
+
+        /// <summary>Holding a candy in the claw.</summary>
+        HoldingCandy,
+
+        /// <summary>Let go, and waiting for the candy to clear the claw before going idle.</summary>
+        Releasing
+    }
+
+    /// <summary>Outcome of a settle attempt on a releasing hand.</summary>
+    internal enum HandSettle
+    {
+        /// <summary>The hand is not releasing, or the candy has not cleared the claw yet.</summary>
+        Stayed,
+
+        /// <summary>The hand went idle; the drop sound was already played by the release site.</summary>
+        Settled,
+
+        /// <summary>The hand went idle and the caller now owes the drop sound.</summary>
+        SettledOwingDropSound
+    }
+
     /// <summary>
     /// Composite mechanical hand element made of articulated segments and a claw.
     /// Handles segment hierarchy, claw position tracking, and catch/release animations.
@@ -19,7 +45,7 @@ namespace CutTheRopeDX.GameMain
         public MechanicalHand()
         {
             rotatingSegment = null;
-            state = STATE_HAND_IDLE;
+            State = MechanicalHandState.Idle;
             cPoint = new ConstraintedPoint
             {
                 disableGravity = true
@@ -207,6 +233,64 @@ namespace CutTheRopeDX.GameMain
         }
 
         /// <summary>
+        /// Takes hold of a candy. Rotation state is cleared so a hold never inherits anything from
+        /// the previous one; the update loop re-derives it from the candy actually held.
+        /// </summary>
+        public void GrabCandy()
+        {
+            State = MechanicalHandState.HoldingCandy;
+            DoRotateCandy = false;
+            releaseSoundPlayed = false;
+        }
+
+        /// <summary>
+        /// Lets go of the candy. The drop sound is still owed and plays when the hand settles.
+        /// </summary>
+        public void ReleaseCandy()
+        {
+            BeginRelease(dropSoundPlayed: false);
+        }
+
+        /// <summary>
+        /// Lets go of the candy when the caller has already played the drop sound itself.
+        /// </summary>
+        public void ReleaseCandyAfterDropSound()
+        {
+            BeginRelease(dropSoundPlayed: true);
+        }
+
+        /// <summary>
+        /// Settles a releasing hand back to idle once the candy has cleared the claw.
+        /// </summary>
+        /// <param name="clawDistance">Distance from this hand to the candy it let go of.</param>
+        /// <returns>Whether the hand settled, and whether the caller now owes the drop sound.</returns>
+        public HandSettle TrySettleToIdle(float clawDistance)
+        {
+            if (State != MechanicalHandState.Releasing || clawDistance <= MH_RELEASE_DISTANCE)
+            {
+                return HandSettle.Stayed;
+            }
+
+            State = MechanicalHandState.Idle;
+            bool owed = !releaseSoundPlayed;
+            releaseSoundPlayed = false;
+            return owed ? HandSettle.SettledOwingDropSound : HandSettle.Settled;
+        }
+
+        /// <summary>Starts rotating the held candy along with the hand's moving segment.</summary>
+        public void BeginCandyRotation()
+        {
+            DoRotateCandy = true;
+        }
+
+        private void BeginRelease(bool dropSoundPlayed)
+        {
+            State = MechanicalHandState.Releasing;
+            DoRotateCandy = false;
+            releaseSoundPlayed = dropSoundPlayed;
+        }
+
+        /// <summary>
         /// Gets a segment by index.
         /// </summary>
         /// <param name="index">Segment index.</param>
@@ -296,20 +380,11 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Cooldown before a hand can play another clap effect.</summary>
         public const float MH_CLAP_COOLDOWN = 0.3f;
 
-        /// <summary>Idle hand state value.</summary>
-        public const int STATE_HAND_IDLE = 0;
-
-        /// <summary>State value used while the hand is holding the candy.</summary>
-        public const int STATE_HAND_CANDY = 1;
-
-        /// <summary>State value used while the hand is releasing the candy.</summary>
-        public const int STATE_HAND_RELEASE = 2;
-
         /// <summary>Current mechanical hand state.</summary>
-        public int state;
+        public MechanicalHandState State { get; private set; }
 
-        /// <summary>Whether attached candy visuals should rotate with segment movement.</summary>
-        public bool doRotateCandy;
+        /// <summary>Whether the candy held by this hand should rotate with segment movement.</summary>
+        public bool DoRotateCandy { get; private set; }
 
         /// <summary>Whether this hand is eligible to play a clap effect.</summary>
         public bool canPlayClap;
@@ -318,7 +393,7 @@ namespace CutTheRopeDX.GameMain
         public float clapTimer;
 
         /// <summary>Whether the release sound has already played for the current release.</summary>
-        public bool releaseSoundPlayed;
+        private bool releaseSoundPlayed;
 
         /// <summary>Offset from the terminal joint to the candy anchor in claw local space.</summary>
         private Vector clawOffset;

--- a/CutTheRopeDX/GameMain/MechanicalHand.cs
+++ b/CutTheRopeDX/GameMain/MechanicalHand.cs
@@ -53,7 +53,7 @@ namespace CutTheRopeDX.GameMain
             cPoint.SetWeight(0.0001f);
             releaseSoundPlayed = false;
             clapTimer = 0f;
-            canPlayClap = false;
+            CanPlayClap = false;
 
             Vector jointCenter = Image.GetQuadCenter(Resources.Img.ObjRoboHand, 2);
             Vector candyAnchor = Image.GetQuadCenter(Resources.Img.ObjRoboHand, 8);
@@ -277,6 +277,36 @@ namespace CutTheRopeDX.GameMain
             return owed ? HandSettle.SettledOwingDropSound : HandSettle.Settled;
         }
 
+        /// <summary>
+        /// Marks this hand as eligible to clap. Never reset once set, matching the original.
+        /// </summary>
+        public void ArmClap()
+        {
+            CanPlayClap = true;
+        }
+
+        /// <summary>
+        /// Arms the clap cooldown on both hands when they are idle and within clap range, and
+        /// reports whether the pair should emit the clap effect.
+        /// </summary>
+        /// <param name="other">The other hand in the pair.</param>
+        /// <returns><see langword="true"/> when the caller should play the clap effect.</returns>
+        public bool TryClapWith(MechanicalHand other)
+        {
+            if (other == null
+                || State != MechanicalHandState.Idle
+                || other.State != MechanicalHandState.Idle
+                || VectDistance(cPoint.pos, other.cPoint.pos) >= MH_CLAP_DISTANCE)
+            {
+                return false;
+            }
+
+            bool clap = (ClapTimer <= 0f || other.ClapTimer <= 0f) && (CanPlayClap || other.CanPlayClap);
+            ClapTimer = MH_CLAP_COOLDOWN;
+            other.ClapTimer = MH_CLAP_COOLDOWN;
+            return clap;
+        }
+
         /// <summary>Starts rotating the held candy along with the hand's moving segment.</summary>
         public void BeginCandyRotation()
         {
@@ -387,10 +417,13 @@ namespace CutTheRopeDX.GameMain
         public bool DoRotateCandy { get; private set; }
 
         /// <summary>Whether this hand is eligible to play a clap effect.</summary>
-        public bool canPlayClap;
+        public bool CanPlayClap { get; private set; }
 
         /// <summary>Remaining clap cooldown time in seconds.</summary>
-        public float clapTimer;
+        public float ClapTimer { get => clapTimer; private set => clapTimer = value; }
+
+        /// <summary>Backing store for <see cref="ClapTimer"/>, needed because it is moved by ref.</summary>
+        private float clapTimer;
 
         /// <summary>Whether the release sound has already played for the current release.</summary>
         private bool releaseSoundPlayed;

--- a/CutTheRopeDX/GameMain/MechanicalHandClaw.cs
+++ b/CutTheRopeDX/GameMain/MechanicalHandClaw.cs
@@ -52,7 +52,7 @@ namespace CutTheRopeDX.GameMain
         {
             PreDraw();
             EnsureHandReference();
-            if (mechanicalHand?.state == MechanicalHand.STATE_HAND_CANDY)
+            if (mechanicalHand?.State == MechanicalHandState.HoldingCandy)
             {
                 clawActive.Draw();
             }
@@ -121,7 +121,7 @@ namespace CutTheRopeDX.GameMain
             }
 
             PreDraw();
-            if (mechanicalHand?.state == MechanicalHand.STATE_HAND_CANDY)
+            if (mechanicalHand?.State == MechanicalHandState.HoldingCandy)
             {
                 clawActive.Draw();
             }


### PR DESCRIPTION
## Description

Make every write to `MechanicalHand`'s five mutable fields go through a named transition on the hand itself. `state`, `doRotateCandy`, `canPlayClap` and `clapTimer` become read-only properties and `releaseSoundPlayed` becomes fully private, so no caller can leave a hand in a half-updated hold.

The three `STATE_HAND_*` int constants become a `MechanicalHandState` enum, and the settle-to-idle path returns a `HandSettle` result instead of leaving each caller to work out whether it still owes the drop sound.

## What's changed

- Replace `STATE_HAND_IDLE`/`_CANDY`/`_RELEASE` with a `MechanicalHandState` enum, and add `HandSettle` for settle outcomes.
- Add transitions covering every previous raw write:
  - `GrabCandy()`, `ReleaseCandy()`, `ReleaseCandyAfterDropSound()`
  - `TrySettleToIdle(clawDistance)`, `BeginCandyRotation()`
  - `ArmClap()`, `TryClapWith(other)`
- Clear rotation state at the grab and the steal, so a hold never inherits it from the previous one.
- Collapse the ten-line idle-pair clap block in `UpdateHands` into one `TryClapWith` call.
- Remove the dead `_ = hand.IsRotating();` call, which has no counterpart in either reference build.
- Rewrite the ten call sites across `GameScene.Update`, `.Input`, `.GameLogic`, `.CandyRemoval`, `.Draw` and `MechanicalHandClaw`.
- Add `MechanicalHandStateTests`, pinning which fields each release path writes, when a releasing hand settles, and how rotation is scoped.
- Add `HandCandyPairingTests`, pinning that a hand's `State` and the candy's `Attachments.Hand` agree after every grab and release path.
- Extend the harness: `Scenario.Hand(..., rotatable:)`, plus `Act.TapClaw`, `RotateSegment`, `ArmClap` and `SettleOwedDropSound`.