### PR TITLE
feat: Add listener for playtesting levels from the browser level editor

### DIFF
--- a/content/locales/en.json
+++ b/content/locales/en.json
@@ -125,6 +125,7 @@
     "ACHIEVEMENT_UNLOCKED": "Achievement unlocked!",
     "QUIT": "Are you sure you want to quit?",
     "QUIT_BUTTON": "Quit",
+    "CLOSE_TAB_BUTTON": "Close tab",
     "LEVEL_EDITOR_BUTTON": "Level editor",
     "FACEBOOK_BUTTON": "",
     "CANDIES_BTN": "Candies",

--- a/src/CutTheRopeDX.Browser/Browser/BrowserFileWatcherFactory.cs
+++ b/src/CutTheRopeDX.Browser/Browser/BrowserFileWatcherFactory.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using CutTheRopeDX.Framework.Platform;
+
+namespace CutTheRopeDX.Browser
+{
+    /// <summary>
+    /// Reports level file changes in the browser, where <see cref="FileSystemWatcher"/> throws
+    /// <see cref="PlatformNotSupportedException"/>.
+    /// </summary>
+    /// <remarks>
+    /// The WASM filesystem is real enough for Core to read and write, but nothing observes it. So
+    /// the writer reports its own change: <c>PlaytestSession</c> (Task 3) writes the level and then
+    /// calls <see cref="NotifyChanged"/>. Core cannot tell this apart from a desktop file event,
+    /// which is the point - it keeps the same debounce and the same reload decision on both heads.
+    /// </remarks>
+    internal sealed class BrowserFileWatcherFactory : IFileWatcherFactory
+    {
+        /// <summary>Registered callbacks, keyed by the full path being watched.</summary>
+        private readonly Dictionary<string, List<Action>> _watches = new(StringComparer.Ordinal);
+
+        /// <inheritdoc />
+        public IDisposable Watch(string directory, string fileName, Action onChanged)
+        {
+            if (string.IsNullOrEmpty(directory) || string.IsNullOrEmpty(fileName) || onChanged == null)
+            {
+                return null;
+            }
+
+            string key = Path.Combine(directory, fileName);
+            if (!_watches.TryGetValue(key, out List<Action> callbacks))
+            {
+                callbacks = [];
+                _watches[key] = callbacks;
+            }
+            callbacks.Add(onChanged);
+            return new Registration(this, key, onChanged);
+        }
+
+        /// <summary>Reports that a watched file has just been rewritten.</summary>
+        /// <param name="directory">Directory holding the file.</param>
+        /// <param name="fileName">File name within <paramref name="directory"/>.</param>
+        /// <remarks>Silently does nothing when nothing is watching that path, which is the normal
+        /// case before the game has reached gameplay and installed its watcher.</remarks>
+        public void NotifyChanged(string directory, string fileName)
+        {
+            if (_watches.TryGetValue(Path.Combine(directory, fileName), out List<Action> callbacks))
+            {
+                // Snapshot: a callback is free to dispose its own registration.
+                foreach (Action callback in callbacks.ToArray())
+                {
+                    callback();
+                }
+            }
+        }
+
+        /// <summary>Stops one watch when disposed.</summary>
+        /// <param name="owner">The factory holding the registry.</param>
+        /// <param name="key">Full path being watched.</param>
+        /// <param name="callback">The callback to remove.</param>
+        private sealed class Registration(BrowserFileWatcherFactory owner, string key, Action callback) : IDisposable
+        {
+            /// <inheritdoc />
+            public void Dispose()
+            {
+                if (owner._watches.TryGetValue(key, out List<Action> callbacks))
+                {
+                    _ = callbacks.Remove(callback);
+                    if (callbacks.Count == 0)
+                    {
+                        _ = owner._watches.Remove(key);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/CutTheRopeDX.Browser/Browser/BrowserHostApp.cs
+++ b/src/CutTheRopeDX.Browser/Browser/BrowserHostApp.cs
@@ -65,6 +65,9 @@ namespace CutTheRopeDX.Browser
         public string LevelEditorUrl => "https://yell0wsuit.github.io/ctrdx-editor/";
 
         /// <inheritdoc />
+        public string CustomLevelExitLabelKey => "CLOSE_TAB_BUTTON";
+
+        /// <inheritdoc />
         /// <remarks>
         /// A tab cannot close itself - except one that was script-opened, which a playtest window
         /// always is, because the editor opened it. So quitting a playtest ends it the way quitting

--- a/src/CutTheRopeDX.Browser/Browser/BrowserHostApp.cs
+++ b/src/CutTheRopeDX.Browser/Browser/BrowserHostApp.cs
@@ -65,8 +65,14 @@ namespace CutTheRopeDX.Browser
         public string LevelEditorUrl => "https://yell0wsuit.github.io/ctrdx-editor/";
 
         /// <inheritdoc />
+        /// <remarks>
+        /// A tab cannot close itself - except one that was script-opened, which a playtest window
+        /// always is, because the editor opened it. So quitting a playtest ends it the way quitting
+        /// on desktop does, while quitting the normal game stays the no-op it has to be.
+        /// </remarks>
         public void Exit()
         {
+            PlaytestSession.Close();
         }
 
         /// <inheritdoc />

--- a/src/CutTheRopeDX.Browser/Browser/GameLoop.cs
+++ b/src/CutTheRopeDX.Browser/Browser/GameLoop.cs
@@ -28,6 +28,9 @@ namespace CutTheRopeDX.Browser
         [JSExport]
         internal static void Tick(double timestampMs)
         {
+            // Between frames, not during one: a level that arrives mid-step would be half-applied.
+            PlaytestSession.Pump();
+
             double elapsed = _lastTimestampMs == 0
                 ? StepSeconds
                 : (timestampMs - _lastTimestampMs) / 1000.0;

--- a/src/CutTheRopeDX.Browser/Browser/PlaytestErrorWriter.cs
+++ b/src/CutTheRopeDX.Browser/Browser/PlaytestErrorWriter.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace CutTheRopeDX.Browser
+{
+    /// <summary>
+    /// Forwards the game's standard error to the editor during a playtest, and onward to the browser
+    /// console as before.
+    /// </summary>
+    /// <remarks>
+    /// Core reports a level it cannot load by writing the reason to <see cref="Console.Error"/>, and
+    /// the desktop editor reads exactly those bytes off the child process's stderr pipe. A browser tab
+    /// has no pipe, so this stands in for one, which is how the browser reaches the same diagnostics
+    /// without Core needing to know that a second reporting channel exists.
+    /// </remarks>
+    /// <param name="inner">The writer installed before this one; keeps receiving everything.</param>
+    internal sealed class PlaytestErrorWriter(TextWriter inner) : TextWriter
+    {
+        /// <summary>Characters written since the last line break.</summary>
+        private readonly StringBuilder _line = new();
+
+        /// <inheritdoc />
+        public override Encoding Encoding => Encoding.UTF8;
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// Overriding the single-character write is enough: every other <see cref="TextWriter"/>
+        /// overload funnels into it.
+        /// </remarks>
+        public override void Write(char value)
+        {
+            inner.Write(value);
+
+            if (value == '\n')
+            {
+                EmitLine();
+            }
+            else if (value != '\r')
+            {
+                _ = _line.Append(value);
+            }
+        }
+
+        /// <summary>Sends the completed line to the editor, if it carries anything.</summary>
+        private void EmitLine()
+        {
+            if (_line.Length > 0)
+            {
+                PlaytestSession.ReportError(_line.ToString());
+                _ = _line.Clear();
+            }
+        }
+    }
+}

--- a/src/CutTheRopeDX.Browser/Browser/PlaytestInterop.cs
+++ b/src/CutTheRopeDX.Browser/Browser/PlaytestInterop.cs
@@ -1,0 +1,39 @@
+using System.Runtime.InteropServices.JavaScript;
+using System.Threading.Tasks;
+
+namespace CutTheRopeDX.Browser
+{
+    /// <summary>Thin managed wrapper over the playtest.js BroadcastChannel module.</summary>
+    internal static partial class PlaytestInterop
+    {
+        /// <summary>Imports playtest.js. Must be awaited once before any other call.</summary>
+        /// <returns>A task that completes when the module is available.</returns>
+        public static Task ImportAsync()
+        {
+            return JSHost.ImportAsync("playtest", "../playtest.js");
+        }
+
+        /// <summary>Reads the session nonce from the launch URL.</summary>
+        /// <returns>The nonce, or an empty string for a normal launch.</returns>
+        [JSImport("nonceFromQuery", "playtest")]
+        public static partial string NonceFromQuery();
+
+        /// <summary>Opens the channel and begins queueing incoming messages.</summary>
+        [JSImport("open", "playtest")]
+        public static partial void Open();
+
+        /// <summary>Posts one JSON message on the channel.</summary>
+        /// <param name="json">Message text from <see cref="GameMain.PlaytestChannelMessage"/>.</param>
+        [JSImport("post", "playtest")]
+        public static partial void Post(string json);
+
+        /// <summary>Takes every message queued since the previous call.</summary>
+        /// <returns>The queued messages, oldest first; empty when none arrived.</returns>
+        [JSImport("drain", "playtest")]
+        public static partial string[] Drain();
+
+        /// <summary>Closes the playtest window.</summary>
+        [JSImport("closeWindow", "playtest")]
+        public static partial void CloseWindow();
+    }
+}

--- a/src/CutTheRopeDX.Browser/Browser/PlaytestSession.cs
+++ b/src/CutTheRopeDX.Browser/Browser/PlaytestSession.cs
@@ -1,0 +1,183 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+
+using CutTheRopeDX.Framework.Platform;
+using CutTheRopeDX.GameMain;
+
+namespace CutTheRopeDX.Browser
+{
+    /// <summary>
+    /// Runs the browser end of a playtest: announces the session, receives levels from the editor,
+    /// and puts them where Core already knows how to find them.
+    /// </summary>
+    /// <remarks>
+    /// The desktop head is handed a level by path on the command line and watches that path. A tab
+    /// has neither, so this stands in for both: the level arrives over the BroadcastChannel and is
+    /// written to <see cref="LevelPath"/> in the WASM in-memory filesystem, which
+    /// <see cref="CustomLevelSession"/> is then activated against. From that point Core cannot tell
+    /// the two heads apart, and the reload path - debounce, resource scan, instant-versus-full
+    /// decision - is literally the same code.
+    /// </remarks>
+    internal static class PlaytestSession
+    {
+        /// <summary>Directory holding the session's level file.</summary>
+        private const string LevelDirectory = "/playtest";
+
+        /// <summary>File name of the session's level file.</summary>
+        private const string LevelFileName = "level.xml";
+
+        /// <summary>How long to wait for the editor to answer the announcement before giving up.</summary>
+        private static readonly TimeSpan LevelTimeout = TimeSpan.FromSeconds(10);
+
+        /// <summary>How often to check for the first level while waiting.</summary>
+        private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(100);
+
+        private static PushedFileWatcherFactory _watchers;
+        private static string _nonce = "";
+
+        /// <summary>Whether this page is running a playtest.</summary>
+        public static bool IsActive { get; private set; }
+
+        /// <summary>Full path of the level file inside the in-memory filesystem.</summary>
+        public static string LevelPath => Path.Combine(LevelDirectory, LevelFileName);
+
+        /// <summary>
+        /// Announces the session and waits for the editor's first level.
+        /// </summary>
+        /// <returns>
+        /// <see langword="true"/> when a level arrived and <see cref="CustomLevelSession"/> was
+        /// activated; <see langword="false"/> for a normal launch, or when no editor answered.
+        /// </returns>
+        /// <remarks>
+        /// The announcement goes out before the caller starts loading the content bundle, so the
+        /// transfer overlaps a ~56 MB download instead of following it. A launch with no editor
+        /// listening - a bookmarked playtest URL, or an editor that has since been closed - times
+        /// out and falls through to the normal game rather than hanging on a loading screen.
+        /// </remarks>
+        public static async Task<bool> BeginAsync()
+        {
+            await PlaytestInterop.ImportAsync();
+
+            _nonce = PlaytestInterop.NonceFromQuery();
+            if (string.IsNullOrEmpty(_nonce))
+            {
+                return false;
+            }
+
+            PlaytestInterop.Open();
+            PlaytestInterop.Post(PlaytestChannelMessage.FormatReady(_nonce, PlaytestHandshake.FormatLine(ResolveVersion())));
+
+            DateTime deadline = DateTime.UtcNow + LevelTimeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                if (TryTakeLevel())
+                {
+                    _watchers = new PushedFileWatcherFactory();
+                    PlatformServices.FileWatchers = _watchers;
+                    CustomLevelSession.Activate(LevelPath);
+                    IsActive = true;
+
+                    // Stands in for the stderr pipe the desktop editor reads. Installed only for a
+                    // playtest, so a normal game's console output is untouched.
+                    Console.SetError(new PlaytestErrorWriter(Console.Error));
+                    return true;
+                }
+
+                await Task.Delay(PollInterval);
+            }
+
+            Console.Error.WriteLine("playtest: no editor answered; starting the normal game.");
+            return false;
+        }
+
+        /// <summary>
+        /// Delivers any levels that arrived since the last frame. Called once per animation frame.
+        /// </summary>
+        /// <remarks>
+        /// Writing the file and reporting the change are separate on purpose: the report goes
+        /// through the same watcher seam a desktop file event does, so Core debounces it and picks
+        /// the same reload strategy on both heads.
+        /// </remarks>
+        public static void Pump()
+        {
+            if (!IsActive)
+            {
+                return;
+            }
+
+            if (TryTakeLevel())
+            {
+                _watchers.NotifyChanged(LevelDirectory, LevelFileName);
+            }
+        }
+
+        /// <summary>Tells the editor about a level this build could not load.</summary>
+        /// <param name="message">Human-readable failure reason.</param>
+        public static void ReportError(string message)
+        {
+            if (IsActive)
+            {
+                PlaytestInterop.Post(PlaytestChannelMessage.FormatError(message));
+            }
+        }
+
+        /// <summary>Says goodbye and closes the playtest window.</summary>
+        public static void Close()
+        {
+            if (!IsActive)
+            {
+                return;
+            }
+
+            PlaytestInterop.Post(PlaytestChannelMessage.FormatBye());
+            PlaytestInterop.CloseWindow();
+        }
+
+        /// <summary>
+        /// Drains the channel and writes the newest level for this session, if one arrived.
+        /// </summary>
+        /// <returns><see langword="true"/> when the level file was rewritten.</returns>
+        /// <remarks>
+        /// Only the last level in a batch is written. Two levels in one frame means the user pressed
+        /// Play twice faster than a frame, and the older one is already stale.
+        /// </remarks>
+        private static bool TryTakeLevel()
+        {
+            string newest = null;
+            foreach (string json in PlaytestInterop.Drain())
+            {
+                if (PlaytestChannelMessage.TryParse(json, out PlaytestMessageKind kind, out string nonce, out string payload)
+                    && kind == PlaytestMessageKind.Level
+                    && string.Equals(nonce, _nonce, StringComparison.Ordinal))
+                {
+                    newest = payload;
+                }
+            }
+
+            if (newest == null)
+            {
+                return false;
+            }
+
+            // Written to a scratch file and moved into place, so a reader never sees a half-written
+            // document. Same-directory moves are atomic, and this holds on the WASM filesystem too.
+            _ = Directory.CreateDirectory(LevelDirectory);
+            string scratch = LevelPath + ".tmp";
+            File.WriteAllText(scratch, newest);
+            File.Move(scratch, LevelPath, true);
+            return true;
+        }
+
+        /// <summary>Resolves this build's version for the handshake.</summary>
+        /// <returns>The informational version, the assembly version, or an empty string.</returns>
+        private static string ResolveVersion()
+        {
+            Assembly assembly = typeof(PlaytestSession).Assembly;
+            return assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                ?? assembly.GetName().Version?.ToString()
+                ?? "";
+        }
+    }
+}

--- a/src/CutTheRopeDX.Browser/Program.cs
+++ b/src/CutTheRopeDX.Browser/Program.cs
@@ -14,6 +14,11 @@ await StorageInterop.ImportAsync();
 await BrowserCursorService.ImportAsync();
 await BrowserVideoPlayer.ImportAsync();
 
+// Announced before the content bundle starts downloading, so the level transfer overlaps a ~56 MB
+// load rather than following it. A normal launch returns immediately.
+bool playtest = await PlaytestSession.BeginAsync();
+Console.WriteLine($"playtest: {(playtest ? "active" : "inactive")}");
+
 int fbo = GLContextInterop.CreateContext("game");
 // Installed before the first measurement so the loop never has to measure again: from here on
 // the canvas reports its own changes.

--- a/src/CutTheRopeDX.Browser/wwwroot/playtest.js
+++ b/src/CutTheRopeDX.Browser/wwwroot/playtest.js
@@ -1,0 +1,49 @@
+// Playtest transport. The editor and this game are served from one origin, so a BroadcastChannel
+// reaches between them; it carries the level itself, because a browser tab has no argv to put it in.
+
+const CHANNEL = "ctrdx-playtest";
+
+let channel = null;
+let inbox = [];
+
+/** The session nonce from ?playtest=..., or "" when this is a normal launch. */
+export function nonceFromQuery() {
+    return new URLSearchParams(globalThis.location.search).get("playtest") ?? "";
+}
+
+/** Opens the channel and starts queueing messages. Safe to call more than once. */
+export function open() {
+    if (channel) {
+        return;
+    }
+    channel = new BroadcastChannel(CHANNEL);
+    channel.onmessage = (event) => {
+        // Everything on this channel is a JSON string; anything else is not ours.
+        if (typeof event.data === "string") {
+            inbox.push(event.data);
+        }
+    };
+}
+
+/** Posts one JSON message. A no-op before open(). */
+export function post(json) {
+    channel?.postMessage(json);
+}
+
+/** Takes every message queued since the last call. */
+export function drain() {
+    if (inbox.length === 0) {
+        return [];
+    }
+    const taken = inbox;
+    inbox = [];
+    return taken;
+}
+
+/**
+ * Closes this window. Only legal because the editor opened it with window.open; a tab the user
+ * navigated to themselves ignores this, which is why the caller falls back to doing nothing.
+ */
+export function closeWindow() {
+    globalThis.close();
+}

--- a/src/CutTheRopeDX.Core/Framework/Platform/IHostApp.cs
+++ b/src/CutTheRopeDX.Core/Framework/Platform/IHostApp.cs
@@ -18,6 +18,12 @@ namespace CutTheRopeDX.Framework.Platform
         /// </summary>
         string LevelEditorUrl { get; }
 
+        /// <summary>
+        /// Localization key for the action that leaves a custom-level session in this host.
+        /// Desktop quits the application; a script-opened browser playtest closes its tab.
+        /// </summary>
+        string CustomLevelExitLabelKey { get; }
+
         void Exit();
 
         /// <summary>Returns whether <paramref name="key"/> transitioned from up to down this frame.</summary>

--- a/src/CutTheRopeDX.Core/Framework/Platform/PushedFileWatcherFactory.cs
+++ b/src/CutTheRopeDX.Core/Framework/Platform/PushedFileWatcherFactory.cs
@@ -2,21 +2,19 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 
-using CutTheRopeDX.Framework.Platform;
-
-namespace CutTheRopeDX.Browser
+namespace CutTheRopeDX.Framework.Platform
 {
     /// <summary>
-    /// Reports level file changes in the browser, where <see cref="FileSystemWatcher"/> throws
-    /// <see cref="PlatformNotSupportedException"/>.
+    /// Reports file changes that are explicitly pushed by a writer, rather than observed by an OS watcher.
     /// </summary>
     /// <remarks>
-    /// The WASM filesystem is real enough for Core to read and write, but nothing observes it. So
-    /// the writer reports its own change: <c>PlaytestSession</c> (Task 3) writes the level and then
-    /// calls <see cref="NotifyChanged"/>. Core cannot tell this apart from a desktop file event,
-    /// which is the point - it keeps the same debounce and the same reload decision on both heads.
+    /// This factory is used in environments where <see cref="FileSystemWatcher"/> is unavailable or
+    /// impractical (such as browser WASM). Rather than observe file system events, the writer reports its own
+    /// changes: the writer modifies the file and then calls <see cref="NotifyChanged"/>. Core cannot tell this
+    /// apart from a desktop file event, which is the point — it keeps the same debounce and the same reload
+    /// decision on both heads.
     /// </remarks>
-    internal sealed class BrowserFileWatcherFactory : IFileWatcherFactory
+    internal sealed class PushedFileWatcherFactory : IFileWatcherFactory
     {
         /// <summary>Registered callbacks, keyed by the full path being watched.</summary>
         private readonly Dictionary<string, List<Action>> _watches = new(StringComparer.Ordinal);
@@ -60,7 +58,7 @@ namespace CutTheRopeDX.Browser
         /// <param name="owner">The factory holding the registry.</param>
         /// <param name="key">Full path being watched.</param>
         /// <param name="callback">The callback to remove.</param>
-        private sealed class Registration(BrowserFileWatcherFactory owner, string key, Action callback) : IDisposable
+        private sealed class Registration(PushedFileWatcherFactory owner, string key, Action callback) : IDisposable
         {
             /// <inheritdoc />
             public void Dispose()

--- a/src/CutTheRopeDX.Core/GameMain/GameController.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameController.cs
@@ -178,7 +178,9 @@ namespace CutTheRopeDX.GameMain
                 Button c3 = MenuController.CreateButtonWithTextIDDelegate(Application.GetString("LEVEL_SELECT"), GameControllerButtonId.LevelSelect, this);
                 _ = vBox.AddChild(c3);
             }
-            string exitLabel = CustomLevelSession.IsActive ? "QUIT_BUTTON" : "MAIN_MENU";
+            string exitLabel = CustomLevelSession.IsActive
+                ? PlatformServices.Host?.CustomLevelExitLabelKey ?? "QUIT_BUTTON"
+                : "MAIN_MENU";
             Button c4 = MenuController.CreateButtonWithTextIDDelegate(Application.GetString(exitLabel), GameControllerButtonId.MainMenu, this);
             _ = vBox.AddChild(c4);
             vBox.anchor = vBox.parentAnchor = 10;

--- a/src/CutTheRopeDX.Core/GameMain/PlaytestChannelMessage.cs
+++ b/src/CutTheRopeDX.Core/GameMain/PlaytestChannelMessage.cs
@@ -1,0 +1,196 @@
+using System.IO;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+
+namespace CutTheRopeDX.GameMain
+{
+    /// <summary>The kinds of message the browser playtest channel carries.</summary>
+    internal enum PlaytestMessageKind
+    {
+        /// <summary>Not a message this protocol version understands.</summary>
+        Unknown = 0,
+
+        /// <summary>Game to editor: a playtest session booted and is waiting for its level.</summary>
+        Ready,
+
+        /// <summary>Editor to game: the level XML to run.</summary>
+        Level,
+
+        /// <summary>Game to editor: the level could not be loaded.</summary>
+        Error,
+
+        /// <summary>Game to editor: the playtest window is going away.</summary>
+        Bye,
+    }
+
+    /// <summary>
+    /// Encodes and decodes the JSON the editor and the browser build exchange over the
+    /// <c>ctrdx-playtest</c> BroadcastChannel.
+    /// </summary>
+    /// <remarks>
+    /// A browser tab has no command line, so this channel replaces <c>--level</c>. The launch URL's
+    /// <c>?playtest=</c> parameter only marks the session; the level itself arrives as a
+    /// <see cref="PlaytestMessageKind.Level"/> message. The editor implements the same format, and the
+    /// literal wire strings asserted by both repositories' tests are the contract between them.
+    /// </remarks>
+    internal static class PlaytestChannelMessage
+    {
+        /// <summary>Protocol version stamped on, and required of, every message.</summary>
+        public const int Version = 1;
+
+        // Relaxed escaping keeps a level from tripling in size: the default encoder escapes '<', '>'
+        // and '"' as \uXXXX, and level XML is mostly those three characters. It is safe here because
+        // these strings are never interpolated into HTML - they go to postMessage and back through
+        // JSON.parse.
+        private static readonly JsonWriterOptions WriterOptions = new()
+        {
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        };
+
+        /// <summary>Builds the handshake a booting playtest session announces itself with.</summary>
+        /// <param name="nonce">Session nonce from the launch URL, echoed so only its own editor answers.</param>
+        /// <param name="handshakeLine">A line from <see cref="PlaytestHandshake.FormatLine"/>.</param>
+        /// <returns>JSON to post on the channel.</returns>
+        public static string FormatReady(string nonce, string handshakeLine)
+        {
+            return Write("ready", nonce, "line", handshakeLine);
+        }
+
+        /// <summary>Builds the message carrying a level to a playtest session.</summary>
+        /// <param name="nonce">Session nonce the target window announced.</param>
+        /// <param name="xml">Serialized level XML.</param>
+        /// <returns>JSON to post on the channel.</returns>
+        public static string FormatLevel(string nonce, string xml)
+        {
+            return Write("level", nonce, "xml", xml);
+        }
+
+        /// <summary>Builds the message reporting a level the game could not load.</summary>
+        /// <param name="message">Human-readable failure reason.</param>
+        /// <returns>JSON to post on the channel.</returns>
+        public static string FormatError(string message)
+        {
+            return Write("error", null, "message", message);
+        }
+
+        /// <summary>Builds the message announcing that a playtest window is going away.</summary>
+        /// <returns>JSON to post on the channel.</returns>
+        public static string FormatBye()
+        {
+            return Write("bye", null, null, null);
+        }
+
+        /// <summary>Decodes one channel message.</summary>
+        /// <param name="json">The raw string received on the channel.</param>
+        /// <param name="kind">Receives the message kind, or <see cref="PlaytestMessageKind.Unknown"/> on failure.</param>
+        /// <param name="nonce">Receives the session nonce, or an empty string when absent.</param>
+        /// <param name="payload">Receives the kind's single string field, or an empty string when absent.</param>
+        /// <returns><see langword="true"/> for a message this build understands.</returns>
+        /// <remarks>
+        /// A wrong version, an unknown type and malformed JSON all return <see langword="false"/> rather
+        /// than throwing, so a future protocol talking to this build degrades to silence.
+        /// </remarks>
+        public static bool TryParse(string json, out PlaytestMessageKind kind, out string nonce, out string payload)
+        {
+            kind = PlaytestMessageKind.Unknown;
+            nonce = "";
+            payload = "";
+
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return false;
+            }
+
+            try
+            {
+                using JsonDocument document = JsonDocument.Parse(json);
+                JsonElement root = document.RootElement;
+                if (root.ValueKind != JsonValueKind.Object)
+                {
+                    return false;
+                }
+
+                if (!root.TryGetProperty("v", out JsonElement version)
+                    || version.ValueKind != JsonValueKind.Number
+                    || !version.TryGetInt32(out int parsedVersion)
+                    || parsedVersion != Version)
+                {
+                    return false;
+                }
+
+                if (!root.TryGetProperty("type", out JsonElement type) || type.ValueKind != JsonValueKind.String)
+                {
+                    return false;
+                }
+
+                switch (type.GetString())
+                {
+                    case "ready":
+                        kind = PlaytestMessageKind.Ready;
+                        payload = ReadString(root, "line");
+                        break;
+                    case "level":
+                        kind = PlaytestMessageKind.Level;
+                        payload = ReadString(root, "xml");
+                        break;
+                    case "error":
+                        kind = PlaytestMessageKind.Error;
+                        payload = ReadString(root, "message");
+                        break;
+                    case "bye":
+                        kind = PlaytestMessageKind.Bye;
+                        break;
+                    default:
+                        return false;
+                }
+
+                nonce = ReadString(root, "nonce");
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>Reads an optional string property, treating absence and wrong type alike.</summary>
+        /// <param name="root">The message object.</param>
+        /// <param name="name">Property name.</param>
+        /// <returns>The value, or an empty string.</returns>
+        private static string ReadString(JsonElement root, string name)
+        {
+            return root.TryGetProperty(name, out JsonElement value) && value.ValueKind == JsonValueKind.String
+                ? value.GetString()
+                : "";
+        }
+
+        /// <summary>Serializes one message. Property order is the wire contract, so it is fixed here.</summary>
+        /// <param name="type">The <c>type</c> discriminator.</param>
+        /// <param name="nonce">Session nonce, or <see langword="null"/> to omit the property.</param>
+        /// <param name="fieldName">Name of the kind's single payload property, or <see langword="null"/> to omit it.</param>
+        /// <param name="fieldValue">Value for <paramref name="fieldName"/>.</param>
+        /// <returns>The JSON text.</returns>
+        private static string Write(string type, string nonce, string fieldName, string fieldValue)
+        {
+            using MemoryStream stream = new();
+            using (Utf8JsonWriter writer = new(stream, WriterOptions))
+            {
+                writer.WriteStartObject();
+                writer.WriteNumber("v", Version);
+                writer.WriteString("type", type);
+                if (nonce != null)
+                {
+                    writer.WriteString("nonce", nonce);
+                }
+                if (fieldName != null)
+                {
+                    writer.WriteString(fieldName, fieldValue);
+                }
+                writer.WriteEndObject();
+            }
+
+            return Encoding.UTF8.GetString(stream.ToArray());
+        }
+    }
+}

--- a/src/CutTheRopeDX.Core/GameMain/PlaytestChannelMessage.cs
+++ b/src/CutTheRopeDX.Core/GameMain/PlaytestChannelMessage.cs
@@ -39,9 +39,10 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Protocol version stamped on, and required of, every message.</summary>
         public const int Version = 1;
 
-        // Relaxed escaping keeps a level from tripling in size: the default encoder escapes '<', '>'
-        // and '"' as \uXXXX, and level XML is mostly those three characters. It is safe here because
-        // these strings are never interpolated into HTML - they go to postMessage and back through
+        // Relaxed escaping keeps a level from ballooning: the default encoder escapes '<' and '>' as
+        // \u003C and \u003E, and level XML is mostly those two characters. (The double quote is not a
+        // reason to relax - JSON escapes it as \" under either encoder.) Relaxing is safe here because
+        // these strings are never interpolated into HTML: they go to postMessage and back through
         // JSON.parse.
         private static readonly JsonWriterOptions WriterOptions = new()
         {

--- a/src/CutTheRopeDX.Desktop/Desktop/DesktopHostApp.cs
+++ b/src/CutTheRopeDX.Desktop/Desktop/DesktopHostApp.cs
@@ -17,6 +17,9 @@ namespace CutTheRopeDX.Desktop
         public string LevelEditorUrl => null;
 
         /// <inheritdoc />
+        public string CustomLevelExitLabelKey => "QUIT_BUTTON";
+
+        /// <inheritdoc />
         public void Exit()
         {
             Global.XnaGame.Exit();

--- a/src/CutTheRopeDX.Tests/PauseDuringRestartTests.cs
+++ b/src/CutTheRopeDX.Tests/PauseDuringRestartTests.cs
@@ -22,6 +22,38 @@ namespace CutTheRopeDX.Tests
             return (Text)controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_PAUSE_MENU).GetChildWithName("mapNameLabel");
         }
 
+        private static Text PauseExitLabel(GameController controller)
+        {
+            BaseElement buttonsGroup = controller.GetView(0).GetChild(GameView.VIEW_ELEMENT_PAUSE_BUTTONS);
+            BaseElement buttons = buttonsGroup.GetChild(0);
+            Button exit = (Button)buttons.GetChild(1);
+            return (Text)exit.GetChild(0).GetChild(0);
+        }
+
+        [Theory]
+        [InlineData("CLOSE_TAB_BUTTON", "Close Tab")]
+        [InlineData("QUIT_BUTTON", "Quit")]
+        public void CustomLevelExitUsesTheHostLabel(string labelKey, string expected)
+        {
+            _ = HeadlessGame.Boot();
+            IHostApp previousHost = PlatformServices.Host;
+
+            try
+            {
+                PlatformServices.Host = new LabelHost(labelKey);
+                CustomLevelSession.Activate("pause-exit-label-test.xml");
+
+                GameController controller = HeadlessGame.LoadLevelWithController(pack: 1, level: 4);
+
+                Assert.Equal(expected, PauseExitLabel(controller).GetString());
+            }
+            finally
+            {
+                CustomLevelSession.Clear();
+                PlatformServices.Host = previousHost;
+            }
+        }
+
         [Fact]
         public void PausingNamedCustomLevelShowsResolvedLevelName()
         {
@@ -262,6 +294,32 @@ namespace CutTheRopeDX.Tests
                     $"{name}: label right edge {rightEdge} ran past the viewport width {visible.w}");
                 Assert.True(label.scaleX > 1f, $"{name}: label did not pick up the narrow-viewport boost");
             });
+        }
+
+        private sealed class LabelHost(string customLevelExitLabelKey) : IHostApp
+        {
+            public bool CanExit => false;
+
+            public string LevelEditorUrl => null;
+
+            public string CustomLevelExitLabelKey { get; } = customLevelExitLabelKey;
+
+            public void Exit()
+            {
+            }
+
+            public bool IsKeyPressed(KeyCode key)
+            {
+                return false;
+            }
+
+            public void DrawMovie()
+            {
+            }
+
+            public void OpenUrl(string url)
+            {
+            }
         }
     }
 }

--- a/src/CutTheRopeDX.Tests/PauseDuringRestartTests.cs
+++ b/src/CutTheRopeDX.Tests/PauseDuringRestartTests.cs
@@ -31,7 +31,7 @@ namespace CutTheRopeDX.Tests
         }
 
         [Theory]
-        [InlineData("CLOSE_TAB_BUTTON", "Close Tab")]
+        [InlineData("CLOSE_TAB_BUTTON", "Close tab")]
         [InlineData("QUIT_BUTTON", "Quit")]
         public void CustomLevelExitUsesTheHostLabel(string labelKey, string expected)
         {

--- a/src/CutTheRopeDX.Tests/PlaytestChannelMessageTests.cs
+++ b/src/CutTheRopeDX.Tests/PlaytestChannelMessageTests.cs
@@ -88,8 +88,8 @@ namespace CutTheRopeDX.Tests
         [InlineData("[1,2,3]")]
         [InlineData("\"a string\"")]
         [InlineData("{}")]
-        [InlineData("{\"type\":\"bye\"}")]
-        [InlineData("{\"v\":\"1\",\"type\":\"bye\"}")]
+        [InlineData(/*lang=json,strict*/ "{\"type\":\"bye\"}")]
+        [InlineData(/*lang=json,strict*/ "{\"v\":\"1\",\"type\":\"bye\"}")]
         public void MalformedInputIsRejected(string json)
         {
             Assert.False(PlaytestChannelMessage.TryParse(json, out _, out _, out _));
@@ -100,14 +100,16 @@ namespace CutTheRopeDX.Tests
         {
             // A future protocol talking to this build must degrade to silence, not a crash.
             Assert.False(PlaytestChannelMessage.TryParse(
-                "{\"v\":1,\"type\":\"teleport\"}", out _, out _, out _));
+                                     /*lang=json,strict*/
+                                     "{\"v\":1,\"type\":\"teleport\"}", out _, out _, out _));
         }
 
         [Fact]
         public void MismatchedVersionIsIgnored()
         {
             Assert.False(PlaytestChannelMessage.TryParse(
-                "{\"v\":2,\"type\":\"bye\"}", out _, out _, out _));
+                                     /*lang=json,strict*/
+                                     "{\"v\":2,\"type\":\"bye\"}", out _, out _, out _));
         }
 
         // These literals are the contract between this repository and ctrdx-editor. The editor's
@@ -115,12 +117,12 @@ namespace CutTheRopeDX.Tests
         [Fact]
         public void WireFormatIsStable()
         {
-            Assert.Equal("{\"v\":1,\"type\":\"bye\"}", PlaytestChannelMessage.FormatBye());
-            Assert.Equal("{\"v\":1,\"type\":\"ready\",\"nonce\":\"abc\",\"line\":\"ctrdx-playtest 1 9.9.9\"}",
+            Assert.Equal(/*lang=json,strict*/ "{\"v\":1,\"type\":\"bye\"}", PlaytestChannelMessage.FormatBye());
+            Assert.Equal(/*lang=json,strict*/ "{\"v\":1,\"type\":\"ready\",\"nonce\":\"abc\",\"line\":\"ctrdx-playtest 1 9.9.9\"}",
                 PlaytestChannelMessage.FormatReady("abc", "ctrdx-playtest 1 9.9.9"));
-            Assert.Equal("{\"v\":1,\"type\":\"level\",\"nonce\":\"abc\",\"xml\":\"<map/>\"}",
+            Assert.Equal(/*lang=json,strict*/ "{\"v\":1,\"type\":\"level\",\"nonce\":\"abc\",\"xml\":\"<map/>\"}",
                 PlaytestChannelMessage.FormatLevel("abc", "<map/>"));
-            Assert.Equal("{\"v\":1,\"type\":\"error\",\"message\":\"boom\"}",
+            Assert.Equal(/*lang=json,strict*/ "{\"v\":1,\"type\":\"error\",\"message\":\"boom\"}",
                 PlaytestChannelMessage.FormatError("boom"));
         }
     }

--- a/src/CutTheRopeDX.Tests/PlaytestChannelMessageTests.cs
+++ b/src/CutTheRopeDX.Tests/PlaytestChannelMessageTests.cs
@@ -1,0 +1,127 @@
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    public class PlaytestChannelMessageTests
+    {
+        [Fact]
+        public void ReadyRoundTrips()
+        {
+            string json = PlaytestChannelMessage.FormatReady("a1b2c3d4", "ctrdx-playtest 1 1.0.0");
+
+            bool ok = PlaytestChannelMessage.TryParse(json, out PlaytestMessageKind kind, out string nonce, out string payload);
+
+            Assert.True(ok);
+            Assert.Equal(PlaytestMessageKind.Ready, kind);
+            Assert.Equal("a1b2c3d4", nonce);
+            Assert.Equal("ctrdx-playtest 1 1.0.0", payload);
+        }
+
+        [Fact]
+        public void ReadyPayloadParsesAsTheDesktopHandshakeLine()
+        {
+            // The browser handshake must stay byte-identical to the line desktop writes to stdout,
+            // so the editor can parse both with one parser.
+            string json = PlaytestChannelMessage.FormatReady("n", PlaytestHandshake.FormatLine("2.3.4"));
+
+            _ = PlaytestChannelMessage.TryParse(json, out _, out _, out string line);
+
+            Assert.Equal("ctrdx-playtest 1 2.3.4", line);
+        }
+
+        [Fact]
+        public void LevelRoundTrips()
+        {
+            string xml = "<map><candy x=\"1\" y=\"2\" /></map>";
+            string json = PlaytestChannelMessage.FormatLevel("nonce123", xml);
+
+            bool ok = PlaytestChannelMessage.TryParse(json, out PlaytestMessageKind kind, out string nonce, out string payload);
+
+            Assert.True(ok);
+            Assert.Equal(PlaytestMessageKind.Level, kind);
+            Assert.Equal("nonce123", nonce);
+            Assert.Equal(xml, payload);
+        }
+
+        [Fact]
+        public void LevelRoundTripsALargeCommunityScaleLevel()
+        {
+            // Real community levels reach ~112 KB; an uncapped editor can produce far more.
+            string xml = "<map>" + string.Concat(System.Linq.Enumerable.Repeat(
+                "<grab x=\"159\" y=\"337\" length=\"90\" wheel=\"false\" gun=\"false\" />", 20000)) + "</map>";
+            string json = PlaytestChannelMessage.FormatLevel("n", xml);
+
+            bool ok = PlaytestChannelMessage.TryParse(json, out _, out _, out string payload);
+
+            Assert.True(ok);
+            Assert.Equal(xml, payload);
+        }
+
+        [Fact]
+        public void ErrorRoundTrips()
+        {
+            string json = PlaytestChannelMessage.FormatError("Level file contains no root element.");
+
+            bool ok = PlaytestChannelMessage.TryParse(json, out PlaytestMessageKind kind, out _, out string payload);
+
+            Assert.True(ok);
+            Assert.Equal(PlaytestMessageKind.Error, kind);
+            Assert.Equal("Level file contains no root element.", payload);
+        }
+
+        [Fact]
+        public void ByeRoundTrips()
+        {
+            bool ok = PlaytestChannelMessage.TryParse(PlaytestChannelMessage.FormatBye(),
+                out PlaytestMessageKind kind, out _, out _);
+
+            Assert.True(ok);
+            Assert.Equal(PlaytestMessageKind.Bye, kind);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("not json at all")]
+        [InlineData("[1,2,3]")]
+        [InlineData("\"a string\"")]
+        [InlineData("{}")]
+        [InlineData("{\"type\":\"bye\"}")]
+        [InlineData("{\"v\":\"1\",\"type\":\"bye\"}")]
+        public void MalformedInputIsRejected(string json)
+        {
+            Assert.False(PlaytestChannelMessage.TryParse(json, out _, out _, out _));
+        }
+
+        [Fact]
+        public void UnknownTypeIsIgnoredRatherThanThrowing()
+        {
+            // A future protocol talking to this build must degrade to silence, not a crash.
+            Assert.False(PlaytestChannelMessage.TryParse(
+                "{\"v\":1,\"type\":\"teleport\"}", out _, out _, out _));
+        }
+
+        [Fact]
+        public void MismatchedVersionIsIgnored()
+        {
+            Assert.False(PlaytestChannelMessage.TryParse(
+                "{\"v\":2,\"type\":\"bye\"}", out _, out _, out _));
+        }
+
+        // These literals are the contract between this repository and ctrdx-editor. The editor's
+        // PlaytestChannelMessageTests assert the same strings. If you change one side, this fails.
+        [Fact]
+        public void WireFormatIsStable()
+        {
+            Assert.Equal("{\"v\":1,\"type\":\"bye\"}", PlaytestChannelMessage.FormatBye());
+            Assert.Equal("{\"v\":1,\"type\":\"ready\",\"nonce\":\"abc\",\"line\":\"ctrdx-playtest 1 9.9.9\"}",
+                PlaytestChannelMessage.FormatReady("abc", "ctrdx-playtest 1 9.9.9"));
+            Assert.Equal("{\"v\":1,\"type\":\"level\",\"nonce\":\"abc\",\"xml\":\"<map/>\"}",
+                PlaytestChannelMessage.FormatLevel("abc", "<map/>"));
+            Assert.Equal("{\"v\":1,\"type\":\"error\",\"message\":\"boom\"}",
+                PlaytestChannelMessage.FormatError("boom"));
+        }
+    }
+}

--- a/src/CutTheRopeDX.Tests/PushedFileWatcherFactoryTests.cs
+++ b/src/CutTheRopeDX.Tests/PushedFileWatcherFactoryTests.cs
@@ -1,0 +1,180 @@
+using System;
+
+using CutTheRopeDX.Framework.Platform;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    /// <summary>Tests for <see cref="PushedFileWatcherFactory"/>.</summary>
+    public sealed class PushedFileWatcherFactoryTests
+    {
+        /// <summary>A single watch fires when NotifyChanged is called for its path.</summary>
+        [Fact]
+        public void SingleWatchFires()
+        {
+            PushedFileWatcherFactory factory = new();
+            int invocations = 0;
+            _ = factory.Watch("dir", "file.txt", () => invocations++);
+
+            factory.NotifyChanged("dir", "file.txt");
+
+            Assert.Equal(1, invocations);
+        }
+
+        /// <summary>Two callbacks on the same path both fire when NotifyChanged is called.</summary>
+        [Fact]
+        public void MultipleCallbacksOnSamePathBothFire()
+        {
+            PushedFileWatcherFactory factory = new();
+            int invocations1 = 0;
+            int invocations2 = 0;
+
+            _ = factory.Watch("dir", "file.txt", () => invocations1++);
+            _ = factory.Watch("dir", "file.txt", () => invocations2++);
+
+            factory.NotifyChanged("dir", "file.txt");
+
+            Assert.Equal(1, invocations1);
+            Assert.Equal(1, invocations2);
+        }
+
+        /// <summary>A watch on a different path does not fire when NotifyChanged is called for another path.</summary>
+        [Fact]
+        public void DifferentPathDoesNotFire()
+        {
+            PushedFileWatcherFactory factory = new();
+            int invocations = 0;
+
+            _ = factory.Watch("dir", "file1.txt", () => invocations++);
+
+            factory.NotifyChanged("dir", "file2.txt");
+
+            Assert.Equal(0, invocations);
+        }
+
+        /// <summary>Disposing one registration leaves the other still firing.</summary>
+        [Fact]
+        public void DisposingOneRegistrationPreservesOthers()
+        {
+            PushedFileWatcherFactory factory = new();
+            int invocations1 = 0;
+            int invocations2 = 0;
+
+            IDisposable watch1 = factory.Watch("dir", "file.txt", () => invocations1++);
+            IDisposable watch2 = factory.Watch("dir", "file.txt", () => invocations2++);
+
+            watch1.Dispose();
+            factory.NotifyChanged("dir", "file.txt");
+
+            Assert.Equal(0, invocations1);
+            Assert.Equal(1, invocations2);
+        }
+
+        /// <summary>Disposing a registration from inside its own callback neither throws nor prevents other callbacks from firing.</summary>
+        [Fact]
+        public void DisposingFromInsideCallbackIsIdempotent()
+        {
+            PushedFileWatcherFactory factory = new();
+            IDisposable watch1 = null;
+            int invocations2 = 0;
+            bool threwException = false;
+
+            watch1 = factory.Watch("dir", "file.txt", () =>
+            {
+                try
+                {
+                    watch1.Dispose();
+                }
+                catch
+                {
+                    threwException = true;
+                    throw;
+                }
+            });
+            _ = factory.Watch("dir", "file.txt", () => invocations2++);
+
+            factory.NotifyChanged("dir", "file.txt");
+
+            Assert.False(threwException);
+            Assert.Equal(1, invocations2);
+        }
+
+        /// <summary>Watch returns null when directory is empty.</summary>
+        [Fact]
+        public void WatchReturnsNullForEmptyDirectory()
+        {
+            PushedFileWatcherFactory factory = new();
+            IDisposable result = factory.Watch("", "file.txt", () => { });
+            Assert.Null(result);
+        }
+
+        /// <summary>Watch returns null when file name is empty.</summary>
+        [Fact]
+        public void WatchReturnsNullForEmptyFileName()
+        {
+            PushedFileWatcherFactory factory = new();
+            IDisposable result = factory.Watch("dir", "", () => { });
+            Assert.Null(result);
+        }
+
+        /// <summary>Watch returns null when callback is null.</summary>
+        [Fact]
+        public void WatchReturnsNullForNullCallback()
+        {
+            PushedFileWatcherFactory factory = new();
+            IDisposable result = factory.Watch("dir", "file.txt", null);
+            Assert.Null(result);
+        }
+
+        /// <summary>NotifyChanged on a path nothing watches does not throw.</summary>
+        [Fact]
+        public void NotifyChangedOnUnwatchedPathDoesNotThrow()
+        {
+            PushedFileWatcherFactory factory = new();
+            // Should not throw
+            factory.NotifyChanged("dir", "file.txt");
+        }
+
+        /// <summary>Disposing a registration twice is idempotent.</summary>
+        [Fact]
+        public void DisposingRegistrationTwiceIsIdempotent()
+        {
+            PushedFileWatcherFactory factory = new();
+            IDisposable watch = factory.Watch("dir", "file.txt", () => { });
+
+            watch.Dispose();
+            // Should not throw
+            watch.Dispose();
+        }
+
+        /// <summary>After all registrations for a path are disposed, NotifyChanged on that path does not throw.</summary>
+        [Fact]
+        public void NotifyChangedAfterAllDisposedDoesNotThrow()
+        {
+            PushedFileWatcherFactory factory = new();
+            IDisposable watch = factory.Watch("dir", "file.txt", () => { });
+
+            watch.Dispose();
+
+            // Should not throw
+            factory.NotifyChanged("dir", "file.txt");
+        }
+
+        /// <summary>Each notification is independent; callbacks do not accumulate across calls.</summary>
+        [Fact]
+        public void EachNotificationIsIndependent()
+        {
+            PushedFileWatcherFactory factory = new();
+            int invocations = 0;
+
+            _ = factory.Watch("dir", "file.txt", () => invocations++);
+
+            factory.NotifyChanged("dir", "file.txt");
+            Assert.Equal(1, invocations);
+
+            factory.NotifyChanged("dir", "file.txt");
+            Assert.Equal(2, invocations);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Lets the browser build receive a level from the browser build of the level editor and play it, with hot reload on every subsequent edit - the same loop the desktop builds already have over `--level`.

### How it works

A browser tab has no argv, so `--level` has no equivalent. Both apps ship to the same origin, so they talk over a `BroadcastChannel` named `ctrdx-playtest`.

On a `?playtest=<nonce>` launch the game announces itself and waits for the editor to send a level, then writes that XML into the WASM in-memory filesystem and activates `CustomLevelSession` against that path.

From there, `Core` cannot tell this apart from a desktop launch. The debounce, the resource scan and the instant-vs-full reload decision are all the same code on both heads.

The announcement goes out before content loading starts, so the level transfer overlaps the ~56 MB download instead of following it.

### Changes

- The level travels in the message, not in storage: 0 localStorage, 0 IndexedDB. That matches desktop, where `PlaytestTempStore` deletes the level file when the editor session ends - level availability is tied to editor liveness on both heads, and it avoids leaving a stale copy of somebody's level in browser storage forever.

- `ready` carries the same handshake line desktop writes to stdout: Byte-identical, produced by the existing `PlaytestHandshake.FormatLine`, so a protocol bump cannot drift between the two transports.

- The `stderr` writer stands in for the `stderr` pipe: `Core` reports an unloadable level by writing to `Console.Error`, and the desktop editor reads those bytes off the child process's pipe. A tab has no pipe, so `PlaytestErrorWriter` replaces the writer during a playtest, reaching the same diagnostics without `Core` learning that a second reporting channel exists.

- `PushedFileWatcherFactory` lives in `Core`, not the browser project: `FileSystemWatcher` throws `PlatformNotSupportedException` under `net10.0-browser`, so the writer reports its own change through the existing `IFileWatcherFactory` seam. It sits in `Core` because a `net10.0` test project cannot reference a `net10.0-browser` one, and its registry and dispose semantics are worth testing.

- "Quit" button closes the window: A tab cannot normally close itself, but a script-opened one can, and a playtest window always is. The pause-menu label also reads "Close Tab" rather than "Quit" in the browser, routed through a new `IHostApp.CustomLevelExitLabelKey` so the wording follows the host rather than a platform branch.