### PR TITLE
fix: Repeat P2 and earth bg across every tiled P1 background section

### DIFF
--- a/src/CutTheRopeDX.Core/GameMain/BackgroundTiling.cs
+++ b/src/CutTheRopeDX.Core/GameMain/BackgroundTiling.cs
@@ -24,6 +24,40 @@ namespace CutTheRopeDX.GameMain
             return Math.Max(0, p1Count - 1);
         }
 
+        /// <summary>
+        /// Returns the inclusive range of repeated sections a view window touches.
+        /// </summary>
+        /// <remarks>
+        /// The P1 tile map repeats in both directions to fill a design-sized window around the
+        /// camera, so everything anchored to a single P1 section — the P2 seam overlay, the earth
+        /// art — has to be repeated over the same sections or it dresses only the section it was
+        /// authored on and leaves every other one bare.
+        /// </remarks>
+        /// <param name="sectionOrigin">Where the authored section starts along this axis.</param>
+        /// <param name="sectionSize">Size of one repeated section along this axis.</param>
+        /// <param name="windowStart">Where the view window starts along this axis.</param>
+        /// <param name="windowSize">Size of the view window along this axis.</param>
+        /// <returns>First and last section index, both inclusive and possibly negative.</returns>
+        public static (int First, int Last) GetSectionRange(
+            float sectionOrigin,
+            float sectionSize,
+            float windowStart,
+            float windowSize)
+        {
+            if (sectionSize <= 0f || float.IsNaN(sectionSize) || float.IsInfinity(sectionSize))
+            {
+                return (0, 0);
+            }
+
+            int first = (int)MathF.Floor((windowStart - sectionOrigin) / sectionSize);
+            // The nudge is a fraction of a source unit, not of a section: it exists only to keep a
+            // window that ends exactly on a boundary from claiming the section past it, and a
+            // section-sized nudge would swallow a genuine sliver of the next one instead.
+            int last = (int)MathF.Ceiling(
+                (windowStart + windowSize - Epsilon - sectionOrigin) / sectionSize) - 1;
+            return (first, Math.Max(first, last));
+        }
+
         /// <summary>Places a P2 overlay at the requested seam between repeated P1 sections.</summary>
         /// <param name="originalP2Y">Authored P2 offset for the first seam.</param>
         /// <param name="p1Height">Height of one repeated P1 texture.</param>

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.Draw.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.Draw.cs
@@ -39,6 +39,14 @@ namespace CutTheRopeDX.GameMain
             Renderer.PushMatrix();
             Renderer.Scale(back.scaleX, back.scaleY, 1f);
             back.Draw();
+            // The tile map repeats P1 in both directions over a design-sized window around the
+            // camera, so every piece anchored to the authored P1 section has to be repeated over
+            // the same sections. Otherwise only the section the camera started on is dressed.
+            (int firstColumn, int lastColumn) = BackgroundTiling.GetSectionRange(
+                back.x,
+                backTexture?._realWidth ?? 0,
+                pos.X,
+                SCREEN_WIDTH);
             int p2Count = BackgroundTiling.GetP2Count(mapHeight, SCREEN_HEIGHT);
             if (p2Count > 0)
             {
@@ -67,11 +75,14 @@ namespace CutTheRopeDX.GameMain
                                 p2Y,
                                 backTexture._realHeight,
                                 seamIndex);
-                            DrawHelper.DrawImagePart(
-                                p2Texture,
-                                p2Rect,
-                                back.x,
-                                back.y + adjustedP2Y);
+                            for (int column = firstColumn; column <= lastColumn; column++)
+                            {
+                                DrawHelper.DrawImagePart(
+                                    p2Texture,
+                                    p2Rect,
+                                    back.x + (column * backTexture._realWidth),
+                                    back.y + adjustedP2Y);
+                            }
                         }
                         Renderer.Disable(Renderer.GL_BLEND);
                     }
@@ -79,7 +90,29 @@ namespace CutTheRopeDX.GameMain
             }
             Renderer.Enable(Renderer.GL_BLEND);
             Renderer.SetBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);
-            gravityState.DrawEarthAnimations();
+            if (gravityState.HasEarthAnimations)
+            {
+                // The earth belongs to the P1 section it was authored on, so it repeats with the
+                // tile map on both axes rather than leaving every other section's sky empty.
+                (int firstRow, int lastRow) = BackgroundTiling.GetSectionRange(
+                    back.y,
+                    backTexture?._realHeight ?? 0,
+                    pos.Y,
+                    SCREEN_HEIGHT);
+                for (int column = firstColumn; column <= lastColumn; column++)
+                {
+                    for (int row = firstRow; row <= lastRow; row++)
+                    {
+                        Renderer.PushMatrix();
+                        Renderer.Translate(
+                            column * (backTexture?._realWidth ?? 0),
+                            row * (backTexture?._realHeight ?? 0),
+                            0f);
+                        gravityState.DrawEarthAnimations();
+                        Renderer.PopMatrix();
+                    }
+                }
+            }
             Renderer.PopMatrix();
             Renderer.Enable(Renderer.GL_BLEND);
             Renderer.SetBlendFunc(BlendingFactor.GLONE, BlendingFactor.GLONEMINUSSRCALPHA);

--- a/src/CutTheRopeDX.Core/GameMain/GravityState.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GravityState.cs
@@ -22,6 +22,9 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Whether gravity currently points opposite its authored vertical direction.</summary>
         public bool IsInverted { get; private set; }
 
+        /// <summary>Whether the loaded level supplied any earth art to draw.</summary>
+        public bool HasEarthAnimations => earthAnimations.Count > 0;
+
         /// <summary>Gravity vector derived from <see cref="BaseVector"/> and <see cref="IsInverted"/>.</summary>
         public Vector CurrentVector => new(BaseVector.X, IsInverted ? -BaseVector.Y : BaseVector.Y);
 

--- a/src/CutTheRopeDX.Tests/BackgroundTilingTests.cs
+++ b/src/CutTheRopeDX.Tests/BackgroundTilingTests.cs
@@ -45,5 +45,40 @@ namespace CutTheRopeDX.Tests
                 Assert.Equal(2560f, BackgroundTiling.ResolveP2Y(1120f, 1440f, seamIndex: 1));
             });
         }
+
+        [Theory]
+        // A window no wider than one section, aligned with it, needs that section alone.
+        [InlineData(0f, 2559f, 0f, 2559f, 0, 0)]
+        // The design window overhangs the one-pixel-narrow art, so its neighbour shows too.
+        [InlineData(0f, 2559f, 0f, 2560f, 0, 1)]
+        // A camera parked on the second section needs only that one.
+        [InlineData(0f, 2559f, 2559f, 2559f, 1, 1)]
+        // A camera straddling the seam needs the sections on both sides of it.
+        [InlineData(0f, 2559f, 1280f, 2560f, 0, 1)]
+        // Sections repeat in both directions, so a camera left of the origin sees negative ones.
+        [InlineData(0f, 2559f, -100f, 2560f, -1, 0)]
+        public void SectionRangeCoversEverySectionTheWindowTouches(
+            float sectionOrigin,
+            float sectionSize,
+            float windowStart,
+            float windowSize,
+            int expectedFirst,
+            int expectedLast)
+        {
+            (int first, int last) = BackgroundTiling.GetSectionRange(
+                sectionOrigin,
+                sectionSize,
+                windowStart,
+                windowSize);
+
+            Assert.Equal(expectedFirst, first);
+            Assert.Equal(expectedLast, last);
+        }
+
+        [Fact]
+        public void SectionRangeIsTheAuthoredSectionAloneWhenTheSizeIsUnusable()
+        {
+            Assert.Equal((0, 0), BackgroundTiling.GetSectionRange(0f, 0f, 0f, 2560f));
+        }
     }
 }


### PR DESCRIPTION
## Description

The gameplay background repeats P1 in both directions: the tile map is `Repeat.ALL` on each axis and wraps to fill a design-sized window around the camera. Everything anchored to a single P1 section was left behind by that repeat.

P2, the band that dresses the join between two P1 sections, was drawn at exactly `back.x`. Its vertical placement already walked the seams a tall map needs, but horizontally it existed once, so on a level wide enough for the camera to travel past one P1 width only the middle section had its seam dressed and the sections beside it showed the bare join.

The earth art had the same gap on both axes. `DrawEarthAnimations` drew each image once at its authored position, so one P1 section carried the earth and every other one showed empty placeholder.

## What's changed

### A section range shared by both pieces

`BackgroundTiling.GetSectionRange` returns the inclusive range of repeated sections a view window touches, with indices free to go negative. It is handed the same window `TileMap` fills for itself - `SCREEN_WIDTH` x `SCREEN_HEIGHT` around the camera, in the background's own space, so wherever a P1 tile is drawn, whatever belongs on it is drawn too.

Its rounding nudge is a fraction of a source unit rather than of a section. A section-sized nudge is about 2.5px against the 2559-wide art, enough to swallow the genuine one-pixel overhang of the 2560-wide design window.

### P2 follows the columns

The existing seam loop now draws each overlay once per column at the P1 cadence. P2 is authored at the same width as P1, so the bands line up across the repeat.

Vertical placement is untouched and still driven by map height, so a level of a single section still gets no P2 at all.

### Earth follows the tiling on both axes

Earth images are drawn per column and per row through `Renderer.Translate` at the P1 cadence, so a wide or tall level shows one earth per visible section rather than one in the whole world.

A new `GravityState.HasEarthAnimations` skips the matrix work on the packs that have no earth art.