### PR TITLE
fix: Require mobile physics for Time Travel's rocket tuning

### DIFF
--- a/src/CutTheRopeDX.Core/GameMain/GameScene.LoadMetadata.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.LoadMetadata.cs
@@ -117,8 +117,14 @@ namespace CutTheRopeDX.GameMain
                             ropePhysicsSpeed = ParseFloatOrZero(item2.Attribute("ropePhysicsSpeed")?.Value);
                             _ = bool.TryParse(item2.Attribute("useMobilePhysics")?.Value, out bool useMobilePhysics);
                             ActivePhysicsConstants.UseMobilePhysicsModel = useMobilePhysics;
+                            // Time Travel's rocket tuning is a mode of the mobile model, not a peer of
+                            // it: the game it comes from is a mobile one, and its authored values are in
+                            // the same level coordinates the mobile model works in. A map that asks for
+                            // it without mobile physics is ignored rather than half-honoured. Everything
+                            // downstream keeps reading UseTimeTravelRocketModel on its own, so the
+                            // per-constant gates are unchanged.
                             _ = bool.TryParse(item2.Attribute("useTimeTravelRocketPhysics")?.Value, out bool useTimeTravelRocketPhysics);
-                            ActivePhysicsConstants.UseTimeTravelRocketModel = useTimeTravelRocketPhysics;
+                            ActivePhysicsConstants.UseTimeTravelRocketModel = useMobilePhysics && useTimeTravelRocketPhysics;
                             Bungee.BUNGEE_REST_LEN = ActivePhysicsConstants.BungeeRestLength;
                             _ = bool.TryParse(item2.Attribute("nightLevel")?.Value, out nightLevel);
                             _ = bool.TryParse(item2.Attribute("twoParts")?.Value, out bool twoPartsBool);

--- a/src/CutTheRopeDX.Tests/Interactions/CandyConnectorPhysicsTests.cs
+++ b/src/CutTheRopeDX.Tests/Interactions/CandyConnectorPhysicsTests.cs
@@ -51,15 +51,23 @@ namespace CutTheRopeDX.Tests.Interactions
             // The extra relaxation is a fidelity port, not a tuning change: Bungee.Update's own
             // 30x pass has already satisfied the connector by the time it runs, so it only
             // corrects the sliver the candy integration adds afterwards.
-            Assert.Equal(SettledConnectorSpan(timeTravel: false), SettledConnectorSpan(timeTravel: true), 1);
+            //
+            // The control is the mobile model without the Time Travel flag, not the desktop one. Time
+            // Travel is a mode of mobile physics, so a desktop control would differ by the whole model -
+            // rope rest length included - and would say nothing about the relaxation pass on its own.
+            Assert.Equal(
+                SettledConnectorSpan(timeTravel: false, mobilePhysics: true),
+                SettledConnectorSpan(timeTravel: true),
+                1);
         }
 
         /// <summary>Runs a connected pair for two seconds and reports the gap between the candies.</summary>
         /// <param name="timeTravel">Whether the map opts into the Time Travel physics.</param>
+        /// <param name="mobilePhysics">Whether the map takes the mobile model without the Time Travel flag.</param>
         /// <returns>The distance between the two candy points, in world units.</returns>
-        private static float SettledConnectorSpan(bool timeTravel)
+        private static float SettledConnectorSpan(bool timeTravel, bool mobilePhysics = false)
         {
-            GameScene scene = ConnectedScene(timeTravel);
+            GameScene scene = ConnectedScene(timeTravel, mobilePhysics);
             HeadlessGame.StepFrames(scene, 120);
             return VectDistance(
                 scene.Candies()[0].WholeBody.Point.pos,
@@ -86,8 +94,9 @@ namespace CutTheRopeDX.Tests.Interactions
         /// from a hook, so one stroke can cross the hook's rope and the connector alike.
         /// </summary>
         /// <param name="timeTravel">Whether the map opts into the Time Travel physics.</param>
+        /// <param name="mobilePhysics">Whether the map takes the mobile model without the Time Travel flag.</param>
         /// <returns>The built scene.</returns>
-        private static GameScene ConnectedScene(bool timeTravel)
+        private static GameScene ConnectedScene(bool timeTravel, bool mobilePhysics = false)
         {
             Scenario scenario = Scenario.New()
                 .MapSize(320, 480)
@@ -97,6 +106,13 @@ namespace CutTheRopeDX.Tests.Interactions
                 .Candy(284, 241, "second")
                 .Rope(284, 25, length: 70, candyNumber: "first")
                 .OmNom(40, 240);
+            if (mobilePhysics || timeTravel)
+            {
+                // Time Travel's tuning is a mode of the mobile model, so asking for it means asking
+                // for both. A caller can also take the mobile model on its own, which is what gives
+                // the Time Travel cases a control that differs by nothing else.
+                _ = scenario.Design("useMobilePhysics", "true");
+            }
             if (timeTravel)
             {
                 _ = scenario.Design("useTimeTravelRocketPhysics", "true");

--- a/src/CutTheRopeDX.Tests/Interactions/CandyConnectorPhysicsTests.cs
+++ b/src/CutTheRopeDX.Tests/Interactions/CandyConnectorPhysicsTests.cs
@@ -1,3 +1,5 @@
+using System;
+
 using CutTheRopeDX.Framework;
 using CutTheRopeDX.Framework.Core;
 using CutTheRopeDX.GameMain;
@@ -55,10 +57,21 @@ namespace CutTheRopeDX.Tests.Interactions
             // The control is the mobile model without the Time Travel flag, not the desktop one. Time
             // Travel is a mode of mobile physics, so a desktop control would differ by the whole model -
             // rope rest length included - and would say nothing about the relaxation pass on its own.
-            Assert.Equal(
-                SettledConnectorSpan(timeTravel: false, mobilePhysics: true),
-                SettledConnectorSpan(timeTravel: true),
-                1);
+            // With that gate in place the relaxation is the only thing left between the two scenes,
+            // so the difference below is its whole contribution and nothing else's.
+            float control = SettledConnectorSpan(timeTravel: false, mobilePhysics: true);
+            float relaxed = SettledConnectorSpan(timeTravel: true);
+            float contribution = Math.Abs(relaxed - control);
+
+            // Non-zero, or the relaxation pass is not running at all and the rest of this says nothing.
+            Assert.NotEqual(control, relaxed);
+
+            // ...and small enough to be a correction rather than a tuning change. Measured at ~0.04
+            // world units on a ~302-unit span; the bound is a ceiling, not the expected value.
+            Assert.True(
+                contribution < 0.1f,
+                $"Relaxing the endpoints moved the settled span by {contribution} world units, "
+                    + $"from {control} to {relaxed} - too far to be the correction it should be.");
         }
 
         /// <summary>Runs a connected pair for two seconds and reports the gap between the candies.</summary>

--- a/src/CutTheRopeDX.Tests/Interactions/TimeTravelRocketPhysicsTests.cs
+++ b/src/CutTheRopeDX.Tests/Interactions/TimeTravelRocketPhysicsTests.cs
@@ -12,6 +12,12 @@ namespace CutTheRopeDX.Tests.Interactions
     /// Pins the rocket behaviours that Cut the Rope: Time Travel does differently from the
     /// Experiments rocket the rest of the port descends from. Every one of them is gated on a
     /// map's <c>useTimeTravelRocketPhysics</c> flag, so each case checks both sides of the gate.
+    /// <para>
+    /// That flag is itself a mode of <c>useMobilePhysics</c>: a map has to ask for both, and asking
+    /// for the tuning alone is ignored. The cases below therefore contrast Time Travel against the
+    /// desktop rocket, which is the comparison they were written to make; the two tests at the end
+    /// pin the gate itself from each side.
+    /// </para>
     /// </summary>
     public sealed class TimeTravelRocketPhysicsTests
     {
@@ -57,6 +63,61 @@ namespace CutTheRopeDX.Tests.Interactions
             {
                 ActivePhysicsConstants.UseMobilePhysicsModel = previous;
             }
+        }
+
+        [Fact]
+        public void TimeTravelTuningNeedsMobilePhysicsToReachIt()
+        {
+            // The flag is a mode of the mobile model, not a peer of it: Time Travel is a mobile game,
+            // and it authors its values in the same level coordinates the mobile model works in. A map
+            // that asks for the tuning without the model it belongs to is ignored, rather than left
+            // half-applied with mobile values reading through desktop scale.
+            GameScene scene = Scenario.New()
+                .MapSize(320, 480)
+                .Design("useTimeTravelRocketPhysics", "true")
+                .Candy(160, 120)
+                .Rope(160, 60, length: 60)
+                .Rocket(160, 260, angle: 180f, impulse: 5f)
+                .OmNom(60, 420)
+                .Build();
+
+            Assert.NotNull(scene);
+            Assert.False(ActivePhysicsConstants.UseTimeTravelRocketModel);
+
+            // The constants the flag alone can move stay on their desktop values.
+            Assert.Equal(2.5f, ActivePhysicsConstants.RocketPointWeight);
+            Assert.Equal(200f, ActivePhysicsConstants.RocketReelSpeed);
+            Assert.Equal(1f, ActivePhysicsConstants.RocketExhaustSpeedFloor);
+            Assert.True(ActivePhysicsConstants.RocketDampsCandyVelocity);
+            Assert.False(ActivePhysicsConstants.RelaxCandyPointsAfterIntegration);
+        }
+
+        [Fact]
+        public void MobilePhysicsAloneDoesNotBringTheTimeTravelTuning()
+        {
+            // The other half of the gate. Mobile physics is the model Time Travel rides on, and it
+            // already shares some of its numbers - the reel speed and point weight below are the same
+            // either way - so what separates the two is the behaviour the flag alone turns on.
+            GameScene scene = Scenario.New()
+                .MapSize(320, 480)
+                .Design("useMobilePhysics", "true")
+                .Candy(160, 120)
+                .Rope(160, 60, length: 60)
+                .Rocket(160, 260, angle: 180f, impulse: 5f)
+                .OmNom(60, 420)
+                .Build();
+
+            Assert.NotNull(scene);
+            Assert.False(ActivePhysicsConstants.UseTimeTravelRocketModel);
+
+            Assert.Equal(600f, ActivePhysicsConstants.RocketReelSpeed);
+            Assert.Equal(0.5f, ActivePhysicsConstants.RocketPointWeight);
+
+            Assert.Equal(1f, ActivePhysicsConstants.RocketExhaustSpeedFloor);
+            Assert.True(ActivePhysicsConstants.RocketDampsCandyVelocity);
+            Assert.True(ActivePhysicsConstants.RocketRelaxDuringFlight);
+            Assert.False(ActivePhysicsConstants.RelaxCandyPointsAfterIntegration);
+            Assert.False(ActivePhysicsConstants.RocketBindPopsCandyBubble);
         }
 
         [Fact]
@@ -256,6 +317,8 @@ namespace CutTheRopeDX.Tests.Interactions
             }
             if (timeTravel)
             {
+                // Time Travel's tuning is a mode of the mobile model, so the map has to ask for both.
+                _ = scenario.Design("useMobilePhysics", "true");
                 _ = scenario.Design("useTimeTravelRocketPhysics", "true");
             }
             return scenario.Build();

--- a/src/CutTheRopeDX.Tests/TextureCollisionWidthTests.cs
+++ b/src/CutTheRopeDX.Tests/TextureCollisionWidthTests.cs
@@ -187,6 +187,7 @@ namespace CutTheRopeDX.Tests
                 .Rocket(220, 200)
                 .Build();
             GameScene timeTravel = Scenario.New()
+                .Design("useMobilePhysics", "true")
                 .Design("useTimeTravelRocketPhysics", "true")
                 .Candy(60, 100)
                 .OmNom(160, 440)

--- a/src/CutTheRopeDX.Tests/TimeFreezeSimulationTests.cs
+++ b/src/CutTheRopeDX.Tests/TimeFreezeSimulationTests.cs
@@ -328,6 +328,7 @@ namespace CutTheRopeDX.Tests
         public void TimeTravelRocketScalesItsAuthoredImpulseIntoDxWorldCoordinates()
         {
             GameScene scene = Scenario.New()
+                .Design("useMobilePhysics", "true")
                 .Design("useTimeTravelRocketPhysics", "true")
                 .Candy(60, 100)
                 .OmNom(160, 440)
@@ -348,6 +349,7 @@ namespace CutTheRopeDX.Tests
             // in the binary - so a rocket's thrust builds unopposed rather than settling at the
             // terminal speed a velocity-opposing force would impose.
             GameScene scene = Scenario.New()
+                .Design("useMobilePhysics", "true")
                 .Design("useTimeTravelRocketPhysics", "true")
                 .Candy(160, 200)
                 .OmNom(160, 440)
@@ -367,6 +369,7 @@ namespace CutTheRopeDX.Tests
         public void TimeTravelThrustKeepsAccelerating()
         {
             GameScene scene = Scenario.New()
+                .Design("useMobilePhysics", "true")
                 .Design("useTimeTravelRocketPhysics", "true")
                 .Candy(160, 200)
                 .OmNom(160, 440)


### PR DESCRIPTION
## Description

Ensure that Time Travel's rocket physics can only be activated when mobile physics is also turned on.