### PR TITLE
chore: Bump xunit to v4 and run tests on Microsoft.Testing.Platform

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -37,4 +37,4 @@ jobs:
               run: dotnet build --no-restore -c Release
 
             - name: Test
-              run: dotnet test CutTheRopeDX.slnx --no-build -c Release
+              run: dotnet test --solution CutTheRopeDX.slnx --no-build -c Release

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,9 +31,7 @@
 
   <!-- Tests -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The build writes the site to the `dist/wwwroot` directory. The [Deploy Browser t
 4. Run the unit tests:
 
     ```bash
-    dotnet test CutTheRopeDX.slnx -p:ExcludeMacOSTarget=true
+    dotnet test --solution CutTheRopeDX.slnx -p:ExcludeMacOSTarget=true
     ```
 
 ## Running a custom level

--- a/global.json
+++ b/global.json
@@ -2,5 +2,8 @@
     "sdk": {
         "version": "10.0.302",
         "rollForward": "latestFeature"
+    },
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
     }
 }

--- a/src/CutTheRopeDX.Desktop.Tests/CutTheRopeDX.Desktop.Tests.csproj
+++ b/src/CutTheRopeDX.Desktop.Tests/CutTheRopeDX.Desktop.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <OutputType>Library</OutputType>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <!--
@@ -17,9 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <!--

--- a/src/CutTheRopeDX.Tests/AssemblyInfo.cs
+++ b/src/CutTheRopeDX.Tests/AssemblyInfo.cs
@@ -1,8 +1,9 @@
-using Xunit;
+using Xunit.Sdk;
+using Xunit.v3;
 
 // Several test classes toggle the process-wide ActivePhysicsConstants model flags
 // (UseMobilePhysicsModel, UseTimeTravelRocketModel) with save/set/restore, and others assert
 // against mode-dependent constants assuming the desktop default. Building a scene also assigns
 // both flags from the level's own metadata. Parallel test classes race on those globals, so run
 // the suite serially.
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: Parallelization(Mode = ParallelMode.None)]

--- a/src/CutTheRopeDX.Tests/CutTheRopeDX.Tests.csproj
+++ b/src/CutTheRopeDX.Tests/CutTheRopeDX.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <OutputType>Library</OutputType>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <!--
@@ -16,9 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Bumps xunit from 3.2.2 to 4.0.0 and moves both test projects off VSTest onto Microsoft.Testing.Platform.

The two are one change rather than two. xunit 4.0.0 ships as `xunit.v3.mtp-v2` and discontinues MTP v1, and MTP v2 removes the VSTest-bridge path on the .NET 10 SDK, so bumping the version and picking a runner are the same decision.