### PR TITLE
fix: Make mobile physics collision and attachment parity with mobile version

### DIFF
--- a/src/CutTheRopeDX.Core/Framework/ActivePhysicsConstants.cs
+++ b/src/CutTheRopeDX.Core/Framework/ActivePhysicsConstants.cs
@@ -130,6 +130,12 @@ namespace CutTheRopeDX.Framework
         public static float BubbleCaptureRadius => SelectScaled(PhysicsConstants.BubbleCaptureRadius, MobilePhysicsConstants.BubbleCaptureRadius);
 
         /// <summary>
+        /// Raw level-space radius used when a bamboo tube captures the candy center.
+        /// The tube applies the level's interaction scale after selecting the physics model.
+        /// </summary>
+        public static float BambooCaptureRadius => SelectRaw(PhysicsConstants.BambooCaptureRadius, MobilePhysicsConstants.BambooCaptureRadius);
+
+        /// <summary>
         /// Gravity acceleration applied to candy break particles.
         /// </summary>
         public static float CandyBreakGravityY => SelectScaled(PhysicsConstants.CandyBreakGravityY, MobilePhysicsConstants.CandyBreakGravityY);

--- a/src/CutTheRopeDX.Core/Framework/Helpers/GameObject.cs
+++ b/src/CutTheRopeDX.Core/Framework/Helpers/GameObject.cs
@@ -217,14 +217,27 @@ namespace CutTheRopeDX.Framework.Helpers
         /// <returns><see langword="true"/> when the objects intersect; otherwise <see langword="false"/>.</returns>
         public static bool ObjectsIntersectRotatedWithUnrotated(GameObject o1, GameObject o2)
         {
+            return ObjectsIntersectRotatedWithUnrotatedAt(o1, o2, o2.drawX, o2.drawY);
+        }
+
+        /// <summary>
+        /// Tests OBB intersection using an explicit draw position for the unrotated object.
+        /// </summary>
+        /// <param name="o1">Rotated object.</param>
+        /// <param name="o2">Unrotated object.</param>
+        /// <param name="o2DrawX">Draw-space X position to use for <paramref name="o2"/>.</param>
+        /// <param name="o2DrawY">Draw-space Y position to use for <paramref name="o2"/>.</param>
+        /// <returns><see langword="true"/> when the objects intersect; otherwise <see langword="false"/>.</returns>
+        internal static bool ObjectsIntersectRotatedWithUnrotatedAt(GameObject o1, GameObject o2, float o2DrawX, float o2DrawY)
+        {
             Vector o1TopLeft = Vect(o1.drawX + o1.rbb.tlX, o1.drawY + o1.rbb.tlY);
             Vector o1TopRight = Vect(o1.drawX + o1.rbb.trX, o1.drawY + o1.rbb.trY);
             Vector o1BottomRight = Vect(o1.drawX + o1.rbb.brX, o1.drawY + o1.rbb.brY);
             Vector o1BottomLeft = Vect(o1.drawX + o1.rbb.blX, o1.drawY + o1.rbb.blY);
-            Vector o2TopLeft = Vect(o2.drawX + o2.bb.x, o2.drawY + o2.bb.y);
-            Vector o2TopRight = Vect(o2.drawX + o2.bb.x + o2.bb.w, o2.drawY + o2.bb.y);
-            Vector o2BottomRight = Vect(o2.drawX + o2.bb.x + o2.bb.w, o2.drawY + o2.bb.y + o2.bb.h);
-            Vector o2BottomLeft = Vect(o2.drawX + o2.bb.x, o2.drawY + o2.bb.y + o2.bb.h);
+            Vector o2TopLeft = Vect(o2DrawX + o2.bb.x, o2DrawY + o2.bb.y);
+            Vector o2TopRight = Vect(o2DrawX + o2.bb.x + o2.bb.w, o2DrawY + o2.bb.y);
+            Vector o2BottomRight = Vect(o2DrawX + o2.bb.x + o2.bb.w, o2DrawY + o2.bb.y + o2.bb.h);
+            Vector o2BottomLeft = Vect(o2DrawX + o2.bb.x, o2DrawY + o2.bb.y + o2.bb.h);
             return ObbInOBB(o1TopLeft, o1TopRight, o1BottomRight, o1BottomLeft, o2TopLeft, o2TopRight, o2BottomRight, o2BottomLeft);
         }
 

--- a/src/CutTheRopeDX.Core/Framework/MobilePhysicsConstants.cs
+++ b/src/CutTheRopeDX.Core/Framework/MobilePhysicsConstants.cs
@@ -47,6 +47,9 @@ namespace CutTheRopeDX.Framework
         /// <inheritdoc cref="ActivePhysicsConstants.BubbleCaptureRadius" />
         public const float BubbleCaptureRadius = 30f;
 
+        /// <inheritdoc cref="ActivePhysicsConstants.BambooCaptureRadius" />
+        public const float BambooCaptureRadius = 25f;
+
         /// <inheritdoc cref="ActivePhysicsConstants.CandyBreakGravityY" />
         public const float CandyBreakGravityY = 500f;
 

--- a/src/CutTheRopeDX.Core/Framework/MobilePhysicsConstants.cs
+++ b/src/CutTheRopeDX.Core/Framework/MobilePhysicsConstants.cs
@@ -5,6 +5,10 @@ namespace CutTheRopeDX.Framework
     /// </summary>
     internal static class MobilePhysicsConstants
     {
+        // The high-resolution iOS bouncer quad widths are asset pixels. Normalize only those
+        // widths to the authored 320-wide space; native collision literals remain logical units.
+        private const float IosHighResolutionScale = 1.5f;
+
         /// <inheritdoc cref="ActivePhysicsConstants.TimeScale" />
         public const float TimeScale = 1f;
 
@@ -189,13 +193,18 @@ namespace CutTheRopeDX.Framework
         public const float ElectroSpikesObjectWidth = 267f;
 
         /// <summary>
-        /// WP7 first-quad width of the small bouncer (obj_bouncer_01, quad 0), subtract 20.
+        /// iOS high-resolution first-quad width of the small bouncer (obj_bouncer_01, quad 0).
+        /// Normalize the asset width to authored coordinates, then subtract the native logical
+        /// 20-unit end-cap.
         /// </summary>
-        public const float BouncerSmallCollisionWidth = 46f;
+        public const float BouncerSmallCollisionWidth = (100f / IosHighResolutionScale) - 20f;
 
         /// <inheritdoc cref="ActivePhysicsConstants.BouncerCollisionWidth" />
-        /// <remarks>obj_bouncer_02 quad 0, subtract 20</remarks>
-        public const float BouncerLargeCollisionWidth = 91f;
+        /// <remarks>
+        /// iOS high-resolution obj_bouncer_02 quad 0 is 150 asset pixels wide. Normalize it to
+        /// authored coordinates, then subtract the native logical 20-unit end-cap.
+        /// </remarks>
+        public const float BouncerLargeCollisionWidth = (150f / IosHighResolutionScale) - 20f;
 
         /// <summary>
         /// Rocket catch-slat box from the Experiments base assets: quad 10 is 116x58 centered

--- a/src/CutTheRopeDX.Core/Framework/PhysicsConstants.cs
+++ b/src/CutTheRopeDX.Core/Framework/PhysicsConstants.cs
@@ -47,6 +47,9 @@ namespace CutTheRopeDX.Framework
         /// <inheritdoc cref="ActivePhysicsConstants.BubbleCaptureRadius" />
         public const float BubbleCaptureRadius = 85f;
 
+        /// <inheritdoc cref="ActivePhysicsConstants.BambooCaptureRadius" />
+        public const float BambooCaptureRadius = 17.5f;
+
         /// <inheritdoc cref="ActivePhysicsConstants.CandyBreakGravityY" />
         public const float CandyBreakGravityY = 500f;
 

--- a/src/CutTheRopeDX.Core/GameMain/BambooTube.cs
+++ b/src/CutTheRopeDX.Core/GameMain/BambooTube.cs
@@ -1,3 +1,4 @@
+using CutTheRopeDX.Framework;
 using CutTheRopeDX.Framework.Core;
 using CutTheRopeDX.Framework.Physics;
 using CutTheRopeDX.Framework.Visual;
@@ -159,7 +160,7 @@ namespace CutTheRopeDX.GameMain
                 return false;
             }
 
-            float captureRadius = BambooCaptureRadius * interactionScale;
+            float captureRadius = ActivePhysicsConstants.BambooCaptureRadius * interactionScale;
             if (VectDistance(candyPoint.pos, bambooHole1) < captureRadius && IsCandyMovingInside(candyPoint, bambooHole1))
             {
                 bambooHoleOut = bambooHole2;
@@ -339,9 +340,6 @@ namespace CutTheRopeDX.GameMain
 
         /// <summary>Bounding-box half-size in unscaled points.</summary>
         private const float BambooBaseBbSize = 75f;
-
-        /// <summary>Capture radius in unscaled points. Scaled by <see cref="interactionScale"/> at runtime.</summary>
-        private const float BambooCaptureRadius = 17.5f;
 
         /// <summary>Launch speed in points per physics step (Verlet impulse magnitude).</summary>
         private const float BambooThrowSpeed = 7.5f;

--- a/src/CutTheRopeDX.Core/GameMain/BarrierCollision.cs
+++ b/src/CutTheRopeDX.Core/GameMain/BarrierCollision.cs
@@ -10,15 +10,17 @@ namespace CutTheRopeDX.GameMain
         public static bool Hits(
             float t1x, float t1y, float t2x, float t2y,
             float b1x, float b1y, float b2x, float b2y,
-            float px, float py, float prevX, float prevY, float radius)
+            float px, float py, float prevX, float prevY, float radius,
+            bool includeSweep = true)
         {
             float bbX = px - radius;
             float bbY = py - radius;
             float bbSize = radius * 2f;
             return CTRMathHelper.LineInRect(t1x, t1y, t2x, t2y, bbX, bbY, bbSize, bbSize)
                 || CTRMathHelper.LineInRect(b1x, b1y, b2x, b2y, bbX, bbY, bbSize, bbSize)
-                || CTRMathHelper.LineInLine(prevX, prevY, px, py, t1x, t1y, t2x, t2y)
-                || CTRMathHelper.LineInLine(prevX, prevY, px, py, b1x, b1y, b2x, b2y);
+                || (includeSweep
+                    && (CTRMathHelper.LineInLine(prevX, prevY, px, py, t1x, t1y, t2x, t2y)
+                        || CTRMathHelper.LineInLine(prevX, prevY, px, py, b1x, b1y, b2x, b2y)));
         }
     }
 }

--- a/src/CutTheRopeDX.Core/GameMain/CandyBody.cs
+++ b/src/CutTheRopeDX.Core/GameMain/CandyBody.cs
@@ -1,3 +1,4 @@
+using CutTheRopeDX.Framework.Core;
 using CutTheRopeDX.Framework.Helpers;
 using CutTheRopeDX.Framework.Physics;
 using CutTheRopeDX.Framework.Visual;
@@ -88,6 +89,11 @@ namespace CutTheRopeDX.GameMain
 
         /// <summary>Gets or sets residual rope-swing rotation that decays while no rope steers the body.</summary>
         public float ResidualRotation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pre-integration visual position used by mobile rocket collision.
+        /// </summary>
+        public Vector RocketCollisionDrawPosition { get; set; }
 
         /// <summary>Gets or sets whether the water-surface splash has been emitted.</summary>
         public bool Splashes { get; set; }

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.BoundingBoxes.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.BoundingBoxes.cs
@@ -1,4 +1,5 @@
 using CutTheRopeDX.Framework;
+using CutTheRopeDX.Framework.Helpers;
 
 namespace CutTheRopeDX.GameMain
 {
@@ -40,6 +41,39 @@ namespace CutTheRopeDX.GameMain
         internal static CTRRectangle GetCandyBoundingBox()
         {
             return SelectPhysicsBoundingBox(142f, 157f, 112f, 104f, 46f, 49f, 35f, 35f);
+        }
+
+        /// <summary>
+        /// Returns the candy collision box positioned relative to the active sprite's center.
+        /// </summary>
+        /// <remarks>
+        /// Collision metadata was authored inside a mode-specific canonical candy canvas. Candy
+        /// skins are cosmetic, so preserve the selected metadata box's center offset rather than
+        /// copying its absolute X/Y into a potentially different skin canvas.
+        /// </remarks>
+        private static CTRRectangle GetCandyBoundingBox(GameObject visual)
+        {
+            CTRRectangle bounds = GetCandyBoundingBox();
+            if (visual == null)
+            {
+                return bounds;
+            }
+
+            float sourceCanvasWidth = 393f;
+            float sourceCanvasHeight = 418f;
+            if (ActivePhysicsConstants.UseMobilePhysicsModel)
+            {
+                float scale = ActivePhysicsConstants.Wp7ToWorldScale;
+                sourceCanvasWidth = 126f * scale;
+                sourceCanvasHeight = 134f * scale;
+            }
+
+            float centerOffsetX = bounds.x + (bounds.w / 2f) - (sourceCanvasWidth / 2f);
+            float centerOffsetY = bounds.y + (bounds.h / 2f) - (sourceCanvasHeight / 2f);
+
+            bounds.x = (visual.width / 2f) + centerOffsetX - (bounds.w / 2f);
+            bounds.y = (visual.height / 2f) + centerOffsetY - (bounds.h / 2f);
+            return bounds;
         }
 
         /// <summary>Returns the bounding box for the split candy (after being cut in half).</summary>

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.Initialize.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.Initialize.cs
@@ -101,7 +101,7 @@ namespace CutTheRopeDX.GameMain
             GameObject candyObj = GameObject.GameObject_createWithResIDQuad(candyResource, 0);
             candyObj.DoRestoreCutTransparency();
             candyObj.anchor = 18;
-            candyObj.bb = GetCandyBoundingBox();
+            candyObj.bb = GetCandyBoundingBox(candyObj);
             candyObj.passTransformationsToChilds = false;
             candyObj.scaleX = candyObj.scaleY = 0.71f;
 

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.LoadMetadata.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.LoadMetadata.cs
@@ -213,7 +213,7 @@ namespace CutTheRopeDX.GameMain
             InstallSplitCandyState();
 
             // Re-apply per-level collision boxes after metadata is fully parsed, so XML order cannot leak stale mode.
-            candy.bb = GetCandyBoundingBox();
+            candy.bb = GetCandyBoundingBox(candy);
             foreach (CandyBody body in ActiveCandyBodies())
             {
                 if (body.Role != CandyBodyRole.Whole)

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.Show.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.Show.cs
@@ -34,6 +34,10 @@ namespace CutTheRopeDX.GameMain
             // Load all game objects from XML
             LoadObjectsFromMap(map, mapScale, mapOffsetX, mapOffsetY, mapGridOffsetX, mapGridOffsetY);
 
+            // Claim candies that start inside a claw before a taut authored rope gets its first
+            // constraint pass. The normal hand update still owns all later catches and releases.
+            UpdateHands(0f);
+
             conveyors.SortBelts();
 
             // Bind objects to transporters once at scene setup (matches iOS [GameScene show])

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.Update.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.Update.cs
@@ -566,17 +566,6 @@ namespace CutTheRopeDX.GameMain
                     }
 
                     CandyContext ctx = body.Owner;
-                    if (ctx.Lifecycle.Attachments.HasActiveRocket)
-                    {
-                        // Rocket-bound candy pops bubbles it touches instead of entering
-                        // them (Experiments reference): the bubble is consumed, never captured.
-                        PopBubbleAtXY(bubble3.x, bubble3.y);
-                        bubble3.popped = true;
-                        bubble3.RemoveChildWithID(0);
-                        conveyors.Remove(bubble3);
-                        captured = true;
-                        break;
-                    }
 
                     // Already carried by a different bubble: release the old one and swap to the new
                     // bubble. Without this, a bubbled body skips every new bubble (e.g. a bubbled
@@ -1079,10 +1068,6 @@ namespace CutTheRopeDX.GameMain
                             {
                                 continue;
                             }
-
-                            // A rocket and a bubble are contradictory drivers on the same point;
-                            // the Experiments reference pops the bubble at bind.
-                            PopCandyBubble(body);
 
                             rocket.mover?.Pause();
                             rocket.startRotation = rocket.rotation;

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.Update.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.Update.cs
@@ -319,6 +319,10 @@ namespace CutTheRopeDX.GameMain
             // presence guards are the enumerator's job.
             foreach (CandyBody body in ActiveCandyBodies(CandyInteraction.Physics))
             {
+                if (ActivePhysicsConstants.UseMobilePhysicsModel)
+                {
+                    body.RocketCollisionDrawPosition = Vect(body.Visual.drawX, body.Visual.drawY);
+                }
                 body.Point.Update(delta * ropePhysicsSpeed);
                 body.Visual.x = body.Point.pos.X;
                 body.Visual.y = body.Point.pos.Y;
@@ -1063,7 +1067,13 @@ namespace CutTheRopeDX.GameMain
                             {
                                 continue;
                             }
-                            bool intersects = GameObject.ObjectsIntersectRotatedWithUnrotated(rocket, body.Visual);
+                            bool intersects = ActivePhysicsConstants.UseMobilePhysicsModel
+                                ? GameObject.ObjectsIntersectRotatedWithUnrotatedAt(
+                                    rocket,
+                                    body.Visual,
+                                    body.RocketCollisionDrawPosition.X,
+                                    body.RocketCollisionDrawPosition.Y)
+                                : GameObject.ObjectsIntersectRotatedWithUnrotated(rocket, body.Visual);
                             if (!RocketBind.ShouldBind(rocket.state == Rocket.STATE_ROCKET_IDLE, candyPresent: true, ctx.Lifecycle.Attachments.InLantern, intersects))
                             {
                                 continue;

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.Update.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.Update.cs
@@ -1202,7 +1202,8 @@ namespace CutTheRopeDX.GameMain
                         bouncer.t1.X, bouncer.t1.Y, bouncer.t2.X, bouncer.t2.Y,
                         bouncer.b1.X, bouncer.b1.Y, bouncer.b2.X, bouncer.b2.Y,
                         body.Point.pos.X, body.Point.pos.Y, body.Point.prevPos.X, body.Point.prevPos.Y,
-                        bouncerCollisionRadius))
+                        bouncerCollisionRadius,
+                        includeSweep: !ActivePhysicsConstants.UseMobilePhysicsModel))
                     {
                         anyCandyHit = true;
 

--- a/src/CutTheRopeDX.Tests/CandyCollisionTests.cs
+++ b/src/CutTheRopeDX.Tests/CandyCollisionTests.cs
@@ -1,7 +1,11 @@
+using System.Reflection;
+
 using CutTheRopeDX.Framework;
 using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.Framework.Helpers;
 using CutTheRopeDX.Framework.Physics;
 using CutTheRopeDX.GameMain;
+using CutTheRopeDX.Tests.Interactions;
 
 using Xunit;
 
@@ -88,6 +92,55 @@ namespace CutTheRopeDX.Tests
             {
                 ActivePhysicsConstants.UseMobilePhysicsModel = previous;
             }
+        }
+
+        [Fact]
+        public void DesktopCandyBoundingBoxKeepsItsAuthoredCenterOffsetForAnySkinCanvas()
+        {
+            bool previous = ActivePhysicsConstants.UseMobilePhysicsModel;
+            try
+            {
+                ActivePhysicsConstants.UseMobilePhysicsModel = false;
+                GameObject differentlySizedSkin = new()
+                {
+                    width = 500,
+                    height = 300
+                };
+                MethodInfo getBounds = typeof(GameScene).GetMethod(
+                    "GetCandyBoundingBox",
+                    BindingFlags.Static | BindingFlags.NonPublic,
+                    binder: null,
+                    types: [typeof(GameObject)],
+                    modifiers: null);
+
+                CTRRectangle bounds = (CTRRectangle)getBounds.Invoke(null, [differentlySizedSkin]);
+                float centerOffsetX = bounds.x + (bounds.w / 2f) - (differentlySizedSkin.width / 2f);
+                float centerOffsetY = bounds.y + (bounds.h / 2f) - (differentlySizedSkin.height / 2f);
+
+                Assert.Equal(1.5f, centerOffsetX, precision: 3);
+                Assert.Equal(0f, centerOffsetY, precision: 3);
+            }
+            finally
+            {
+                ActivePhysicsConstants.UseMobilePhysicsModel = previous;
+            }
+        }
+
+        [Fact]
+        public void MobileCandyCollisionBoxKeepsTheIosCenterOffsetForTheActiveSkin()
+        {
+            GameScene scene = Scenario.New()
+                .Design("useMobilePhysics", "true")
+                .Candy(160, 200)
+                .OmNom(160, 440)
+                .Build();
+            GameObject visual = scene.Candy().WholeBody.Visual;
+
+            float centerOffsetX = visual.bb.x + (visual.bb.w / 2f) - (visual.width / 2f);
+            float centerOffsetY = visual.bb.y + (visual.bb.h / 2f) - (visual.height / 2f);
+
+            Assert.Equal(1.5f, centerOffsetX, precision: 3);
+            Assert.Equal(-1.5f, centerOffsetY, precision: 3);
         }
 
         [Fact]

--- a/src/CutTheRopeDX.Tests/GhostOwnershipTests.cs
+++ b/src/CutTheRopeDX.Tests/GhostOwnershipTests.cs
@@ -248,7 +248,7 @@ namespace CutTheRopeDX.Tests
         }
 
         [Fact]
-        public void RocketConsumedBubbleDoesNotBlockGhostCycling()
+        public void RocketCarriedGhostBubbleRemainsOwnedUntilItIsPopped()
         {
             GameScene scene = Scenario.New()
                 .Candy(160, 200)
@@ -261,12 +261,12 @@ namespace CutTheRopeDX.Tests
             ghost.ResetToForm(GhostForm.Bubble);
             _ = Act.BindRocket(scene, candy);
 
-            Bubble consumed = Act.PushBubbleAgainst(scene, candy);
+            Bubble carried = Act.CaptureInBubble(scene, candy);
 
-            Assert.True(consumed.popped);
-            Assert.Null(candy.WholeBody.Bubble);
-            Assert.True(ghost.OnTouchDownXY(ghost.x, ghost.y));
-            Assert.Equal(GhostForm.Grab, ghost.Form);
+            Assert.True(carried.popped);
+            Assert.Same(carried, candy.WholeBody.Bubble);
+            Assert.False(ghost.OnTouchDownXY(ghost.x, ghost.y));
+            Assert.Equal(GhostForm.Bubble, ghost.Form);
         }
 
         private static (Ghost Ghost, List<Bubble> Bubbles, List<Grab> Grabs, List<Bouncer> Bouncers) CreateGhost()

--- a/src/CutTheRopeDX.Tests/Interactions/AttachmentSetupTests.cs
+++ b/src/CutTheRopeDX.Tests/Interactions/AttachmentSetupTests.cs
@@ -1,3 +1,6 @@
+using System;
+
+using CutTheRopeDX.Framework.Core;
 using CutTheRopeDX.GameMain;
 
 using Xunit;
@@ -76,6 +79,37 @@ namespace CutTheRopeDX.Tests.Interactions
             Interaction.PlaceCandyAt(candy, hand.ClawPosition());
 
             Assert.True(Interaction.StepUntil(scene, () => candy.Lifecycle.Attachments.Hand == hand));
+        }
+
+        [Fact]
+        public void SuppliedMobileHandLayoutCatchesAndRetainsTheCandy()
+        {
+            GameScene scene = Scenario.New()
+                .Design("useMobilePhysics", "true")
+                .Candy(178, 96)
+                .Hand(177, 194, segmentLength: 93, segmentAngle: -90f, rotatable: true)
+                .Rope(89, 284, length: 45)
+                .OmNom(187, 435)
+                .Build();
+            CandyContext candy = scene.Candy();
+            MechanicalHand hand = scene.Hands()[0];
+            Vector claw = hand.ClawPosition();
+            Vector candyPosition = candy.WholeBody.Point.pos;
+            float initialDistance = MathF.Sqrt(
+                MathF.Pow(claw.X - candyPosition.X, 2f) + MathF.Pow(claw.Y - candyPosition.Y, 2f));
+
+            Assert.True(
+                initialDistance < MechanicalHand.MH_GRAB_DISTANCE,
+                $"loaded claw ({claw.X}, {claw.Y}) is {initialDistance} world units from candy ({candyPosition.X}, {candyPosition.Y})");
+
+            HeadlessGame.StepFrames(scene, 1);
+
+            Assert.Same(hand, candy.Lifecycle.Attachments.Hand);
+
+            HeadlessGame.StepFrames(scene, 120);
+
+            Assert.Same(hand, candy.Lifecycle.Attachments.Hand);
+            Assert.Equal(MechanicalHandState.HoldingCandy, hand.State);
         }
 
         [Fact]

--- a/src/CutTheRopeDX.Tests/Interactions/BubbleCaptureRowTests.cs
+++ b/src/CutTheRopeDX.Tests/Interactions/BubbleCaptureRowTests.cs
@@ -8,8 +8,8 @@ namespace CutTheRopeDX.Tests.Interactions
 {
     /// <summary>
     /// Interaction matrix, "Bubble capture" row: a bubble is the weakest claim on a candy. It keeps
-    /// ropes and a carrying mouse, replaces an earlier bubble, and simply pops against a rocket or
-    /// a snail rather than taking the candy from them.
+    /// ropes, a rocket, and a carrying mouse, replaces an earlier bubble, and simply pops against a
+    /// snail rather than taking the candy from it.
     /// </summary>
     public sealed class BubbleCaptureRowTests
     {
@@ -24,15 +24,15 @@ namespace CutTheRopeDX.Tests.Interactions
         }
 
         [Fact]
-        public void BubbleCapturePopsAgainstARocketBoundCandyWithoutCapturingIt()
+        public void BubbleCaptureCoexistsWithARocketBoundCandy()
         {
             (GameScene scene, CandyContext candy) = Rig(s => s.Rocket(160, 200, impulse: 0f));
             Rocket rocket = Act.BindRocket(scene, candy);
 
-            Bubble bubble = Act.PushBubbleAgainst(scene, candy);
+            Bubble bubble = Act.CaptureInBubble(scene, candy);
 
             Assert.True(bubble.popped);
-            Assert.Null(candy.WholeBody.Bubble);
+            Assert.Same(bubble, candy.WholeBody.Bubble);
             Assert.Same(rocket, candy.Lifecycle.Attachments.Rocket);
         }
 

--- a/src/CutTheRopeDX.Tests/Interactions/CandyTransportLifecycleTests.cs
+++ b/src/CutTheRopeDX.Tests/Interactions/CandyTransportLifecycleTests.cs
@@ -58,6 +58,29 @@ namespace CutTheRopeDX.Tests.Interactions
         }
 
         [Fact]
+        public void MobileBambooExitScalesTheIosLaunchStepIntoWorldCoordinates()
+        {
+            GameScene scene = Scenario.New()
+                .Design("useMobilePhysics", "true")
+                .Candy(160, 200)
+                .OmNom(20, 460)
+                .BambooTube(20, 40, TubeMouth.CatchesFalling)
+                .Build();
+            CandyContext candy = scene.Candy();
+            Interaction.Hover(candy);
+            Act.EnterBambooTube(scene, candy, TubeMouth.CatchesFalling);
+
+            Assert.True(
+                Interaction.StepUntil(scene, () => candy.Lifecycle.Presence == CandyPresence.Present),
+                "the tube never released the candy");
+
+            float dx = candy.WholeBody.Point.pos.X - candy.WholeBody.Point.prevPos.X;
+            float dy = candy.WholeBody.Point.pos.Y - candy.WholeBody.Point.prevPos.Y;
+            float launchStep = MathF.Sqrt((dx * dx) + (dy * dy));
+            Assert.InRange(launchStep, 22.4f, 22.6f);
+        }
+
+        [Fact]
         public void HatEntryHidesTheWholeBodyInASockSessionCarryingItsExitSpeed()
         {
             (GameScene scene, CandyContext candy) = HatRig();

--- a/src/CutTheRopeDX.Tests/Interactions/MobileBambooTubeCollisionTests.cs
+++ b/src/CutTheRopeDX.Tests/Interactions/MobileBambooTubeCollisionTests.cs
@@ -1,0 +1,41 @@
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>Mobile-reference candy entry boundaries for bamboo tubes.</summary>
+    public sealed class MobileBambooTubeCollisionTests
+    {
+        [Theory]
+        [InlineData(24f, true)]
+        [InlineData(25f, false)]
+        public void EntryUsesStrictTwentyFiveUnitRadiusFromCandyCenter(float lateralOffset, bool expected)
+        {
+            GameScene scene = Scenario.New()
+                .Design("useMobilePhysics", "true")
+                .Candy(160, 100)
+                .BambooTube(160, 220, TubeMouth.CatchesFalling)
+                .OmNom(20, 460)
+                .Build();
+            CandyBody body = scene.Candy().WholeBody;
+            BambooTube tube = scene.BambooTubes()[0];
+            Vector towardCenter = TubeGeometry.CentreDirection(TubeMouth.CatchesFalling);
+            float halfBody = tube.bb.w * 0.5f;
+            Vector entryHole = new(
+                tube.x - (towardCenter.X * halfBody),
+                tube.y - (towardCenter.Y * halfBody));
+            Vector position = new(
+                entryHole.X + (lateralOffset * Scenario.Scale),
+                entryHole.Y);
+
+            body.Point.pos = position;
+            body.Point.prevPos = new Vector(
+                position.X - (towardCenter.X * Scenario.Scale),
+                position.Y - (towardCenter.Y * Scenario.Scale));
+
+            Assert.Equal(expected, tube.TryCatchCandy(body.Point));
+        }
+    }
+}

--- a/src/CutTheRopeDX.Tests/Interactions/MobileBouncerCollisionTests.cs
+++ b/src/CutTheRopeDX.Tests/Interactions/MobileBouncerCollisionTests.cs
@@ -1,0 +1,75 @@
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>Mobile-reference collision sampling for bouncers.</summary>
+    public sealed class MobileBouncerCollisionTests
+    {
+        [Fact]
+        public void CrossingPathDoesNotBounceAfterCurrentCandyBoxHasPassed()
+        {
+            GameScene scene = Scenario.New()
+                .Design("useMobilePhysics", "true")
+                .Candy(160, 100)
+                .Bouncer(160, 300)
+                .OmNom(20, 460)
+                .Build();
+            CandyBody body = scene.Candy().WholeBody;
+            Bouncer bouncer = scene.Bouncers()[0];
+            float expectedY = bouncer.y + 100f;
+
+            body.Point.disableGravity = true;
+            body.Point.pos = new Vector(bouncer.x, bouncer.y - 100f);
+            body.Point.prevPos = new Vector(bouncer.x, bouncer.y - 300f);
+            body.Visual.x = body.Point.pos.X;
+            body.Visual.y = body.Point.pos.Y;
+
+            HeadlessGame.StepFrames(scene, 1);
+
+            Assert.Equal(expectedY, body.Point.pos.Y, precision: 3);
+        }
+
+        [Fact]
+        public void CandyFromRightBambooTubeBouncesAtLargeBouncerLeftEdge()
+        {
+            GameScene scene = Scenario.New()
+                .MapSize(320, 480)
+                .Design("useMobilePhysics", "true")
+                .Candy(291, 143)
+                .Rope(289, 56, length: 80)
+                .BambooTube(289, 268, TubeMouth.CatchesFalling)
+                .Bouncer(157, 331, size: 2)
+                .OmNom(156, 425)
+                .Build();
+            CandyContext candy = scene.Candy();
+
+            Act.CutRope(scene, scene.Grabs()[0]);
+            Assert.True(
+                Interaction.StepUntil(scene, () => candy.Lifecycle.Transport?.BambooTube != null, maxFrames: 180),
+                "the falling candy never entered the right bamboo tube");
+            Assert.True(
+                Interaction.StepUntil(scene, () => candy.Lifecycle.Presence == CandyPresence.Present, maxFrames: 180),
+                "the bamboo tube never released the candy");
+
+            bool movedDownward = false;
+            bool reversedUpward = false;
+            for (int frame = 0; frame < 90 && candy.Lifecycle.Presence == CandyPresence.Present; frame++)
+            {
+                HeadlessGame.StepFrames(scene, 1);
+                CandyBody body = candy.WholeBody;
+                float verticalDelta = body.Point.pos.Y - body.Point.prevPos.Y;
+                movedDownward |= verticalDelta > 0.01f;
+                if (movedDownward && verticalDelta < -0.01f)
+                {
+                    reversedUpward = true;
+                    break;
+                }
+            }
+
+            Assert.True(reversedUpward, "the candy crossed the bouncer's left edge without bouncing upward");
+        }
+    }
+}

--- a/src/CutTheRopeDX.Tests/Interactions/MobileRocketTrajectoryTests.cs
+++ b/src/CutTheRopeDX.Tests/Interactions/MobileRocketTrajectoryTests.cs
@@ -1,0 +1,93 @@
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests.Interactions
+{
+    /// <summary>Mobile-reference trajectories involving a candy binding to a rocket.</summary>
+    public sealed class MobileRocketTrajectoryTests
+    {
+        [Fact]
+        public void RightSideApproachMovesLowerRocketDuringReelIn()
+        {
+            GameScene scene = ReferenceScene(includeUpperRocket: false);
+            CandyContext candy = scene.Candy();
+            Rocket rocket = scene.Rockets()[0];
+            float authoredRocketX = rocket.x;
+            float maximumRocketX = authoredRocketX;
+            StartReferencePath(scene, candy);
+
+            Assert.True(
+                Interaction.StepUntil(scene, () => candy.Lifecycle.Attachments.Rocket == rocket, maxFrames: 180),
+                "the right-side approach never bound the candy to the lower rocket");
+
+            for (int frame = 0; frame < 45; frame++)
+            {
+                HeadlessGame.StepFrames(scene, 1);
+                maximumRocketX = System.MathF.Max(maximumRocketX, rocket.x);
+            }
+
+            // The iOS footage shows the lower rocket move down-right while reeling in the candy;
+            // its red body is not pinned at the authored location.
+            Assert.True(maximumRocketX > authoredRocketX + Scenario.Scale);
+        }
+
+        [Fact]
+        public void CandyCarriedByLowerRocketDoesNotBindUpperRocket()
+        {
+            GameScene scene = ReferenceScene(includeUpperRocket: true);
+            CandyContext candy = scene.Candy();
+            Rocket lowerRocket = scene.Rockets()[0];
+            Rocket upperRocket = scene.Rockets()[1];
+            StartReferencePath(scene, candy);
+
+            Assert.True(
+                Interaction.StepUntil(scene, () => candy.Lifecycle.Attachments.Rocket == lowerRocket, maxFrames: 180),
+                "the candy never bound the lower rocket");
+
+            bool upperRocketBound = false;
+            string upperBind = null;
+            for (int frame = 0; frame < 180; frame++)
+            {
+                HeadlessGame.StepFrames(scene, 1);
+                if (!upperRocketBound && candy.Lifecycle.Attachments.Rocket == upperRocket)
+                {
+                    upperRocketBound = true;
+                    upperBind = $"frame={frame}, candy=({candy.WholeBody.Point.pos.X},{candy.WholeBody.Point.pos.Y}), "
+                        + $"visual=({candy.WholeBody.Visual.x},{candy.WholeBody.Visual.y}), "
+                        + $"upper=({upperRocket.point.pos.X},{upperRocket.point.pos.Y}), "
+                        + $"lower=({lowerRocket.point.pos.X},{lowerRocket.point.pos.Y})";
+                }
+            }
+
+            Assert.False(upperRocketBound, $"the upper rocket caught the candy carried past it: {upperBind}");
+        }
+
+        private static GameScene ReferenceScene(bool includeUpperRocket)
+        {
+            Scenario scenario = Scenario.New()
+                .MapSize(320, 480)
+                .Design("useMobilePhysics", "true")
+                .Candy(291, 143)
+                .Rope(289, 56, length: 80)
+                .BambooTube(289, 268, TubeMouth.CatchesFalling)
+                .Rocket(108, 265, angle: -90f, impulse: 25f, time: 0.58f, impulseFactor: 0.6f);
+            if (includeUpperRocket)
+            {
+                _ = scenario.Rocket(124, 182, angle: -90f, impulse: 25f, time: 0.27f, impulseFactor: 0.6f, isRotatable: true);
+            }
+            return scenario
+                .Bouncer(157, 331, size: 2)
+                .OmNom(156, 425)
+                .Build();
+        }
+
+        private static void StartReferencePath(GameScene scene, CandyContext candy)
+        {
+            Act.CutRope(scene, scene.Grabs()[0]);
+            Assert.True(
+                Interaction.StepUntil(scene, () => candy.Lifecycle.Transport?.BambooTube != null, maxFrames: 180),
+                "the falling candy never entered the right bamboo tube");
+        }
+    }
+}

--- a/src/CutTheRopeDX.Tests/Interactions/RocketBindRowTests.cs
+++ b/src/CutTheRopeDX.Tests/Interactions/RocketBindRowTests.cs
@@ -8,8 +8,8 @@ namespace CutTheRopeDX.Tests.Interactions
 {
     /// <summary>
     /// Interaction matrix, "Rocket bind" row: the rocket steals from nobody. It coexists with a
-    /// hand or a mouse on a zero-rest FLY bind, keeps ropes and snail, pops a bubble it cannot
-    /// share the point with, and burns out any rocket already on the candy.
+    /// hand or a mouse on a zero-rest FLY bind, keeps ropes, bubble, and snail, and burns out any
+    /// rocket already on the candy.
     /// </summary>
     public sealed class RocketBindRowTests
     {
@@ -52,15 +52,16 @@ namespace CutTheRopeDX.Tests.Interactions
         }
 
         [Fact]
-        public void RocketBindPopsItsBubble()
+        public void RocketBindKeepsItsBubble()
         {
             (GameScene scene, CandyContext candy) = Rig(s => s.Bubble(160, 200));
             Bubble bubble = Act.CaptureInBubble(scene, candy);
 
-            _ = Act.BindRocket(scene, candy);
+            Rocket rocket = Act.BindRocket(scene, candy);
 
-            Assert.Null(candy.WholeBody.Bubble);
+            Assert.Same(bubble, candy.WholeBody.Bubble);
             Assert.True(bubble.popped);
+            Assert.Same(rocket, candy.Lifecycle.Attachments.Rocket);
         }
 
         [Fact]

--- a/src/CutTheRopeDX.Tests/TextureCollisionWidthTests.cs
+++ b/src/CutTheRopeDX.Tests/TextureCollisionWidthTests.cs
@@ -84,15 +84,27 @@ namespace CutTheRopeDX.Tests
 
         // Both originals set the bouncer's collision width from the initial sprite (quad 0) and
         // never advance it with the bounce animation, so only the first quad width is used.
-        // Mobile applies the Experiments-style end-cap of 20 (1x) to the quad-0 width.
+        // Mobile first normalizes the high-resolution iOS quad into authored level space,
+        // then applies the native 20-unit logical end-cap.
         [Theory]
-        [InlineData(false, 138f)] // small quad 0: (66 - 20) * 3
-        [InlineData(true, 273f)]  // large quad 0: (111 - 20) * 3
-        public void BouncerWidthMobileUsesWp7FirstQuadWidth(bool large, float expected)
+        [InlineData(false, 140f)] // small quad 0: ((100 / 1.5) - 20) * 3
+        [InlineData(true, 240f)]  // large quad 0: ((150 / 1.5) - 20) * 3
+        public void BouncerWidthMobileUsesIosFirstQuadWidth(bool large, float expected)
         {
             float result = WithMobilePhysics(true, () =>
                 ActivePhysicsConstants.BouncerCollisionWidth(large));
             Assert.Equal(expected, result, precision: 3);
+        }
+
+        [Fact]
+        public void BouncerCandyBoxAndBandMobileUseNativeLogicalUnits()
+        {
+            (float radius, float height) = WithMobilePhysics(true, () => (
+                ActivePhysicsConstants.BouncerCollisionRadius,
+                ActivePhysicsConstants.BouncerHeight));
+
+            Assert.Equal(60f, radius, precision: 3); // 20 * 3
+            Assert.Equal(15f, height, precision: 3); // 5 * 3
         }
 
         [Theory]


### PR DESCRIPTION
## Description

- Preserve bubbles when candy binds to a rocket instead of popping them.
- Capture candy placed inside a hand during scene initialization.
- Keep candy collision geometry centered consistently across cosmetic skins.
- Match native rocket collision timing using the candy's pre-integration position.
- Preserve the original bamboo tube exit speed and correct its mobile capture radius.
- Match iOS bouncer geometry and current-frame collision sampling:
  - Normalize high-resolution sprite widths before applying logical collision offsets
  - Preserve the native 20-unit candy radius and 5-unit collision band
  - Disable swept bouncer collision in mobile physics mode