### PR TITLE
feat: Address playtest error and bye messages to their session

### DIFF
--- a/src/CutTheRopeDX.Browser/Browser/PlaytestSession.cs
+++ b/src/CutTheRopeDX.Browser/Browser/PlaytestSession.cs
@@ -119,7 +119,7 @@ namespace CutTheRopeDX.Browser
         {
             if (IsActive)
             {
-                PlaytestInterop.Post(PlaytestChannelMessage.FormatError(message));
+                PlaytestInterop.Post(PlaytestChannelMessage.FormatError(_nonce, message));
             }
         }
 
@@ -131,7 +131,7 @@ namespace CutTheRopeDX.Browser
                 return;
             }
 
-            PlaytestInterop.Post(PlaytestChannelMessage.FormatBye());
+            PlaytestInterop.Post(PlaytestChannelMessage.FormatBye(_nonce));
             PlaytestInterop.CloseWindow();
         }
 

--- a/src/CutTheRopeDX.Core/GameMain/PlaytestChannelMessage.cs
+++ b/src/CutTheRopeDX.Core/GameMain/PlaytestChannelMessage.cs
@@ -68,18 +68,20 @@ namespace CutTheRopeDX.GameMain
         }
 
         /// <summary>Builds the message reporting a level the game could not load.</summary>
+        /// <param name="nonce">Session nonce, so only the editor that opened this window reacts.</param>
         /// <param name="message">Human-readable failure reason.</param>
         /// <returns>JSON to post on the channel.</returns>
-        public static string FormatError(string message)
+        public static string FormatError(string nonce, string message)
         {
-            return Write("error", null, "message", message);
+            return Write("error", nonce, "message", message);
         }
 
         /// <summary>Builds the message announcing that a playtest window is going away.</summary>
+        /// <param name="nonce">Session nonce, so only the editor that opened this window reacts.</param>
         /// <returns>JSON to post on the channel.</returns>
-        public static string FormatBye()
+        public static string FormatBye(string nonce)
         {
-            return Write("bye", null, null, null);
+            return Write("bye", nonce, null, null);
         }
 
         /// <summary>Decodes one channel message.</summary>

--- a/src/CutTheRopeDX.Tests/PlaytestChannelMessageTests.cs
+++ b/src/CutTheRopeDX.Tests/PlaytestChannelMessageTests.cs
@@ -62,23 +62,25 @@ namespace CutTheRopeDX.Tests
         [Fact]
         public void ErrorRoundTrips()
         {
-            string json = PlaytestChannelMessage.FormatError("Level file contains no root element.");
+            string json = PlaytestChannelMessage.FormatError("abc", "Level file contains no root element.");
 
-            bool ok = PlaytestChannelMessage.TryParse(json, out PlaytestMessageKind kind, out _, out string payload);
+            bool ok = PlaytestChannelMessage.TryParse(json, out PlaytestMessageKind kind, out string nonce, out string payload);
 
             Assert.True(ok);
             Assert.Equal(PlaytestMessageKind.Error, kind);
+            Assert.Equal("abc", nonce);
             Assert.Equal("Level file contains no root element.", payload);
         }
 
         [Fact]
         public void ByeRoundTrips()
         {
-            bool ok = PlaytestChannelMessage.TryParse(PlaytestChannelMessage.FormatBye(),
-                out PlaytestMessageKind kind, out _, out _);
+            bool ok = PlaytestChannelMessage.TryParse(PlaytestChannelMessage.FormatBye("abc"),
+                out PlaytestMessageKind kind, out string nonce, out _);
 
             Assert.True(ok);
             Assert.Equal(PlaytestMessageKind.Bye, kind);
+            Assert.Equal("abc", nonce);
         }
 
         [Theory]
@@ -117,13 +119,13 @@ namespace CutTheRopeDX.Tests
         [Fact]
         public void WireFormatIsStable()
         {
-            Assert.Equal(/*lang=json,strict*/ "{\"v\":1,\"type\":\"bye\"}", PlaytestChannelMessage.FormatBye());
+            Assert.Equal(/*lang=json,strict*/ "{\"v\":1,\"type\":\"bye\",\"nonce\":\"abc\"}", PlaytestChannelMessage.FormatBye("abc"));
             Assert.Equal(/*lang=json,strict*/ "{\"v\":1,\"type\":\"ready\",\"nonce\":\"abc\",\"line\":\"ctrdx-playtest 1 9.9.9\"}",
                 PlaytestChannelMessage.FormatReady("abc", "ctrdx-playtest 1 9.9.9"));
             Assert.Equal(/*lang=json,strict*/ "{\"v\":1,\"type\":\"level\",\"nonce\":\"abc\",\"xml\":\"<map/>\"}",
                 PlaytestChannelMessage.FormatLevel("abc", "<map/>"));
-            Assert.Equal(/*lang=json,strict*/ "{\"v\":1,\"type\":\"error\",\"message\":\"boom\"}",
-                PlaytestChannelMessage.FormatError("boom"));
+            Assert.Equal(/*lang=json,strict*/ "{\"v\":1,\"type\":\"error\",\"nonce\":\"abc\",\"message\":\"boom\"}",
+                PlaytestChannelMessage.FormatError("abc", "boom"));
         }
     }
 }


### PR DESCRIPTION
## Description

Follow-up to #328. Small correctness fix to the browser playtest channel.

`BroadcastChannel` is a broadcast, every same-origin page listening on `ctrdx-playtest` receives every message, with no addressing of its own. That is why `ready` and `level` carry a session nonce and both sides filter on it. `error` and `bye` were emitted with no nonce, and the editor did not filter them. With two playtests running at once, a level that game B could not parse raised a "could not load this level" notification on editor A as well as B - citing a level A never sent.

The `bye` half was invisible in practice: it maps to exit code 0, which the editor ignores. But it was addressed to nobody in the same way.

Now with this PR, `FormatError` and `FormatBye` take the session nonce, and `PlaytestSession` passes its own - making all four message types addressed rather than two. Parsing needed no change: `TryParse` already read `nonce` generically for every message kind, so only the emitters were missing it.
