### PR TITLE
fix: Address some gameplay background coverages

### DIFF
--- a/src/CutTheRopeDX.Core/GameMain/BackgroundTiling.cs
+++ b/src/CutTheRopeDX.Core/GameMain/BackgroundTiling.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>Calculates placement shared by the authored gameplay background pieces.</summary>
+    internal static class BackgroundTiling
+    {
+        private const float Epsilon = 0.001f;
+
+        /// <summary>Returns how many seams between P1 sections need a P2 overlay.</summary>
+        /// <param name="mapHeight">Height of the level map.</param>
+        /// <param name="mapSectionHeight">Map height represented by one P1 section.</param>
+        /// <returns>One fewer than the number of P1 sections used by the map.</returns>
+        public static int GetP2Count(float mapHeight, float mapSectionHeight)
+        {
+            if (mapSectionHeight <= 0f)
+            {
+                return 0;
+            }
+
+            int p1Count = Math.Max(
+                1,
+                (int)MathF.Ceiling((mapHeight / mapSectionHeight) - Epsilon));
+            return Math.Max(0, p1Count - 1);
+        }
+
+        /// <summary>Places a P2 overlay at the requested seam between repeated P1 sections.</summary>
+        /// <param name="originalP2Y">Authored P2 offset for the first seam.</param>
+        /// <param name="p1Height">Height of one repeated P1 texture.</param>
+        /// <param name="seamIndex">Zero-based seam index from the top of the map.</param>
+        /// <returns>The P2 offset for that seam.</returns>
+        public static float ResolveP2Y(float originalP2Y, float p1Height, int seamIndex)
+        {
+            return originalP2Y + (Math.Max(0, seamIndex) * p1Height);
+        }
+    }
+}

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.Draw.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.Draw.cs
@@ -39,7 +39,8 @@ namespace CutTheRopeDX.GameMain
             Renderer.PushMatrix();
             Renderer.Scale(back.scaleX, back.scaleY, 1f);
             back.Draw();
-            if (mapHeight > SCREEN_HEIGHT)
+            int p2Count = BackgroundTiling.GetP2Count(mapHeight, SCREEN_HEIGHT);
+            if (p2Count > 0)
             {
                 int pack = ((CTRRootController)Application.SharedRootController()).GetPack();
                 int p2Y = PackConfig.GetBoxBackgroundP2Y(pack);
@@ -58,10 +59,20 @@ namespace CutTheRopeDX.GameMain
                         Renderer.Enable(Renderer.GL_BLEND);
                         Renderer.SetBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
 
-                        // Hung from the same corner the first piece is, at the authored offset
-                        // below it. The two are one picture, so a piece placed from the origin
-                        // instead would come away from the other wherever the fit has moved it.
-                        DrawHelper.DrawImagePart(p2Texture, p2Rect, back.x, back.y + p2Y);
+                        // P2 is authored for the first seam. Repeat it at the P1 cadence so maps
+                        // with three sections dress both their top and bottom seams.
+                        for (int seamIndex = 0; seamIndex < p2Count; seamIndex++)
+                        {
+                            float adjustedP2Y = BackgroundTiling.ResolveP2Y(
+                                p2Y,
+                                backTexture._realHeight,
+                                seamIndex);
+                            DrawHelper.DrawImagePart(
+                                p2Texture,
+                                p2Rect,
+                                back.x,
+                                back.y + adjustedP2Y);
+                        }
                         Renderer.Disable(Renderer.GL_BLEND);
                     }
                 }

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.Draw.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.Draw.cs
@@ -306,7 +306,7 @@ namespace CutTheRopeDX.GameMain
                     body.Visual.Draw();
                 }
             }
-            waterLayer?.DrawFront(camera.RenderPos.Y);
+            waterLayer?.DrawFront();
             foreach (LightBulb bulb in LightEmitterVisuals())
             {
                 bulb?.DrawBottleAndFirefly();

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.Init.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.Init.cs
@@ -192,6 +192,7 @@ namespace CutTheRopeDX.GameMain
             image.x += xs;
             image.y += ys;
             gravityState.AddEarthAnimation(image);
+            gravityState.RelayoutEarthAnimations(back.x, back.y);
         }
     }
 }

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.Init.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.Init.cs
@@ -60,7 +60,8 @@ namespace CutTheRopeDX.GameMain
                 throw new InvalidDataException($"Pack config is missing boxBackground for pack {cTRRootController.GetPack()}.");
             }
             back = new TileMap().InitWithRowsColumns(1, 1);
-            back.SetRepeatHorizontally(TileMap.Repeat.NONE);
+            // Wide levels can move the camera past one P1 width, so repeat it on both axes.
+            back.SetRepeatHorizontally(TileMap.Repeat.ALL);
             back.SetRepeatVertically(TileMap.Repeat.ALL);
             // Cache the background texture so we can keep scaling tied to internal width.
             backTexture = Application.GetTexture(boxBackground);

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.cs
@@ -443,6 +443,29 @@ namespace CutTheRopeDX.GameMain
                 cameraWindow.h);
 
             camera.ApplyFit(LayoutMath.FitCamera(window, viewport, anchorX, anchorY));
+            RelayoutWaterCoverage(snapshot);
+        }
+
+        /// <summary>Extends water through any world exposed beyond the authored level frame.</summary>
+        private void RelayoutWaterCoverage(ViewportLayoutSnapshot snapshot)
+        {
+            if (waterLayer == null || camera.Scale <= 0f)
+            {
+                return;
+            }
+
+            CTRRectangle viewport = snapshot.VisibleBounds;
+            float visibleLeft = camera.RenderPos.X;
+            float visibleRight = visibleLeft + (viewport.w / camera.Scale);
+            float visibleBottom = camera.RenderPos.Y + (viewport.h / camera.Scale);
+
+            float authoredLeft = mapWidth < SCREEN_WIDTH ? 0f : mapOriginX;
+            float authoredRight = mapWidth < SCREEN_WIDTH ? SCREEN_WIDTH : mapOriginX + mapWidth;
+            waterLayer.RelayoutCoverage(
+                MathF.Min(authoredLeft, visibleLeft),
+                MathF.Max(authoredRight, visibleRight),
+                MathF.Max(mapOriginY + mapHeight, visibleBottom));
+            waterLayer.RelayoutViewportClip(camera.RenderPos, camera.Scale);
         }
 
         /// <summary>

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.cs
@@ -399,6 +399,7 @@ namespace CutTheRopeDX.GameMain
             // world as the camera moves, so a level taller than the screen still scrolls past it.
             back.x = (SCREEN_WIDTH / 2f / backgroundScale) - (backTexture._realWidth / 2f);
             back.y = (SCREEN_HEIGHT / 2f / backgroundScale) - (backTexture._realHeight / 2f);
+            gravityState.RelayoutEarthAnimations(back.x, back.y);
         }
 
         /// <summary>

--- a/src/CutTheRopeDX.Core/GameMain/GravityState.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GravityState.cs
@@ -12,7 +12,7 @@ namespace CutTheRopeDX.GameMain
     /// </summary>
     internal sealed class GravityState
     {
-        private readonly List<Image> earthAnimations = [];
+        private readonly List<EarthAnimationPlacement> earthAnimations = [];
         private readonly List<ToggleButton> buttons = [];
         private int toggleTouchIndex = -1;
 
@@ -55,7 +55,19 @@ namespace CutTheRopeDX.GameMain
         {
             if (earthAnimation != null)
             {
-                earthAnimations.Add(earthAnimation);
+                earthAnimations.Add(new EarthAnimationPlacement(
+                    earthAnimation,
+                    new Vector(earthAnimation.x, earthAnimation.y)));
+            }
+        }
+
+        /// <summary>Places every earth image relative to the fitted P1 background origin.</summary>
+        public void RelayoutEarthAnimations(float backgroundX, float backgroundY)
+        {
+            foreach (EarthAnimationPlacement placement in earthAnimations)
+            {
+                placement.Image.x = backgroundX + placement.AuthoredPosition.X;
+                placement.Image.y = backgroundY + placement.AuthoredPosition.Y;
             }
         }
 
@@ -130,18 +142,18 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Advances all gravity-owned earth animations.</summary>
         public void UpdateEarthAnimations(float delta)
         {
-            foreach (Image earthAnimation in earthAnimations)
+            foreach (EarthAnimationPlacement placement in earthAnimations)
             {
-                earthAnimation.Update(delta);
+                placement.Image.Update(delta);
             }
         }
 
         /// <summary>Draws all gravity-owned earth animations.</summary>
         public void DrawEarthAnimations()
         {
-            foreach (Image earthAnimation in earthAnimations)
+            foreach (EarthAnimationPlacement placement in earthAnimations)
             {
-                earthAnimation.Draw();
+                placement.Image.Draw();
             }
         }
 
@@ -159,8 +171,9 @@ namespace CutTheRopeDX.GameMain
                 }
             }
 
-            foreach (Image earthAnimation in earthAnimations)
+            foreach (EarthAnimationPlacement placement in earthAnimations)
             {
+                Image earthAnimation = placement.Image;
                 if (animateEarth)
                 {
                     earthAnimation.PlayTimeline(IsInverted ? 1 : 0);
@@ -175,5 +188,7 @@ namespace CutTheRopeDX.GameMain
                 }
             }
         }
+
+        private sealed record EarthAnimationPlacement(Image Image, Vector AuthoredPosition);
     }
 }

--- a/src/CutTheRopeDX.Core/GameMain/WaterElement.cs
+++ b/src/CutTheRopeDX.Core/GameMain/WaterElement.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 using CutTheRopeDX.Framework;
 using CutTheRopeDX.Framework.Core;
@@ -67,6 +68,9 @@ namespace CutTheRopeDX.GameMain
         /// Randomly repositioned spotlight element.
         /// </summary>
         private Image spotLight;
+
+        /// <summary>Ambient light strips distributed across the current water width.</summary>
+        private readonly List<Image> ambientLights = [];
 
         /// <summary>
         /// Whether this water element is being released and should stop drawing or updating.
@@ -161,18 +165,19 @@ namespace CutTheRopeDX.GameMain
             backTileSize = GetQuadSize(Resources.Img.WaterTile, 2);
             xOffsetBack = backTileSize.X;
 
-            const int ambientLights = 10;
-            for (int i = 0; i <= ambientLights; i++)
+            const int ambientLightCount = 10;
+            for (int i = 0; i <= ambientLightCount; i++)
             {
-                RGBAColor alphaColor = (i is 0 or ambientLights)
+                RGBAColor alphaColor = (i is 0 or ambientLightCount)
                     ? RGBAColor.MakeRGBA(1f, 1f, 1f, 0.5f)
                     : RGBAColor.solidOpaqueRGBA;
-                Image light = CreateLightWithXPosquadalphaColordelegate(SCREEN_WIDTH / ambientLights * (i - 1f), 7, alphaColor, this);
+                Image light = CreateLightWithXPosquadalphaColordelegate(width / (float)ambientLightCount * (i - 1f), 7, alphaColor, this);
+                ambientLights.Add(light);
                 _ = AddChild(light);
             }
 
             spotLight = CreateLightWithXPosquadalphaColordelegate(
-                RND_RANGE((int)SCREEN_WIDTH / 4, (int)SCREEN_WIDTH * 3 / 4),
+                RND_RANGE(width / 4, width * 3 / 4),
                 6,
                 RGBAColor.MakeRGBA(1f, 1f, 1f, 0.6f),
                 this);
@@ -203,7 +208,6 @@ namespace CutTheRopeDX.GameMain
 
                 scissorElement = new ScissorElement
                 {
-                    parentAnchor = 9,
                     width = width,
                     height = height,
                     y = topTileSize.Y
@@ -213,6 +217,67 @@ namespace CutTheRopeDX.GameMain
             }
 
             return this;
+        }
+
+        /// <summary>
+        /// Resizes the water body to cover responsive world bounds without moving its surface.
+        /// </summary>
+        /// <param name="left">Left edge of the required world-space coverage.</param>
+        /// <param name="right">Right edge of the required world-space coverage.</param>
+        /// <param name="bottom">Bottom edge of the required world-space coverage.</param>
+        public void RelayoutCoverage(float left, float right, float bottom)
+        {
+            float oldWidth = width;
+            float spotFraction = oldWidth > 0f && spotLight != null
+                ? spotLight.x / oldWidth
+                : 0.5f;
+            float coverageLeft = MathF.Floor(left);
+            float coverageRight = MathF.Ceiling(right);
+
+            x = coverageLeft;
+            width = Math.Max(0, (int)(coverageRight - coverageLeft));
+            height = Math.Max(0, (int)MathF.Ceiling(bottom - y));
+
+            if (bubbles != null)
+            {
+                bubbles.width = width;
+                bubbles.height = height;
+                bubbles.x = width / 2f;
+                bubbles.posVar.X = width / 2f;
+            }
+
+            if (scissorElement != null)
+            {
+                scissorElement.width = width;
+                scissorElement.height = height;
+            }
+
+            int ambientLightCount = ambientLights.Count - 1;
+            if (ambientLightCount > 0)
+            {
+                for (int i = 0; i < ambientLights.Count; i++)
+                {
+                    ambientLights[i].x = width / (float)ambientLightCount * (i - 1f);
+                }
+            }
+
+            _ = (spotLight?.x = FIT_TO_BOUNDARIES(spotFraction * width, width / 4f, width * 3f / 4f));
+        }
+
+        /// <summary>Projects the world-space water clip into the camera's viewport coordinates.</summary>
+        /// <param name="cameraPosition">World-space top-left of the camera.</param>
+        /// <param name="cameraScale">World-to-viewport scale.</param>
+        public void RelayoutViewportClip(Vector cameraPosition, float cameraScale)
+        {
+            if (scissorElement == null || cameraScale <= 0f)
+            {
+                return;
+            }
+
+            scissorElement.x = (x - cameraPosition.X) * cameraScale;
+            scissorElement.y = (y + topTileSize.Y - cameraPosition.Y) * cameraScale;
+            scissorElement.width = (int)MathF.Ceiling(width * cameraScale);
+            scissorElement.height = (int)MathF.Ceiling(height * cameraScale);
         }
 
         /// <summary>
@@ -239,7 +304,12 @@ namespace CutTheRopeDX.GameMain
         /// <param name="ty">The Y position to spawn particles at.</param>
         public void AddParticlesAtXY(float tx, float ty)
         {
-            if (isReleasing || bubbles == null)
+            if (isReleasing
+                || bubbles == null
+                || tx < x
+                || tx > x + width
+                || ty <= y
+                || ty > y + height)
             {
                 return;
             }
@@ -289,8 +359,7 @@ namespace CutTheRopeDX.GameMain
         /// <summary>
         /// Draws the front layer of the water (top shadow, bubbles with additive blending, and top tile).
         /// </summary>
-        /// <param name="cameraY">The camera Y offset used to adjust the scissor region.</param>
-        public void DrawFront(float cameraY)
+        public void DrawFront()
         {
             if (isReleasing)
             {
@@ -301,11 +370,6 @@ namespace CutTheRopeDX.GameMain
             DrawHelper.DrawImageTiled(texture, 1, drawX, drawY, width, topShadowSize.Y);
 
             Renderer.SetBlendFunc(BlendingFactor.GLSRCALPHA, BlendingFactor.GLONE);
-            if (scissorElement != null)
-            {
-                scissorElement.y = topTileSize.Y - cameraY;
-                scissorElement.height = height;
-            }
             PostDraw();
 
             Renderer.SetBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
@@ -317,7 +381,7 @@ namespace CutTheRopeDX.GameMain
         /// <inheritdoc/>
         public override void Draw()
         {
-            DrawFront(0f);
+            DrawFront();
         }
 
         /// <inheritdoc/>
@@ -368,7 +432,7 @@ namespace CutTheRopeDX.GameMain
 
             if (ReferenceEquals(t.element, spotLight))
             {
-                t.element.x = RND_RANGE((int)SCREEN_WIDTH / 4, (int)SCREEN_WIDTH * 3 / 4);
+                t.element.x = RND_RANGE(width / 4, width * 3 / 4);
             }
         }
 
@@ -396,6 +460,7 @@ namespace CutTheRopeDX.GameMain
                 scissorElement = null;
                 aniPool = null;
                 spotLight = null;
+                ambientLights.Clear();
             }
             base.Dispose(disposing);
         }

--- a/src/CutTheRopeDX.Tests/BackgroundTilingTests.cs
+++ b/src/CutTheRopeDX.Tests/BackgroundTilingTests.cs
@@ -1,5 +1,5 @@
-using CutTheRopeDX.GameMain;
 using CutTheRopeDX.Framework;
+using CutTheRopeDX.GameMain;
 
 using Xunit;
 

--- a/src/CutTheRopeDX.Tests/BackgroundTilingTests.cs
+++ b/src/CutTheRopeDX.Tests/BackgroundTilingTests.cs
@@ -1,0 +1,49 @@
+using CutTheRopeDX.GameMain;
+using CutTheRopeDX.Framework;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public sealed class BackgroundTilingTests
+    {
+        [Theory]
+        [InlineData(1440f, 0)]
+        [InlineData(2880f, 1)]
+        [InlineData(4320f, 2)]
+        [InlineData(5760f, 3)]
+        public void EveryP1SeamGetsAP2Overlay(float mapHeight, int expectedCount)
+        {
+            Assert.Equal(
+                expectedCount,
+                BackgroundTiling.GetP2Count(mapHeight, mapSectionHeight: 1440f));
+        }
+
+        [Fact]
+        public void ThreeP1SectionsPlaceP2AtBothSeams()
+        {
+            Assert.Equal(1120f, BackgroundTiling.ResolveP2Y(1120f, 1440f, seamIndex: 0));
+            Assert.Equal(2560f, BackgroundTiling.ResolveP2Y(1120f, 1440f, seamIndex: 1));
+        }
+
+        [Theory]
+        [InlineData(2560, 1440)]
+        [InlineData(2560, 1600)]
+        [InlineData(2560, 2160)]
+        public void ThreeP1SectionsKeepBothOverlaysAtTallSurfaceHeights(int width, int height)
+        {
+            LayoutSurfaces.WithSurface(width, height, () =>
+            {
+                float sectionHeight = FrameworkTypes.SCREEN_HEIGHT;
+
+                Assert.Equal(
+                    2,
+                    BackgroundTiling.GetP2Count(
+                        mapHeight: sectionHeight * 3f,
+                        mapSectionHeight: sectionHeight));
+                Assert.Equal(1120f, BackgroundTiling.ResolveP2Y(1120f, 1440f, seamIndex: 0));
+                Assert.Equal(2560f, BackgroundTiling.ResolveP2Y(1120f, 1440f, seamIndex: 1));
+            });
+        }
+    }
+}

--- a/src/CutTheRopeDX.Tests/GameplayBackgroundTests.cs
+++ b/src/CutTheRopeDX.Tests/GameplayBackgroundTests.cs
@@ -1,11 +1,14 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 
 using CutTheRopeDX.Framework;
+using CutTheRopeDX.Framework.Core;
 using CutTheRopeDX.Framework.Helpers;
 using CutTheRopeDX.Framework.Platform;
 using CutTheRopeDX.Framework.Visual;
 using CutTheRopeDX.GameMain;
+using CutTheRopeDX.Tests.Interactions;
 
 using Xunit;
 
@@ -123,6 +126,49 @@ namespace CutTheRopeDX.Tests
                 Assert.Equal(before.w, after.w, 0.01);
                 Assert.Equal(before.h, after.h, 0.01);
             });
+        }
+
+        [Fact]
+        public void WideLevelP1TilesCoverTheRightCameraWindow()
+        {
+            GameScene scene = Scenario.New()
+                .MapSize(1280, 480)
+                .Candy(1100, 120)
+                .OmNom(1180, 360)
+                .Build();
+
+            Assert.True(Read<float>(scene, "mapWidth") > FrameworkTypes.SCREEN_WIDTH);
+            TileMap background = Read<TileMap>(scene, "back");
+            Assert.Equal(
+                TileMap.Repeat.ALL,
+                Read<TileMap.Repeat>(background, "repeatedHorizontally"));
+
+            // Move the tile-map camera half a frame to the right, past the original P1's center.
+            // The generated quads must still form one unbroken span across the whole camera.
+            float cameraX = FrameworkTypes.SCREEN_WIDTH / 2f;
+            background.UpdateWithCameraPos(new Vector(cameraX, 0f));
+
+            List<ImageMultiDrawer> drawers = Read<List<ImageMultiDrawer>>(background, "drawers");
+            ImageMultiDrawer drawer = Assert.Single(drawers);
+            List<Quad3D> quads = [];
+            for (int i = 0; i < drawer.numberOfQuadsToDraw; i++)
+            {
+                quads.Add(drawer.vertices[i]);
+            }
+            quads.Sort((left, right) => left.BlX.CompareTo(right.BlX));
+
+            float coveredUntil = cameraX;
+            foreach (Quad3D quad in quads)
+            {
+                Assert.True(
+                    quad.BlX <= coveredUntil + EdgeTolerance,
+                    $"P1 leaves a horizontal gap from {coveredUntil} to {quad.BlX}");
+                coveredUntil = MathF.Max(coveredUntil, quad.BrX);
+            }
+            Assert.True(
+                coveredUntil >= cameraX + FrameworkTypes.SCREEN_WIDTH - EdgeTolerance,
+                $"P1 coverage ends at {coveredUntil}, before the camera edge at "
+                    + $"{cameraX + FrameworkTypes.SCREEN_WIDTH}");
         }
 
         /// <summary>

--- a/src/CutTheRopeDX.Tests/GameplayBackgroundTests.cs
+++ b/src/CutTheRopeDX.Tests/GameplayBackgroundTests.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 
+using CutTheRopeDX.Commons;
 using CutTheRopeDX.Framework;
 using CutTheRopeDX.Framework.Core;
 using CutTheRopeDX.Framework.Helpers;
@@ -171,6 +173,26 @@ namespace CutTheRopeDX.Tests
                     + $"{cameraX + FrameworkTypes.SCREEN_WIDTH}");
         }
 
+        [Fact]
+        public void EarthImageKeepsItsAuthoredOffsetFromP1AfterResize()
+        {
+            _ = HeadlessGame.Boot();
+
+            LayoutSurfaces.WithSurface(2560, 1440, () =>
+            {
+                GameScene scene = HeadlessGame.LoadLevel(pack: 7, level: 0);
+
+                CtrRenderer.OnSurfaceChanged(1868, 1674);
+                scene.RelayoutCamera();
+                scene.RelayoutHud();
+
+                TileMap background = Read<TileMap>(scene, "back");
+                Image earth = ReadFirstEarthImage(scene.gravityState);
+                Assert.Equal(1284f, earth.x - background.x, 0.01);
+                Assert.Equal(724f, earth.y - background.y, 0.01);
+            });
+        }
+
         /// <summary>
         /// Loads a level laid out for the given surface and hands its background to
         /// <paramref name="body"/> along with the region of world the screen exposes.
@@ -234,6 +256,26 @@ namespace CutTheRopeDX.Tests
                 .GetField(field, BindingFlags.Instance | BindingFlags.NonPublic)
                 ?.GetValue(target);
             return Assert.IsType<T>(value);
+        }
+
+        private static Image ReadFirstEarthImage(GravityState gravityState)
+        {
+            object value = gravityState.GetType()
+                .GetField("earthAnimations", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.GetValue(gravityState);
+            IList earthAnimations = Assert.IsAssignableFrom<IList>(value);
+            _ = Assert.Single(earthAnimations);
+            object first = earthAnimations[0];
+            if (first is Image image)
+            {
+                return image;
+            }
+
+            PropertyInfo imageProperty = first.GetType().GetProperty(
+                "Image",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(imageProperty);
+            return Assert.IsType<Image>(imageProperty.GetValue(first));
         }
 
         public static TheoryData<string, int, int> Surfaces()

--- a/src/CutTheRopeDX.Tests/WaterResponsiveLayoutTests.cs
+++ b/src/CutTheRopeDX.Tests/WaterResponsiveLayoutTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Reflection;
+
+using CutTheRopeDX.Commons;
+using CutTheRopeDX.Framework;
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.Framework.Helpers;
+using CutTheRopeDX.Framework.Platform;
+using CutTheRopeDX.GameMain;
+using CutTheRopeDX.Tests.Interactions;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    /// <summary>Responsive coverage for the world-space water layer.</summary>
+    public sealed class WaterResponsiveLayoutTests
+    {
+        [Fact]
+        public void WaterExtendsAcrossTheVisibleWorldAfterNonSixteenNineResizes()
+        {
+            LayoutSurfaces.WithSurface(2560, 1440, () =>
+            {
+                GameScene scene = Scenario.New()
+                    .MapSize(320, 480)
+                    .Design("water", "160")
+                    .Candy(160, 120)
+                    .OmNom(160, 400)
+                    .Build();
+
+                WaterElement water = Read<WaterElement>(scene, "waterLayer");
+                float authoredWaterline = water.y;
+
+                AssertWaterCoversVisibleWorld(scene, water, 2560, 1080, authoredWaterline);
+                AssertWaterCoversVisibleWorld(scene, water, 1000, 1000, authoredWaterline);
+            });
+        }
+
+        [Fact]
+        public void BubbleClipTracksTheCameraScaledWaterSurfaceAfterPortraitResize()
+        {
+            LayoutSurfaces.WithSurface(2560, 1440, () =>
+            {
+                GameScene scene = BuildWaterScene();
+                WaterElement water = Read<WaterElement>(scene, "waterLayer");
+
+                CtrRenderer.OnSurfaceChanged(640, 1600);
+                scene.RelayoutCamera();
+
+                Camera2D camera = Read<Camera2D>(scene, "camera");
+                ScissorElement clip = Read<ScissorElement>(water, "scissorElement");
+                Vector topTileSize = Read<Vector>(water, "topTileSize");
+
+                Assert.Equal((water.x - camera.RenderPos.X) * camera.Scale, clip.x, 0.01);
+                Assert.Equal(
+                    (water.y + topTileSize.Y - camera.RenderPos.Y) * camera.Scale,
+                    clip.y,
+                    0.01);
+                Assert.Equal(MathF.Ceiling(water.width * camera.Scale), clip.width);
+                Assert.Equal(MathF.Ceiling(water.height * camera.Scale), clip.height);
+            });
+        }
+
+        [Fact]
+        public void ClickBubblesOnlySpawnInsideTheResponsiveWaterBounds()
+        {
+            LayoutSurfaces.WithSurface(2560, 1440, () =>
+            {
+                GameScene scene = BuildWaterScene();
+                WaterElement water = Read<WaterElement>(scene, "waterLayer");
+
+                CtrRenderer.OnSurfaceChanged(640, 1600);
+                scene.RelayoutCamera();
+
+                WaterBubbles bubbles = Read<WaterBubbles>(water, "bubbles");
+                int initialParticles = bubbles.particleCount;
+                float middleX = water.x + (water.width / 2f);
+
+                water.AddParticlesAtXY(middleX, water.y - 1f);
+                Assert.Equal(initialParticles, bubbles.particleCount);
+
+                water.AddParticlesAtXY(middleX, water.y + water.height - 1f);
+                Assert.Equal(initialParticles + 3, bubbles.particleCount);
+
+                water.AddParticlesAtXY(water.x - 1f, water.y + 1f);
+                Assert.Equal(initialParticles + 3, bubbles.particleCount);
+            });
+        }
+
+        private static GameScene BuildWaterScene()
+        {
+            return Scenario.New()
+                .MapSize(320, 480)
+                .Design("water", "160")
+                .Candy(160, 120)
+                .OmNom(160, 400)
+                .Build();
+        }
+
+        private static void AssertWaterCoversVisibleWorld(
+            GameScene scene,
+            WaterElement water,
+            int width,
+            int height,
+            float authoredWaterline)
+        {
+            CtrRenderer.OnSurfaceChanged(width, height);
+            scene.RelayoutCamera();
+
+            Camera2D camera = Read<Camera2D>(scene, "camera");
+            CTRRectangle viewport = ScreenPresentation.Instance.Snapshot.VisibleBounds;
+            float visibleLeft = camera.RenderPos.X;
+            float visibleRight = visibleLeft + (viewport.w / camera.Scale);
+            float visibleBottom = camera.RenderPos.Y + (viewport.h / camera.Scale);
+
+            Assert.True(
+                water.x <= visibleLeft && water.x + water.width >= visibleRight,
+                $"{width}x{height}: water spans x [{water.x}, {water.x + water.width}], "
+                    + $"visible world needs [{visibleLeft}, {visibleRight}]");
+            Assert.True(
+                water.y + water.height >= visibleBottom,
+                $"{width}x{height}: water ends at {water.y + water.height}, visible world ends "
+                    + $"at {visibleBottom}");
+            Assert.Equal(authoredWaterline, water.y, 0.01);
+        }
+
+        private static T Read<T>(object target, string field)
+        {
+            object value = target.GetType()
+                .GetField(field, BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.GetValue(target);
+            return Assert.IsType<T>(value);
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Tile P1 backgrounds horizontally
- Repeat P2 overlays across every vertical seam
- Keep earth decorations aligned with the fitted gameplay background after resizing
- Extend water, lighting, particle bounds, and clipping across the responsive viewport