### PR TITLE
fix: Preload each level's sounds so objects don't hitch on first use

### DIFF
--- a/src/CutTheRopeDX.Core/GameMain/LevelResourceScanner.cs
+++ b/src/CutTheRopeDX.Core/GameMain/LevelResourceScanner.cs
@@ -13,6 +13,11 @@ namespace CutTheRopeDX.GameMain
     /// <summary>
     /// Discovers gameplay resource dependencies from parsed level XML.
     /// </summary>
+    /// <remarks>
+    /// The scan covers sound effects as well as textures. Both are loaded on demand by the
+    /// resource manager, so anything a level's objects can reach but the scan misses is read
+    /// off disk on the game thread at the moment the object first acts.
+    /// </remarks>
     internal static class LevelResourceScanner
     {
         /// <summary>
@@ -34,7 +39,10 @@ namespace CutTheRopeDX.GameMain
             bool nightLevel = false;
             bool waterLevel = false;
             bool sawTarget = false;
-            bool hasClassicTarget = false;
+
+            // Null entries stand for classic targets, so the post-loop passes can tell the
+            // skins apart without depending on where gameDesign sits in document order.
+            List<OmNomSkinDefinition> targetSkins = [];
 
             foreach (XElement node in map.Descendants())
             {
@@ -43,6 +51,11 @@ namespace CutTheRopeDX.GameMain
                     case "gameDesign":
                         nightLevel = ParseBool(node.Attribute("nightLevel")?.Value);
                         waterLevel = ParseFloatOrZero(node.Attribute("water")?.Value) > 0f;
+                        if (ParseBool(node.Attribute("candiesConnected")?.Value))
+                        {
+                            _ = resources.Add(Resources.Snd.CandyLink);
+                        }
+
                         break;
                     case "star":
                         if (nightLevel)
@@ -50,59 +63,95 @@ namespace CutTheRopeDX.GameMain
                             _ = resources.Add(Resources.Img.ObjStarNight);
                         }
                         break;
+                    case "candyL":
+                    case "candyR":
+                        _ = resources.Add(Resources.Snd.CandyLink);
+                        break;
                     case "grab":
                         AddGrabResources(resources, node);
                         break;
                     case "bubble":
+                        _ = resources.Add(Resources.Snd.Bubble);
+                        _ = resources.Add(Resources.Snd.BubbleBreak);
                         break;
                     case "spike1":
                     case "spike2":
                     case "spike3":
                     case "spike4":
                         _ = resources.Add(Resources.Img.ObjSpikes);
+                        AddSpikeRotationSounds(resources);
                         break;
                     case "electro":
                         _ = resources.Add(Resources.Img.ObjElectrodes);
+                        _ = resources.Add(Resources.Snd.Electric);
+                        AddSpikeRotationSounds(resources);
                         break;
                     case "bouncer1":
                     case "bouncer2":
                         _ = resources.Add(Resources.Img.ObjBouncer);
+                        _ = resources.Add(Resources.Snd.Bouncer);
                         break;
                     case "pump":
                         _ = resources.Add(Resources.Img.ObjPump);
+                        _ = resources.Add(Resources.Snd.Pump1);
+                        _ = resources.Add(Resources.Snd.Pump2);
+                        _ = resources.Add(Resources.Snd.Pump3);
+                        _ = resources.Add(Resources.Snd.Pump4);
                         break;
                     case "sock":
                         _ = resources.Add(SpecialEvents.IsXmas ? Resources.Img.ObjSock : Resources.Img.ObjHat);
+                        _ = resources.Add(SpecialEvents.IsXmas ? Resources.Snd.TeleportXmas : Resources.Snd.Teleport);
                         break;
                     case "ghost":
                         _ = resources.Add(Resources.Img.ObjGhost);
+                        _ = resources.Add(Resources.Snd.GhostPuff);
                         break;
                     case "rocket":
                         _ = resources.Add(Resources.Img.ObjRocket);
+                        _ = resources.Add(Resources.Snd.ExpRocketStart);
+                        _ = resources.Add(Resources.Snd.ExpRocketFlyLooped);
+                        _ = resources.Add(Resources.Snd.ExpRocketInWater);
                         break;
                     case "axe":
                         _ = resources.Add(Resources.Img.ObjAxe);
                         _ = resources.Add(Resources.Img.FxCutChain);
+                        _ = resources.Add(Resources.Snd.ChainCut);
                         break;
                     case "load":
                         _ = resources.Add(Resources.Img.ObjSnail);
+                        _ = resources.Add(Resources.Snd.ExpSnailIn);
+                        _ = resources.Add(Resources.Snd.ExpSnailOut);
                         break;
                     case "pipe":
                         _ = resources.Add(Resources.Img.ObjBambooTube);
+                        _ = resources.Add(Resources.Snd.ExpBambooChute);
                         break;
                     case "ants":
                         _ = resources.Add(Resources.Img.ObjAnt);
+                        _ = resources.Add(Resources.Snd.ExpAntsTakeCandy);
+                        _ = resources.Add(Resources.Snd.ExpAntsDropCandy);
                         break;
                     case "lantern":
                         _ = resources.Add(Resources.Img.ObjLantern);
+                        _ = resources.Add(Resources.Snd.LanternTeleportIn);
+                        _ = resources.Add(Resources.Snd.LanternTeleportOut);
                         break;
                     case "gap":
                     case "mouse":
                         _ = resources.Add(Resources.Img.ObjMouse);
+                        _ = resources.Add(Resources.Snd.MouseIdle);
+                        _ = resources.Add(Resources.Snd.MouseRustle);
+                        _ = resources.Add(Resources.Snd.MouseTap);
                         break;
                     case "conveyorBelt":
                     case "transporter":
                         _ = resources.Add(Resources.Img.ObjConveyor);
+                        _ = resources.Add(Resources.Snd.TransporterMove);
+                        _ = resources.Add(Resources.Snd.TransporterDrop);
+                        _ = resources.Add(Resources.Snd.Conv01);
+                        _ = resources.Add(Resources.Snd.Conv02);
+                        _ = resources.Add(Resources.Snd.Conv03);
+                        _ = resources.Add(Resources.Snd.Conv04);
                         break;
                     case "tutorialText":
                         _ = resources.Add(Resources.Fnt.SmallFont);
@@ -127,23 +176,48 @@ namespace CutTheRopeDX.GameMain
                         break;
                     case "hand":
                         _ = resources.Add(Resources.Img.ObjRoboHand);
+                        _ = resources.Add(Resources.Snd.ExpHandCatch);
+                        _ = resources.Add(Resources.Snd.ExpHandDrop);
+                        _ = resources.Add(Resources.Snd.ExpHandRotate);
+                        _ = resources.Add(Resources.Snd.ExpHandClap);
+                        break;
+                    case "gravitySwitch":
+                        _ = resources.Add(Resources.Snd.GravityOn);
+                        _ = resources.Add(Resources.Snd.GravityOff);
+                        break;
+                    case "pauseSwitcher":
+                        _ = resources.Add(Resources.Img.ObjPause);
+                        _ = resources.Add(Resources.Img.FxPause);
+                        _ = resources.Add(Resources.Snd.PauseDown);
+                        _ = resources.Add(Resources.Snd.PauseUp);
                         break;
                     case "target":
                         sawTarget = true;
-                        if (AddTargetResources(resources, node))
-                        {
-                            hasClassicTarget = true;
-                        }
-
+                        targetSkins.Add(AddTargetResources(resources, node));
                         break;
                     case "steamTube":
                         _ = resources.Add(Resources.Img.ObjPipe);
+                        _ = resources.Add(Resources.Snd.SteamStart);
+                        _ = resources.Add(Resources.Snd.SteamStart2);
+                        _ = resources.Add(Resources.Snd.SteamEnd);
                         break;
                     case "rotatedCircle":
                         _ = resources.Add(Resources.Img.ObjVinil);
+                        _ = resources.Add(Resources.Snd.ScratchIn);
+                        _ = resources.Add(Resources.Snd.ScratchOut);
                         break;
                     default:
                         break;
+                }
+            }
+
+            // A classic target sleeps only on night levels; a themed one also sleeps after
+            // being fed on a day level, so its sleep set is needed either way.
+            foreach (OmNomSkinDefinition skin in targetSkins)
+            {
+                if (nightLevel || skin != null)
+                {
+                    AddOmNomSleepSounds(resources, skin);
                 }
             }
 
@@ -155,7 +229,7 @@ namespace CutTheRopeDX.GameMain
                 // present. Use per-target resolution; if a night level has no target node,
                 // fall back to the player's selected skin to preserve prior behavior.
                 bool needsClassicSleeping = sawTarget
-                    ? hasClassicTarget
+                    ? targetSkins.Contains(null)
                     : OmNomSkinRegistry.IsClassicSkin(OmNomSkinRegistry.GetSelectedSkinIndex());
                 if (needsClassicSleeping)
                 {
@@ -163,16 +237,21 @@ namespace CutTheRopeDX.GameMain
                 }
 
                 _ = resources.Add(Resources.Img.FxSleep);
+                _ = resources.Add(Resources.Snd.StarLight1);
+                _ = resources.Add(Resources.Snd.StarLight2);
             }
             if (waterLevel)
             {
                 _ = resources.Add(Resources.Img.WaterTile);
+                _ = resources.Add(Resources.Snd.ExpWaterSplash);
             }
             if (SpecialEvents.IsXmas)
             {
                 _ = resources.Add(Resources.Img.CharGreetingXmas);
                 _ = resources.Add(Resources.Img.CharIdleXmas);
                 _ = resources.Add(Resources.Img.XmasLights);
+                _ = resources.Add(Resources.Img.Snowflakes);
+                _ = resources.Add(Resources.Snd.XmasBell);
             }
 
             return [.. resources.Where(static resourceName => !string.IsNullOrWhiteSpace(resourceName))];
@@ -215,6 +294,33 @@ namespace CutTheRopeDX.GameMain
             _ = resources.Add(Resources.Img.ObjStarIdle);
             _ = resources.Add(Resources.Img.ObjStarDisappear);
             _ = resources.Add(Resources.Img.ObjBubble);
+
+            // Every trace skin draws from these two, and nothing touches them until the
+            // player's first swipe, which is exactly when a load must not happen.
+            _ = resources.Add(Resources.Img.FingerTraces);
+            _ = resources.Add(Resources.Img.FingerTraceGlow);
+
+            _ = resources.Add(Resources.Snd.Tap);
+            _ = resources.Add(Resources.Snd.CandyBreak);
+            _ = resources.Add(Resources.Snd.RopeBleak1);
+            _ = resources.Add(Resources.Snd.RopeBleak2);
+            _ = resources.Add(Resources.Snd.RopeBleak3);
+            _ = resources.Add(Resources.Snd.RopeBleak4);
+            _ = resources.Add(Resources.Snd.RopeGet);
+            _ = resources.Add(Resources.Snd.Star1);
+            _ = resources.Add(Resources.Snd.Star2);
+            _ = resources.Add(Resources.Snd.Star3);
+            _ = resources.Add(Resources.Snd.Win);
+        }
+
+        /// <summary>
+        /// Adds the sounds a spike button press plays, shared by plain and electrified spikes.
+        /// </summary>
+        /// <param name="resources">The destination set being accumulated.</param>
+        private static void AddSpikeRotationSounds(HashSet<string> resources)
+        {
+            _ = resources.Add(Resources.Snd.SpikeRotateIn);
+            _ = resources.Add(Resources.Snd.SpikeRotateOut);
         }
 
         /// <summary>
@@ -229,6 +335,8 @@ namespace CutTheRopeDX.GameMain
             bool bee = ParseBool(node.Attribute("bee")?.Value) || node.Attribute("path") != null;
             bool chain = node.Attribute("breakable") is XAttribute breakableAttr && !ParseBool(breakableAttr.Value);
             bool autoHook = node.Attribute("radius")?.Value is string radius && radius != "-1" && !gun;
+            bool spider = ParseBool(node.Attribute("spider")?.Value);
+            bool wheel = ParseBool(node.Attribute("wheel")?.Value);
 
             _ = resources.Add(chain
                 ? autoHook ? Resources.Img.ObjHookAutoChain : Resources.Img.ObjHookChain
@@ -237,28 +345,43 @@ namespace CutTheRopeDX.GameMain
             if (bee)
             {
                 _ = resources.Add(Resources.Img.ObjBee);
+                _ = resources.Add(Resources.Snd.Buzz);
             }
             if (gun)
             {
                 _ = resources.Add(Resources.Img.ObjGun);
+                _ = resources.Add(Resources.Snd.ExpGun);
             }
             if (kickable)
             {
                 _ = resources.Add(Resources.Img.ObjSticker);
+                _ = resources.Add(Resources.Snd.ExpSuckerDrop);
+                _ = resources.Add(Resources.Snd.ExpSuckerLand);
             }
             if (chain)
             {
                 _ = resources.Add(Resources.Img.ObjExpChain);
             }
+            if (spider)
+            {
+                _ = resources.Add(Resources.Img.ObjSpider);
+                _ = resources.Add(Resources.Snd.SpiderActivate);
+                _ = resources.Add(Resources.Snd.SpiderFall);
+                _ = resources.Add(Resources.Snd.SpiderWin);
+            }
+            if (wheel)
+            {
+                _ = resources.Add(Resources.Snd.Wheel);
+            }
         }
 
         /// <summary>
-        /// Adds Om Nom animation resources for a single target, using its resolved skin.
+        /// Adds Om Nom animation and voice resources for a single target, using its resolved skin.
         /// </summary>
         /// <param name="resources">The destination set being accumulated.</param>
         /// <param name="node">The target XML node, whose <c>targetType</c> selects the skin.</param>
-        /// <returns><see langword="true"/> when the target resolved to the classic skin; otherwise, <see langword="false"/>.</returns>
-        private static bool AddTargetResources(HashSet<string> resources, XElement node)
+        /// <returns>The target's themed skin definition, or <see langword="null"/> for the classic skin.</returns>
+        private static OmNomSkinDefinition AddTargetResources(HashSet<string> resources, XElement node)
         {
             int targetType = ParseIntOrZero(node.Attribute("targetType")?.Value ?? string.Empty);
             int skinIndex = OmNomSkinRegistry.ResolveTargetSkinIndex(
@@ -267,6 +390,7 @@ namespace CutTheRopeDX.GameMain
                 OmNomSkinRegistry.TotalSkinCount);
 
             bool isClassic = OmNomSkinRegistry.IsClassicSkin(skinIndex);
+            OmNomSkinDefinition skin = null;
             if (isClassic)
             {
                 _ = resources.Add(Resources.Img.CharAnimations);
@@ -275,7 +399,7 @@ namespace CutTheRopeDX.GameMain
             }
             else
             {
-                OmNomSkinDefinition skin = OmNomSkinRegistry.GetXmlSkinDefinition(skinIndex);
+                skin = OmNomSkinRegistry.GetXmlSkinDefinition(skinIndex);
                 _ = string.Equals(skin.Id, "OM_NOM_PREHISTORIC", StringComparison.Ordinal)
                     ? resources.Add(Resources.Img.CharAnimationsPrehistoric)
                     : resources.Add(Resources.Img.CharAnimationsSmooth);
@@ -283,7 +407,40 @@ namespace CutTheRopeDX.GameMain
 
             _ = resources.Add(Resources.Img.FxBubbles);
             _ = resources.Add(Resources.Img.CharSupports);
-            return isClassic;
+
+            AddOmNomSound(resources, skin, Resources.Snd.MonsterChewing);
+            AddOmNomSound(resources, skin, Resources.Snd.MonsterClose);
+            AddOmNomSound(resources, skin, Resources.Snd.MonsterOpen);
+            AddOmNomSound(resources, skin, Resources.Snd.MonsterSad);
+            AddOmNomSound(resources, skin, Resources.Snd.MonsterExcited);
+            AddOmNomSound(resources, skin, Resources.Snd.MonsterGreeting);
+
+            return skin;
+        }
+
+        /// <summary>
+        /// Adds the three sleep voice clips a target can play, resolved against its skin.
+        /// </summary>
+        /// <param name="resources">The destination set being accumulated.</param>
+        /// <param name="skin">The target's themed skin, or <see langword="null"/> for the classic skin.</param>
+        private static void AddOmNomSleepSounds(HashSet<string> resources, OmNomSkinDefinition skin)
+        {
+            AddOmNomSound(resources, skin, Resources.Snd.MonsterSleep1);
+            AddOmNomSound(resources, skin, Resources.Snd.MonsterSleep2);
+            AddOmNomSound(resources, skin, Resources.Snd.MonsterSleep3);
+        }
+
+        /// <summary>
+        /// Adds the sound a target actually plays for a classic clip, following the same skin
+        /// resolution that playback uses so themed skins warm their own recordings.
+        /// </summary>
+        /// <param name="resources">The destination set being accumulated.</param>
+        /// <param name="skin">The target's themed skin, or <see langword="null"/> for the classic skin.</param>
+        /// <param name="classicSoundResourceName">The classic clip the target would ask for.</param>
+        private static void AddOmNomSound(HashSet<string> resources, OmNomSkinDefinition skin, string classicSoundResourceName)
+        {
+            // Resolves to null for clips a skin opts out of, which the final filter drops.
+            _ = resources.Add(OmNomSoundResolver.ResolveSoundResource(skin, classicSoundResourceName));
         }
 
         /// <summary>

--- a/src/CutTheRopeDX.Core/GameMain/LevelResourceScanner.cs
+++ b/src/CutTheRopeDX.Core/GameMain/LevelResourceScanner.cs
@@ -221,17 +221,18 @@ namespace CutTheRopeDX.GameMain
                 }
             }
 
+            // Spritesheets owned by the classic animation backend are only needed when a classic
+            // Om Nom is present. Use per-target resolution; if a level has no target node, fall
+            // back to the player's selected skin to preserve prior behavior.
+            bool hasClassicTarget = sawTarget
+                ? targetSkins.Contains(null)
+                : OmNomSkinRegistry.IsClassicSkin(OmNomSkinRegistry.GetSelectedSkinIndex());
+
             if (nightLevel)
             {
                 _ = resources.Add(Resources.Img.ObjStarNight);
 
-                // The classic sleeping spritesheet is only needed when a classic Om Nom is
-                // present. Use per-target resolution; if a night level has no target node,
-                // fall back to the player's selected skin to preserve prior behavior.
-                bool needsClassicSleeping = sawTarget
-                    ? targetSkins.Contains(null)
-                    : OmNomSkinRegistry.IsClassicSkin(OmNomSkinRegistry.GetSelectedSkinIndex());
-                if (needsClassicSleeping)
+                if (hasClassicTarget)
                 {
                     _ = resources.Add(Resources.Img.CharAnimationsSleeping);
                 }
@@ -247,8 +248,14 @@ namespace CutTheRopeDX.GameMain
             }
             if (SpecialEvents.IsXmas)
             {
-                _ = resources.Add(Resources.Img.CharGreetingXmas);
-                _ = resources.Add(Resources.Img.CharIdleXmas);
+                // Both Xmas character sheets belong to the classic animation backend; a themed
+                // skin animates from its own Flash XML and never asks for them.
+                if (hasClassicTarget)
+                {
+                    _ = resources.Add(Resources.Img.CharGreetingXmas);
+                    _ = resources.Add(Resources.Img.CharIdleXmas);
+                }
+
                 _ = resources.Add(Resources.Img.XmasLights);
                 _ = resources.Add(Resources.Img.Snowflakes);
                 _ = resources.Add(Resources.Snd.XmasBell);

--- a/src/CutTheRopeDX.Desktop/Desktop/MonoGameAudioBackend.cs
+++ b/src/CutTheRopeDX.Desktop/Desktop/MonoGameAudioBackend.cs
@@ -17,8 +17,17 @@ namespace CutTheRopeDX.Desktop
     /// </summary>
     internal sealed class MonoGameAudioBackend(ContentManager contentManager) : IAudioBackend
     {
-        /// <summary>Wraps a MonoGame <see cref="SoundEffect"/> as the platform sound effect handle.</summary>
-        private sealed class XnaSoundEffect(SoundEffect effect) : ISoundEffect
+        /// <summary>
+        /// Wraps a MonoGame <see cref="SoundEffect"/> together with the content manager that owns it.
+        /// </summary>
+        /// <remarks>
+        /// A loaded asset belongs to its content manager's cache, so releasing one means unloading
+        /// that manager. Disposing the effect on its own would leave the dead object in the cache,
+        /// and every later load of the same asset would hand that corpse back: creating an instance
+        /// from it throws, and the sound is silent for the rest of the process. Each effect
+        /// therefore gets its own manager, exactly as <see cref="Images"/> does for textures.
+        /// </remarks>
+        private sealed class XnaSoundEffect(ContentManager owner, SoundEffect effect) : ISoundEffect
         {
             public SoundEffect Effect { get; } = effect;
 
@@ -29,7 +38,7 @@ namespace CutTheRopeDX.Desktop
 
             public void Dispose()
             {
-                Effect.Dispose();
+                owner.Unload();
             }
         }
 
@@ -96,7 +105,10 @@ namespace CutTheRopeDX.Desktop
 
         public ISoundEffect LoadSound(string contentPath)
         {
-            return new XnaSoundEffect(_contentManager.Load<SoundEffect>(contentPath));
+            // Sound effects are freed one at a time when a gameplay session ends, so each gets
+            // its own manager to unload. Music stays on the shared manager: it is never freed.
+            DesktopContentManager owner = new(_contentManager.ServiceProvider);
+            return new XnaSoundEffect(owner, owner.Load<SoundEffect>(contentPath));
         }
 
         public IMusicTrack LoadMusic(string contentPath)

--- a/src/CutTheRopeDX.Tests/LevelResourceScannerSoundTests.cs
+++ b/src/CutTheRopeDX.Tests/LevelResourceScannerSoundTests.cs
@@ -1,0 +1,180 @@
+using System.Xml.Linq;
+
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    /// <summary>
+    /// Guards that the level scanner reports the sound effects and action-triggered
+    /// textures a level can reach, so they warm on the loading screen instead of
+    /// stalling the game thread the first time an object acts.
+    /// </summary>
+    public class LevelResourceScannerSoundTests
+    {
+        private static string[] Scan(string mapXml)
+        {
+            return LevelResourceScanner.GetRequiredResources(XElement.Parse(mapXml));
+        }
+
+        private static string[] ScanWithObject(string objectXml)
+        {
+            return Scan($"<map><gameDesign>{objectXml}</gameDesign></map>");
+        }
+
+        [Fact]
+        public void EveryLevelRequiresTheFingerTraceTextures()
+        {
+            string[] resources = Scan("<map><gameDesign /></map>");
+
+            Assert.Contains(Resources.Img.FingerTraces, resources);
+            Assert.Contains(Resources.Img.FingerTraceGlow, resources);
+        }
+
+        [Fact]
+        public void EveryLevelRequiresTheCoreGameplaySounds()
+        {
+            string[] resources = Scan("<map><gameDesign /></map>");
+
+            Assert.Contains(Resources.Snd.CandyBreak, resources);
+            Assert.Contains(Resources.Snd.RopeBleak1, resources);
+            Assert.Contains(Resources.Snd.RopeGet, resources);
+            Assert.Contains(Resources.Snd.Star1, resources);
+            Assert.Contains(Resources.Snd.Win, resources);
+        }
+
+        [Fact]
+        public void BouncerLevelRequiresTheBouncerSound()
+        {
+            Assert.Contains(Resources.Snd.Bouncer, ScanWithObject("<bouncer1 />"));
+        }
+
+        [Fact]
+        public void PumpLevelRequiresEveryPumpSoundVariant()
+        {
+            string[] resources = ScanWithObject("<pump />");
+
+            Assert.Contains(Resources.Snd.Pump1, resources);
+            Assert.Contains(Resources.Snd.Pump2, resources);
+            Assert.Contains(Resources.Snd.Pump3, resources);
+            Assert.Contains(Resources.Snd.Pump4, resources);
+        }
+
+        [Fact]
+        public void RocketLevelRequiresTheRocketSounds()
+        {
+            string[] resources = ScanWithObject("<rocket />");
+
+            Assert.Contains(Resources.Snd.ExpRocketStart, resources);
+            Assert.Contains(Resources.Snd.ExpRocketFlyLooped, resources);
+            Assert.Contains(Resources.Snd.ExpRocketInWater, resources);
+        }
+
+        [Fact]
+        public void SpiderGrabRequiresTheSpiderSounds()
+        {
+            string[] resources = ScanWithObject("<grab spider=\"true\" />");
+
+            Assert.Contains(Resources.Snd.SpiderActivate, resources);
+            Assert.Contains(Resources.Snd.SpiderFall, resources);
+            Assert.Contains(Resources.Snd.SpiderWin, resources);
+        }
+
+        [Fact]
+        public void WheelGrabRequiresTheWheelSound()
+        {
+            Assert.Contains(Resources.Snd.Wheel, ScanWithObject("<grab wheel=\"true\" />"));
+        }
+
+        [Fact]
+        public void PauseSwitcherRequiresItsTexturesAndSounds()
+        {
+            string[] resources = ScanWithObject("<pauseSwitcher />");
+
+            Assert.Contains(Resources.Img.ObjPause, resources);
+            Assert.Contains(Resources.Img.FxPause, resources);
+            Assert.Contains(Resources.Snd.PauseDown, resources);
+            Assert.Contains(Resources.Snd.PauseUp, resources);
+        }
+
+        [Fact]
+        public void GravitySwitchRequiresTheGravitySounds()
+        {
+            string[] resources = ScanWithObject("<gravitySwitch />");
+
+            Assert.Contains(Resources.Snd.GravityOn, resources);
+            Assert.Contains(Resources.Snd.GravityOff, resources);
+        }
+
+        [Fact]
+        public void ConnectedCandiesRequireTheCandyLinkSound()
+        {
+            Assert.Contains(Resources.Snd.CandyLink, ScanWithObject("<candyL /><candyR />"));
+        }
+
+        [Fact]
+        public void WaterLevelRequiresTheSplashSound()
+        {
+            Assert.Contains(
+                Resources.Snd.ExpWaterSplash,
+                Scan("<map><gameDesign water=\"100\" /></map>"));
+        }
+
+        [Fact]
+        public void RotatedCircleRequiresTheScratchSounds()
+        {
+            string[] resources = ScanWithObject("<rotatedCircle />");
+
+            Assert.Contains(Resources.Snd.ScratchIn, resources);
+            Assert.Contains(Resources.Snd.ScratchOut, resources);
+        }
+
+        [Fact]
+        public void ConveyorRequiresItsMoveSounds()
+        {
+            string[] resources = ScanWithObject("<transporter />");
+
+            Assert.Contains(Resources.Snd.TransporterMove, resources);
+            Assert.Contains(Resources.Snd.TransporterDrop, resources);
+            Assert.Contains(Resources.Snd.Conv01, resources);
+            Assert.Contains(Resources.Snd.Conv04, resources);
+        }
+
+        [Fact]
+        public void PlainLevelDoesNotRequireUnrelatedObjectSounds()
+        {
+            string[] resources = Scan("<map><gameDesign /></map>");
+
+            Assert.DoesNotContain(Resources.Snd.ExpRocketStart, resources);
+            Assert.DoesNotContain(Resources.Snd.Bouncer, resources);
+            Assert.DoesNotContain(Resources.Snd.MouseIdle, resources);
+            Assert.DoesNotContain(Resources.Snd.SteamStart, resources);
+        }
+
+        [Fact]
+        public void EveryReportedResourceIsAKnownResourceName()
+        {
+            // The loader silently drops names the resource table rejects, so a typo here
+            // would resurrect the very lazy-load hitch this scan exists to prevent.
+            string[] resources = Scan(
+                """
+                <map>
+                  <gameDesign water="100" nightLevel="true">
+                    <target />
+                    <grab spider="true" wheel="true" gun="true" kickable="true" bee="true" />
+                    <bubble /><pump /><sock /><ghost /><rocket /><axe /><load /><pipe />
+                    <ants /><lantern /><mouse /><transporter /><steamTube /><rotatedCircle />
+                    <bouncer1 /><spike1 /><electro /><hand /><lightBulb /><star />
+                    <gravitySwitch /><pauseSwitcher /><candyL /><candyR />
+                    <tutorialText /><tutorial01 />
+                  </gameDesign>
+                </map>
+                """);
+
+            Assert.All(resources, static resourceName => Assert.True(
+                Resources.IsValidResourceName(resourceName),
+                $"'{resourceName}' is not a known resource name."));
+        }
+    }
+}

--- a/src/CutTheRopeDX.Tests/SoundMgrFreeReloadTests.cs
+++ b/src/CutTheRopeDX.Tests/SoundMgrFreeReloadTests.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+
+using CutTheRopeDX.Framework.Core;
+using CutTheRopeDX.Framework.Media;
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    /// <summary>
+    /// Pins the free-then-reload contract between <see cref="SoundMgr"/> and an audio backend:
+    /// gameplay sounds are freed when a session ends and loaded again for the next level, so a
+    /// released effect must never be handed back a second time. A backend that leaves a disposed
+    /// effect in its own cache turns one quit-to-menu into silence for the rest of the process.
+    /// </summary>
+    public sealed class SoundMgrFreeReloadTests
+    {
+        [Fact]
+        public void FreeingASoundReleasesTheBackendEffect()
+        {
+            _ = HeadlessGame.Boot();
+            SoundMgr manager = Application.SharedSoundMgr();
+            CountingAudioBackend backend = new();
+            SoundMgr.SetBackend(backend);
+
+            try
+            {
+                FakeSoundEffect first = (FakeSoundEffect)manager.GetSound(Resources.Snd.Bouncer);
+                Assert.NotNull(first);
+                Assert.False(first.Released);
+
+                manager.FreeSound(Resources.Snd.Bouncer);
+
+                Assert.True(first.Released);
+            }
+            finally
+            {
+                manager.StopAllSounds();
+                SoundMgr.SetBackend(null);
+            }
+        }
+
+        [Fact]
+        public void ReloadingAFreedSoundYieldsAUsableEffect()
+        {
+            _ = HeadlessGame.Boot();
+            SoundMgr manager = Application.SharedSoundMgr();
+            CountingAudioBackend backend = new();
+            SoundMgr.SetBackend(backend);
+
+            try
+            {
+                ISoundEffect first = manager.GetSound(Resources.Snd.Bouncer);
+                manager.FreeSound(Resources.Snd.Bouncer);
+
+                FakeSoundEffect second = (FakeSoundEffect)manager.GetSound(Resources.Snd.Bouncer);
+
+                Assert.NotNull(second);
+                Assert.NotSame(first, second);
+                Assert.False(second.Released);
+
+                // The whole point of reloading: it can still be played.
+                Assert.NotNull(second.CreateInstance());
+                Assert.Equal(2, backend.LoadCount);
+            }
+            finally
+            {
+                manager.StopAllSounds();
+                SoundMgr.SetBackend(null);
+            }
+        }
+
+        [Fact]
+        public void FreeingOneSoundLeavesOtherLoadedSoundsUsable()
+        {
+            _ = HeadlessGame.Boot();
+            SoundMgr manager = Application.SharedSoundMgr();
+            CountingAudioBackend backend = new();
+            SoundMgr.SetBackend(backend);
+
+            try
+            {
+                FakeSoundEffect bouncer = (FakeSoundEffect)manager.GetSound(Resources.Snd.Bouncer);
+                FakeSoundEffect electric = (FakeSoundEffect)manager.GetSound(Resources.Snd.Electric);
+
+                manager.FreeSound(Resources.Snd.Bouncer);
+
+                Assert.True(bouncer.Released);
+                Assert.False(electric.Released);
+                Assert.Same(electric, manager.GetSound(Resources.Snd.Electric));
+                Assert.NotNull(electric.CreateInstance());
+            }
+            finally
+            {
+                manager.StopAllSounds();
+                SoundMgr.SetBackend(null);
+            }
+        }
+
+        [Fact]
+        public void FreeingALoopedSoundStopsOnlyItsOwnInstances()
+        {
+            _ = HeadlessGame.Boot();
+            SoundMgr manager = Application.SharedSoundMgr();
+            CountingAudioBackend backend = new();
+            SoundMgr.SetBackend(backend);
+
+            try
+            {
+                ISoundInstance loop = manager.PlaySoundLooped(Resources.Snd.Electric);
+                ISoundInstance other = manager.PlaySoundLooped(Resources.Snd.TransporterMove);
+                Assert.Equal(AudioPlaybackState.Playing, loop.State);
+                Assert.Equal(AudioPlaybackState.Playing, other.State);
+
+                manager.FreeSound(Resources.Snd.Electric);
+
+                Assert.Equal(AudioPlaybackState.Stopped, loop.State);
+                Assert.Equal(AudioPlaybackState.Playing, other.State);
+            }
+            finally
+            {
+                manager.StopAllSounds();
+                SoundMgr.SetBackend(null);
+            }
+        }
+
+        /// <summary>
+        /// A backend whose released effects stay released, so a test can tell a fresh load from
+        /// a corpse handed back out of a cache.
+        /// </summary>
+        private sealed class CountingAudioBackend : IAudioBackend
+        {
+            private readonly Dictionary<string, int> loadsByPath = [];
+
+            public int LoadCount { get; private set; }
+
+            public ISoundEffect LoadSound(string contentPath)
+            {
+                LoadCount++;
+                loadsByPath[contentPath] = loadsByPath.GetValueOrDefault(contentPath) + 1;
+                return new FakeSoundEffect();
+            }
+
+            public IMusicTrack LoadMusic(string contentPath)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void PlayMusic(IMusicTrack track, bool repeating)
+            {
+            }
+
+            public void StopMusic()
+            {
+            }
+
+            public void PauseMusic()
+            {
+            }
+
+            public void ResumeMusic()
+            {
+            }
+
+            public AudioPlaybackState MusicState => AudioPlaybackState.Stopped;
+
+            public bool TryInstallSongCompletionCallback(IMusicTrack track, EventHandler<EventArgs> onDecoderFinished)
+            {
+                return false;
+            }
+        }
+
+        private sealed class FakeSoundEffect : ISoundEffect
+        {
+            public bool Released { get; private set; }
+
+            public ISoundInstance CreateInstance()
+            {
+                ObjectDisposedException.ThrowIf(Released, this);
+                return new FakeSoundInstance();
+            }
+
+            public void Dispose()
+            {
+                Released = true;
+            }
+        }
+
+        private sealed class FakeSoundInstance : ISoundInstance
+        {
+            public bool IsLooped { get; set; }
+
+            public float Volume { get; set; } = 1f;
+
+            public AudioPlaybackState State { get; private set; } = AudioPlaybackState.Stopped;
+
+            public void Play()
+            {
+                State = AudioPlaybackState.Playing;
+            }
+
+            public void Stop()
+            {
+                State = AudioPlaybackState.Stopped;
+            }
+
+            public void Pause()
+            {
+                State = AudioPlaybackState.Paused;
+            }
+
+            public void Resume()
+            {
+                State = AudioPlaybackState.Playing;
+            }
+
+            public void Dispose()
+            {
+                State = AudioPlaybackState.Stopped;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Levels loaded fast but stuttered during play: the first bounce, the first swipe, the first rocket launch each froze the game thread for a moment.

Right now, nothing ever preloads a sound. `SoundMgr.GetSound` loads on first play, which on desktop is a synchronous `ContentManager.Load<SoundEffect>`, which is a disk read, an XNB decode and a native audio buffer upload, and no load pack (`PackStartup`, `PackMenu`, `PackGame`, or the level scan) named a single one of the 80 sounds the game plays across 74 call sites. Every effect paid its load cost at the exact moment its object first acted.

A few textures had the same problem for the same reason: the finger trace atlases are only named at draw time, so the first swipe of every level loaded two of them.

## What's changed

### Covers sounds during level scan, not just textures

`LevelResourceScanner` now reports the sound effects a level's objects can reach alongside its textures. `ResourceMgr.LoadResource` already routes sound names to `SharedSoundMgr().GetSound()` and `FreeResource` frees them, so they ride the existing loading screen and session tracking symmetrically.

Objects the scan missed entirely are now covered: `gravitySwitch`, `pauseSwitcher`, `candyL`/`candyR` and the `candiesConnected` attribute, plus the `spider` and `wheel` grab attributes.

Om Nom audios resolve through `OmNomSoundResolver` per target skin, so a themed skin warms its own recordings rather than the classic ones.

### Sound effects are released correctly

Putting sounds in the session set activated `SoundMgr.FreeSound`, which until now was dead code, and it disposed an asset it does not own. A `ContentManager` owns what it loads and keeps it in `loadedAssets`, so disposing the `SoundEffect` left a corpse in the cache that every later load handed back. Creating an instance from it throws, `TryPlay` swallows that and returns null, and the sound is silent for the rest of the process. One quit to menu disposed every gameplay effect, `tap` included, so menu clicks died too.

Sound effects now get a per-asset `DesktopContentManager` and release by unloading it, the same shape `Images` already uses for textures. Music stays on the shared manager, since it is never freed.

## Cost

A level scans 29–39 resources instead of just ~12–15, of which 15–24 are sounds (~2 MB). The loading screen advances one resource per 1/60 s tick, so the first level of a box gains roughly 0.3 s. Later levels get free enhancement as usual - the box prefetcher already runs the same scan in the background during play.