### PR TITLE
fix: Give a hand a grace window before a bouncer takes its candy

### DIFF
--- a/CutTheRopeDX.Tests/Interactions/BouncerHandGraceTests.cs
+++ b/CutTheRopeDX.Tests/Interactions/BouncerHandGraceTests.cs
@@ -1,0 +1,133 @@
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>
+    /// Pins the post-grab grace window that keeps a bouncer from instantly stripping a candy out of
+    /// a hand that just caught it. iOS Experiments gates its bouncer detach on
+    /// <c>time - candyHandCatchTime &gt; 0.1</c>; DX scopes the same window to the individual hold.
+    /// </summary>
+    public sealed class BouncerHandGraceTests
+    {
+        [Fact]
+        public void ABouncerBouncesAFreeCandy()
+        {
+            (GameScene scene, CandyContext candy, Bouncer bouncer) = Rig();
+
+            Interaction.PlaceCandyAt(candy, new Vector(bouncer.x, bouncer.y));
+            HeadlessGame.StepFrames(scene, 2);
+
+            Assert.NotEqual(0f, candy.WholeBody.Point.v.Y);
+        }
+
+        [Fact]
+        public void AFreshGrabIsProtectedFromTheBouncer()
+        {
+            (GameScene scene, CandyContext candy, _) = Rig();
+            MechanicalHand hand = scene.Hands()[0];
+            _ = candy;
+
+            hand.GrabCandy();
+
+            Assert.False(hand.CanBeDetachedByBouncer);
+            _ = scene;
+        }
+
+        [Fact]
+        public void TheGraceWindowExpires()
+        {
+            (GameScene scene, CandyContext candy, _) = Rig();
+            MechanicalHand hand = scene.Hands()[0];
+            _ = candy;
+
+            hand.GrabCandy();
+            hand.Update(MechanicalHand.MH_BOUNCER_GRACE);
+
+            Assert.True(hand.CanBeDetachedByBouncer);
+        }
+
+        [Fact]
+        public void ABouncerDoesNotStripAJustGrabbedCandy()
+        {
+            (GameScene scene, CandyContext candy, Bouncer bouncer) = Rig();
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            // Re-stamp the hold, then walk the claw onto the bouncer: this is a hand carrying a candy
+            // into a bouncer the instant after catching it.
+            hand.GrabCandy();
+            Act.MoveClawTo(hand, new Vector(bouncer.x, bouncer.y));
+            HeadlessGame.StepFrames(scene, 1);
+
+            Assert.Same(hand, candy.Lifecycle.Attachments.Hand);
+        }
+
+        [Fact]
+        public void ABouncerStripsTheCandyOnceTheWindowExpires()
+        {
+            (GameScene scene, CandyContext candy, Bouncer bouncer) = Rig();
+            MechanicalHand hand = Act.GrabWithHand(scene, candy);
+
+            Assert.True(
+                Interaction.StepUntil(
+                    scene,
+                    () => Act.MoveClawTo(hand, new Vector(bouncer.x, bouncer.y)),
+                    () => candy.Lifecycle.Attachments.Hand == null,
+                    maxFrames: 30),
+                "the bouncer never took the candy off the hand");
+        }
+
+        [Fact]
+        public void OneHandsGraceDoesNotShieldAnotherHandsCandy()
+        {
+            // The iOS window is a single scene-wide timestamp, which only worked because Experiments
+            // had one candy. Here two holds run on different clocks and must be judged separately.
+            GameScene scene = Scenario.New()
+                .Candy(100, 200)
+                .Candy(400, 200, number: "2")
+                .OmNom(20, 460)
+                .Hand(60, 40, segmentLength: 20, segmentAngle: 90f)
+                .Hand(440, 40, segmentLength: 20, segmentAngle: 90f)
+                .Bouncer(100, 330)
+                .Bouncer(400, 330)
+                .Build();
+
+            CandyContext stale = scene.Candies()[0];
+            CandyContext fresh = scene.Candies()[1];
+            Interaction.Hover(stale);
+            Interaction.Hover(fresh);
+
+            MechanicalHand staleHand = Act.GrabWithHand(scene, stale, handIndex: 0);
+            MechanicalHand freshHand = Act.GrabWithHand(scene, fresh, handIndex: 1);
+
+            // Age both holds well past the window while the claws are still clear of the bouncers,
+            // then re-arm only the second one.
+            HeadlessGame.StepFrames(scene, 10);
+            freshHand.GrabCandy();
+
+            Act.MoveClawTo(staleHand, new Vector(scene.Bouncers()[0].x, scene.Bouncers()[0].y));
+            Act.MoveClawTo(freshHand, new Vector(scene.Bouncers()[1].x, scene.Bouncers()[1].y));
+            HeadlessGame.StepFrames(scene, 1);
+
+            Assert.Null(stale.Lifecycle.Attachments.Hand);
+            Assert.Same(freshHand, fresh.Lifecycle.Attachments.Hand);
+        }
+
+        /// <summary>One hand, one hovering candy, and a bouncer parked clear of both.</summary>
+        private static (GameScene Scene, CandyContext Candy, Bouncer Bouncer) Rig()
+        {
+            GameScene scene = Scenario.New()
+                .Candy(160, 200)
+                .OmNom(20, 460)
+                .Hand(20, 40, segmentLength: 20, segmentAngle: 90f)
+                .Bouncer(160, 330)
+                .Build();
+
+            CandyContext candy = scene.Candy();
+            Interaction.Hover(candy);
+            return (scene, candy, scene.Bouncers()[0]);
+        }
+    }
+}

--- a/CutTheRopeDX.Tests/Interactions/Scenario.cs
+++ b/CutTheRopeDX.Tests/Interactions/Scenario.cs
@@ -259,6 +259,20 @@ namespace CutTheRopeDX.Tests.Interactions
             return Add(Node("bubble", x, y));
         }
 
+        /// <summary>Adds a bouncer.</summary>
+        /// <param name="x">Level-space X.</param>
+        /// <param name="y">Level-space Y.</param>
+        /// <param name="size">Width class: 1 is the small bouncer, 2 the large one.</param>
+        /// <param name="angle">Bouncer angle in degrees.</param>
+        /// <returns>This scenario.</returns>
+        public Scenario Bouncer(int x, int y, int size = 2, float angle = 0f)
+        {
+            XElement bouncer = Node(size == 1 ? "bouncer1" : "bouncer2", x, y);
+            bouncer.SetAttributeValue("size", Num(size));
+            bouncer.SetAttributeValue("angle", Num(angle));
+            return Add(bouncer);
+        }
+
         /// <summary>Adds a ghost that can morph into a bubble and a grab.</summary>
         /// <param name="x">Level-space X.</param>
         /// <param name="y">Level-space Y.</param>

--- a/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
+++ b/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
@@ -71,6 +71,14 @@ namespace CutTheRopeDX.Tests.Interactions
             return Field<List<Ghost>>(scene, "ghosts");
         }
 
+        /// <summary>All bouncers.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns>The bouncer list.</returns>
+        public static List<Bouncer> Bouncers(this GameScene scene)
+        {
+            return Field<List<Bouncer>>(scene, "bouncers");
+        }
+
         /// <summary>All air pumps.</summary>
         /// <param name="scene">Scene to read.</param>
         /// <returns>The pump list.</returns>

--- a/CutTheRopeDX/GameMain/GameScene.Update.cs
+++ b/CutTheRopeDX/GameMain/GameScene.Update.cs
@@ -1203,7 +1203,16 @@ namespace CutTheRopeDX.GameMain
                         bouncerCollisionRadius))
                     {
                         anyCandyHit = true;
-                        DetachHandsForPoint(body.Point);
+
+                        // A hand that just caught this candy keeps it for a moment, otherwise the
+                        // bouncer takes it straight back and the two fight over it every frame. The
+                        // window belongs to the individual hold, so a candy held past its own grace
+                        // still drops even while another hand is inside one.
+                        MechanicalHand holder = body.Owner.Lifecycle.Attachments.Hand;
+                        if (holder == null || holder.CanBeDetachedByBouncer)
+                        {
+                            DetachHandsForPoint(body.Point);
+                        }
                         HandleBouncePtDelta(bouncer, body.Point, delta);
                     }
                 }

--- a/CutTheRopeDX/GameMain/MechanicalHand.cs
+++ b/CutTheRopeDX/GameMain/MechanicalHand.cs
@@ -241,6 +241,7 @@ namespace CutTheRopeDX.GameMain
             State = MechanicalHandState.HoldingCandy;
             DoRotateCandy = false;
             releaseSoundPlayed = false;
+            graceTimer = MH_BOUNCER_GRACE;
         }
 
         /// <summary>
@@ -354,6 +355,7 @@ namespace CutTheRopeDX.GameMain
             base.Update(delta);
             cPoint.pos = ClawPosition();
             _ = Mover.MoveVariableToTarget(ref clapTimer, 0f, 1f, delta);
+            _ = Mover.MoveVariableToTarget(ref graceTimer, 0f, 1f, delta);
         }
 
         /// <inheritdoc />
@@ -410,6 +412,13 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Cooldown before a hand can play another clap effect.</summary>
         public const float MH_CLAP_COOLDOWN = 0.3f;
 
+        /// <summary>
+        /// Grace period after a grab during which a bouncer may not strip the candy away. Without it
+        /// a hand can never pick a candy up off a bouncer: the collision would take it back the frame
+        /// after the catch, and the pair would fight each other. Unscaled, matching the original.
+        /// </summary>
+        public const float MH_BOUNCER_GRACE = 0.1f;
+
         /// <summary>Current mechanical hand state.</summary>
         public MechanicalHandState State { get; private set; }
 
@@ -422,8 +431,14 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Remaining clap cooldown time in seconds.</summary>
         public float ClapTimer { get => clapTimer; private set => clapTimer = value; }
 
+        /// <summary>Whether a bouncer is allowed to take this hand's candy yet.</summary>
+        public bool CanBeDetachedByBouncer => graceTimer <= 0f;
+
         /// <summary>Backing store for <see cref="ClapTimer"/>, needed because it is moved by ref.</summary>
         private float clapTimer;
+
+        /// <summary>Remaining post-grab bouncer grace time in seconds.</summary>
+        private float graceTimer;
 
         /// <summary>Whether the release sound has already played for the current release.</summary>
         private bool releaseSoundPlayed;


### PR DESCRIPTION
## Description

A hand cannot currently pick a candy up off a bouncer. The collision check strips it back the frame after the catch, so the hand and the bouncer fight over the candy every frame.

In iOS version of Cut the Rope: Experiments, it guards against exactly this. Its bouncer block detaches only when `time - candyHandCatchTime > 0.1`, where `candyHandCatchTime` is stamped at each grab, giving the hand 100ms to pull the candy clear before the bouncer can take it back. DX had the detach but not the guard.

## What's changed

- Add `MechanicalHand.MH_BOUNCER_GRACE` (0.1s, unscaled, matching the original's bare literal).
- Stamp a private `graceTimer` in `GrabCandy()` and decay it in `Update` through the same `Mover.MoveVariableToTarget` idiom `clapTimer` already uses.
- Expose `CanBeDetachedByBouncer`, and consult the candy's own holder in the bouncer block so each hold is judged on its own clock.
- Extend the harness with `Scenario.Bouncer(...)` and `SceneProbe.Bouncers()`.
- Add `BouncerHandGraceTests`, covering the protected window, its expiry, and that one hand's grace does not shield another hand's candy.