### PR TITLE
fix: Follow the candy across large levels, and hold gameplay through the intro pan

### DIFF
--- a/src/CutTheRopeDX.Core/GameMain/GameScene.Show.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.Show.cs
@@ -178,45 +178,45 @@ namespace CutTheRopeDX.GameMain
                 camera.speed = 20f;
                 cameraMoveMode = 0;
                 ConstraintedPoint constraintedPoint = CameraFocusPoint();
+
+                // The pan starts at whichever end of the tracking range is away from the focus
+                // point. Both ends and the midpoint they are chosen by are the level's own: a
+                // level wider than the design box is centered on it, so its near end is a negative
+                // world X and neither end is at the origin.
+                CTRRectangle range = CameraTrackingRange();
                 float cameraStartX;
                 float cameraStartY;
                 if (mapWidth > SCREEN_WIDTH)
                 {
-                    if (constraintedPoint.pos.X > mapWidth / 2)
-                    {
-                        cameraStartX = 0f;
-                        cameraStartY = 0f;
-                    }
-                    else
-                    {
-                        cameraStartX = mapWidth - SCREEN_WIDTH;
-                        cameraStartY = 0f;
-                    }
+                    cameraStartX = constraintedPoint.pos.X > range.x + (mapWidth / 2f)
+                        ? range.x
+                        : range.x + range.w;
+                    cameraStartY = range.y;
                 }
-                else if (constraintedPoint.pos.Y > mapHeight / 2)
+                else if (constraintedPoint.pos.Y > range.y + (mapHeight / 2f))
                 {
-                    cameraStartX = 0f;
-                    cameraStartY = 0f;
+                    cameraStartX = range.x;
+                    cameraStartY = range.y;
                 }
                 else
                 {
-                    cameraStartX = 0f;
-                    cameraStartY = mapHeight - SCREEN_HEIGHT;
+                    cameraStartX = range.x;
+                    cameraStartY = range.y + range.h;
                 }
-                float targetCameraX = constraintedPoint.pos.X - (SCREEN_WIDTH / 2f);
-                float targetCameraY = constraintedPoint.pos.Y - (SCREEN_HEIGHT / 2f);
-                float boundedCameraX = FIT_TO_BOUNDARIES(targetCameraX, 0f, mapWidth - SCREEN_WIDTH);
-                float boundedCameraY = FIT_TO_BOUNDARIES(targetCameraY, 0f, mapHeight - SCREEN_HEIGHT);
+                Vector boundedCamera = BoundedCameraPosition(
+                    constraintedPoint.pos.X - (SCREEN_WIDTH / 2f),
+                    constraintedPoint.pos.Y - (SCREEN_HEIGHT / 2f));
 
                 // Seat the tracked position at the authored start point and let the fit derive the
                 // rest from it, the way every later frame does.
                 camera.MoveToXYImmediate(cameraStartX, cameraStartY, true);
                 ApplyCameraFit(ScreenPresentation.Instance.Snapshot);
-                initialCameraToStarDistance = VectDistance(camera.pos, Vect(boundedCameraX, boundedCameraY));
+                initialCameraToStarDistance = VectDistance(camera.pos, boundedCamera);
                 return;
             }
             ignoreTouches = false;
-            camera.MoveToXYImmediate(0f, 0f, true);
+            Vector resting = BoundedCameraPosition(0f, 0f);
+            camera.MoveToXYImmediate(resting.X, resting.Y, true);
             ApplyCameraFit(ScreenPresentation.Instance.Snapshot);
         }
 

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.Show.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.Show.cs
@@ -170,7 +170,8 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         public void StartCamera()
         {
-            if (mapWidth > SCREEN_WIDTH || mapHeight > SCREEN_HEIGHT)
+            ViewportLayoutSnapshot snapshot = ScreenPresentation.Instance.Snapshot;
+            if (CameraCanTravel(snapshot))
             {
                 ignoreTouches = true;
                 fastenCamera = false;
@@ -210,14 +211,22 @@ namespace CutTheRopeDX.GameMain
                 // Seat the tracked position at the authored start point and let the fit derive the
                 // rest from it, the way every later frame does.
                 camera.MoveToXYImmediate(cameraStartX, cameraStartY, true);
-                ApplyCameraFit(ScreenPresentation.Instance.Snapshot);
+                ApplyCameraFit(snapshot);
                 initialCameraToStarDistance = VectDistance(camera.pos, boundedCamera);
                 return;
             }
+
+            // Nothing to preview: this viewport already holds the level end to end, so a pan would
+            // sit the player in front of a picture that cannot move - and, since gameplay is held
+            // for the length of one, do it while the level they can already see waits. Seat the
+            // camera where the pan would have left it and hand them the level.
             ignoreTouches = false;
-            Vector resting = BoundedCameraPosition(0f, 0f);
+            ConstraintedPoint restingFocus = CameraFocusPoint();
+            Vector resting = BoundedCameraPosition(
+                restingFocus.pos.X - (SCREEN_WIDTH / 2f),
+                restingFocus.pos.Y - (SCREEN_HEIGHT / 2f));
             camera.MoveToXYImmediate(resting.X, resting.Y, true);
-            ApplyCameraFit(ScreenPresentation.Instance.Snapshot);
+            ApplyCameraFit(snapshot);
         }
 
         /// <summary>

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.Update.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.Update.cs
@@ -98,8 +98,9 @@ namespace CutTheRopeDX.GameMain
             ConstraintedPoint constraintedPoint4 = CameraFocusPoint();
             float targetCameraX = constraintedPoint4.pos.X - (SCREEN_WIDTH / 2f);
             float targetCameraY = constraintedPoint4.pos.Y - (SCREEN_HEIGHT / 2f);
-            float boundedCameraX = FIT_TO_BOUNDARIES(targetCameraX, 0f, mapWidth - SCREEN_WIDTH);
-            float boundedCameraY = FIT_TO_BOUNDARIES(targetCameraY, 0f, mapHeight - SCREEN_HEIGHT);
+            Vector boundedCamera = BoundedCameraPosition(targetCameraX, targetCameraY);
+            float boundedCameraX = boundedCamera.X;
+            float boundedCameraY = boundedCamera.Y;
             camera.MoveToXYImmediate(boundedCameraX, boundedCameraY, false);
             if (!freezeCamera || camera.type != CAMERATYPE.CAMERASPEEDDELAY)
             {

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.Update.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.Update.cs
@@ -17,6 +17,19 @@ namespace CutTheRopeDX.GameMain
         public override void Update(float delta)
         {
             delta = 0.016f;
+
+            // The opening pan flies the camera across the level with input switched off. Nothing
+            // else advances until it hands input back, so a candy cannot fall - or be eaten, or
+            // drift out of a claw - before the player has seen where it is. On a level the design
+            // box already covered there is no pan and this never fires; the levels that grew one
+            // are the ones whose pan is long enough to lose the level on the way.
+            if (IntroPanIsRunning)
+            {
+                UpdateCameraTracking(delta);
+                _ = AdvanceRestartFlow(delta);
+                return;
+            }
+
             base.Update(delta);
             foreach (PauseSwitcher switcher in pauseSwitchers)
             {
@@ -95,60 +108,7 @@ namespace CutTheRopeDX.GameMain
             }
             _ = Mover.MoveVariableToTarget(ref ropeAtOnceTimer, 0, 1, delta);
 
-            ConstraintedPoint constraintedPoint4 = CameraFocusPoint();
-            float targetCameraX = constraintedPoint4.pos.X - (SCREEN_WIDTH / 2f);
-            float targetCameraY = constraintedPoint4.pos.Y - (SCREEN_HEIGHT / 2f);
-            Vector boundedCamera = BoundedCameraPosition(targetCameraX, targetCameraY);
-            float boundedCameraX = boundedCamera.X;
-            float boundedCameraY = boundedCamera.Y;
-            camera.MoveToXYImmediate(boundedCameraX, boundedCameraY, false);
-            if (!freezeCamera || camera.type != CAMERATYPE.CAMERASPEEDDELAY)
-            {
-                camera.Update(delta);
-            }
-            if (camera.type == CAMERATYPE.CAMERASPEEDPIXELS)
-            {
-                float touchEnableDistance = 100f;
-                float cameraAcceleration = 800f;
-                float cameraDeceleration = 400f;
-                float maxCameraSpeed = 1000f;
-                float minCameraSpeed = 300f;
-                float cameraTargetDistance = VectDistance(camera.pos, Vect(boundedCameraX, boundedCameraY));
-                if (cameraTargetDistance < touchEnableDistance)
-                {
-                    ignoreTouches = false;
-                }
-                if (fastenCamera)
-                {
-                    if (camera.speed < 5500f)
-                    {
-                        camera.speed *= 1.5f;
-                    }
-                }
-                else if (cameraTargetDistance > initialCameraToStarDistance / 2)
-                {
-                    camera.speed += delta * cameraAcceleration;
-                    camera.speed = MIN(maxCameraSpeed, camera.speed);
-                }
-                else
-                {
-                    camera.speed -= delta * cameraDeceleration;
-                    camera.speed = MAX(minCameraSpeed, camera.speed);
-                }
-                if (MathF.Abs(camera.pos.X - boundedCameraX) < 1 && MathF.Abs(camera.pos.Y - boundedCameraY) < 1)
-                {
-                    camera.type = CAMERATYPE.CAMERASPEEDDELAY;
-                    camera.speed = 14f;
-                }
-            }
-            else
-            {
-                time += delta;
-            }
-
-            // Project where the tracking just left the camera onto the current viewport. Last,
-            // because this reads the tracked position and writes only what gets drawn.
-            ApplyCameraFit(ScreenPresentation.Instance.Snapshot);
+            UpdateCameraTracking(delta);
 
             if (bungees.Count > 0)
             {
@@ -1703,18 +1663,100 @@ namespace CutTheRopeDX.GameMain
             {
                 HoldFrozenPoints();
             }
+            _ = AdvanceRestartFlow(delta);
+        }
+
+        /// <summary>
+        /// Advances the restart dim by one frame and carries out whatever step it reports.
+        /// </summary>
+        /// <remarks>
+        /// Runs during the opening pan as well as during play. The dim is presentation, not
+        /// gameplay: a restart hands the reloaded level straight to the pan, and the fade back in
+        /// has to finish over it rather than waiting for it - otherwise the level the player just
+        /// restarted sits behind a full-strength dim for as long as the pan lasts.
+        /// </remarks>
+        /// <param name="delta">Elapsed frame time in seconds.</param>
+        /// <returns>
+        /// <see langword="true"/> when the scene was reloaded, so the caller must not touch it
+        /// further this step.
+        /// </returns>
+        private bool AdvanceRestartFlow(float delta)
+        {
             switch (gameplayFlow.Advance(delta))
             {
                 case RestartStep.SwapScene:
                     dd.CancelAllDispatches();
                     Hide();
                     Show();
-                    return;
+                    return true;
                 case RestartStep.Completed:
                 case RestartStep.None:
                 default:
-                    break;
+                    return false;
             }
+        }
+
+        /// <summary>
+        /// Drives the camera toward the point it follows and projects where that leaves it
+        /// onto the current viewport.
+        /// </summary>
+        /// <param name="delta">Elapsed frame time in seconds.</param>
+        private void UpdateCameraTracking(float delta)
+        {
+            ConstraintedPoint constraintedPoint4 = CameraFocusPoint();
+            float targetCameraX = constraintedPoint4.pos.X - (SCREEN_WIDTH / 2f);
+            float targetCameraY = constraintedPoint4.pos.Y - (SCREEN_HEIGHT / 2f);
+            Vector boundedCamera = BoundedCameraPosition(targetCameraX, targetCameraY);
+            float boundedCameraX = boundedCamera.X;
+            float boundedCameraY = boundedCamera.Y;
+            camera.MoveToXYImmediate(boundedCameraX, boundedCameraY, false);
+            if (!freezeCamera || camera.type != CAMERATYPE.CAMERASPEEDDELAY)
+            {
+                camera.Update(delta);
+            }
+            if (camera.type == CAMERATYPE.CAMERASPEEDPIXELS)
+            {
+                float touchEnableDistance = 100f;
+                float cameraAcceleration = 800f;
+                float cameraDeceleration = 400f;
+                float maxCameraSpeed = 1000f;
+                float minCameraSpeed = 300f;
+                float cameraTargetDistance = VectDistance(camera.pos, Vect(boundedCameraX, boundedCameraY));
+                if (cameraTargetDistance < touchEnableDistance)
+                {
+                    ignoreTouches = false;
+                }
+                if (fastenCamera)
+                {
+                    if (camera.speed < 5500f)
+                    {
+                        camera.speed *= 1.5f;
+                    }
+                }
+                else if (cameraTargetDistance > initialCameraToStarDistance / 2)
+                {
+                    camera.speed += delta * cameraAcceleration;
+                    camera.speed = MIN(maxCameraSpeed, camera.speed);
+                }
+                else
+                {
+                    camera.speed -= delta * cameraDeceleration;
+                    camera.speed = MAX(minCameraSpeed, camera.speed);
+                }
+                if (MathF.Abs(camera.pos.X - boundedCameraX) < 1 && MathF.Abs(camera.pos.Y - boundedCameraY) < 1)
+                {
+                    camera.type = CAMERATYPE.CAMERASPEEDDELAY;
+                    camera.speed = 14f;
+                }
+            }
+            else
+            {
+                time += delta;
+            }
+
+            // Project where the tracking just left the camera onto the current viewport. Last,
+            // because this reads the tracked position and writes only what gets drawn.
+            ApplyCameraFit(ScreenPresentation.Instance.Snapshot);
         }
 
         /// <summary>Advances pointer visuals even when outcome presentation freezes gameplay simulation.</summary>

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.cs
@@ -403,6 +403,40 @@ namespace CutTheRopeDX.GameMain
         }
 
         /// <summary>
+        /// The range the tracking may drive the camera through: the positions of the design-box
+        /// window's top-left corner that keep the window inside the level.
+        /// </summary>
+        /// <remarks>
+        /// Measured from <see cref="cameraBounds"/>'s own origin rather than from world zero. A
+        /// level wider than the design box is laid out centered on it, so its left edge sits at a
+        /// negative world X; a range starting at zero would strand that half outside what the
+        /// camera can reach and pin it against the right edge for everything past the level's
+        /// midpoint. An axis the level does not exceed contributes no extent, leaving the one
+        /// position that shows the whole level on that axis.
+        /// </remarks>
+        /// <returns>The origin of the range and its extent on each axis.</returns>
+        private CTRRectangle CameraTrackingRange()
+        {
+            return new CTRRectangle(
+                cameraBounds.x,
+                cameraBounds.y,
+                MathF.Max(0f, mapWidth - SCREEN_WIDTH),
+                MathF.Max(0f, mapHeight - SCREEN_HEIGHT));
+        }
+
+        /// <summary>Clamps a desired camera position into <see cref="CameraTrackingRange"/>.</summary>
+        /// <param name="x">Desired camera X, in world units.</param>
+        /// <param name="y">Desired camera Y, in world units.</param>
+        /// <returns>The clamped position.</returns>
+        private Vector BoundedCameraPosition(float x, float y)
+        {
+            CTRRectangle range = CameraTrackingRange();
+            return Vect(
+                FIT_TO_BOUNDARIES(x, range.x, range.x + range.w),
+                FIT_TO_BOUNDARIES(y, range.y, range.y + range.h));
+        }
+
+        /// <summary>
         /// Fits the camera to the level for the current viewport, holding it centered when the
         /// whole level is already visible.
         /// </summary>
@@ -415,8 +449,13 @@ namespace CutTheRopeDX.GameMain
             }
 
             CTRRectangle viewport = snapshot.VisibleBounds;
-            bool locked = GameplayCamera.ScrollIsLocked(
-                cameraBounds.w, cameraBounds.h, viewport.w, viewport.h);
+
+            // The fit scales cameraWindow, never the whole map, so the scale - and with it how
+            // much world beyond the window the viewport exposes - is settled before any anchor is
+            // chosen. Computing it here lets the anchor be made against that exposed slack.
+            float scale = MathF.Min(viewport.w / cameraWindow.w, viewport.h / cameraWindow.h);
+            float slackX = (viewport.w / scale) - cameraWindow.w;
+            float slackY = (viewport.h / scale) - cameraWindow.h;
 
             // On an axis the level exceeds, cameraWindow is capped to the design size rather than
             // the full map, so it is the window - not the whole map - that fits the viewport; the
@@ -429,12 +468,8 @@ namespace CutTheRopeDX.GameMain
             // The anchor is read from where the tracking has driven the camera, which nothing here
             // writes back to. A fit that took its anchor from its own previous result would
             // subtract the viewport's slack afresh on every pass and walk the camera off the level.
-            float anchorX = locked || scrollableX <= 0f
-                ? 0.5f
-                : FIT_TO_BOUNDARIES((camera.pos.X - cameraBounds.x) / scrollableX, 0f, 1f);
-            float anchorY = locked || scrollableY <= 0f
-                ? 0.5f
-                : FIT_TO_BOUNDARIES((camera.pos.Y - cameraBounds.y) / scrollableY, 0f, 1f);
+            float anchorX = GameplayCamera.Anchor(camera.pos.X, cameraBounds.x, scrollableX, slackX);
+            float anchorY = GameplayCamera.Anchor(camera.pos.Y, cameraBounds.y, scrollableY, slackY);
 
             CTRRectangle window = new(
                 cameraBounds.x + (scrollableX * anchorX),

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.cs
@@ -1317,16 +1317,17 @@ namespace CutTheRopeDX.GameMain
         public bool ignoreTouches;
 
         /// <summary>
-        /// Whether the opening camera pan is still travelling toward the level and swallowing
-        /// input on the way.
+        /// Whether the opening camera pan is still travelling toward the level.
         /// </summary>
         /// <remarks>
-        /// This is the predicate the port already suppressed spiders and star timers with, so the
-        /// pan is treated as over at the same moment it hands input back - the last hundred pixels
-        /// are a settle the player is already free to act through, not part of the preview.
+        /// The pan mode is entered once, by <see cref="StartCamera"/>, and left once, when the
+        /// camera lands within a pixel of the point it is chasing - so the mode alone is the whole
+        /// flight, and gameplay resumes only after the picture has actually come to rest. Reading
+        /// <c>ignoreTouches</c> here instead would end the hold a hundred pixels early, while the
+        /// camera is still visibly moving. The pan always terminates: the point it chases cannot
+        /// move while gameplay is held.
         /// </remarks>
-        private bool IntroPanIsRunning =>
-            camera.type == CAMERATYPE.CAMERASPEEDPIXELS && ignoreTouches;
+        private bool IntroPanIsRunning => camera.type == CAMERATYPE.CAMERASPEEDPIXELS;
 
         /// <summary>
         /// Whether the loaded level uses night-specific behavior.

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.cs
@@ -437,6 +437,60 @@ namespace CutTheRopeDX.GameMain
         }
 
         /// <summary>
+        /// World the viewport exposes beyond the camera window on each axis.
+        /// </summary>
+        /// <remarks>
+        /// The fit scales <see cref="cameraWindow"/> - the design box, or the level when it is
+        /// smaller - and never the whole map, so a viewport shaped differently from that box
+        /// reveals world past it. That reveal is settled before any anchor is chosen, which is
+        /// what lets both the anchor and the decision to stage an opening pan be made against it.
+        /// </remarks>
+        /// <param name="snapshot">The viewport to measure against.</param>
+        /// <returns>Exposed world beyond the window, horizontally and vertically.</returns>
+        private Vector CameraSlack(ViewportLayoutSnapshot snapshot)
+        {
+            CTRRectangle viewport = snapshot.VisibleBounds;
+            float scale = MathF.Min(viewport.w / cameraWindow.w, viewport.h / cameraWindow.h);
+            return Vect((viewport.w / scale) - cameraWindow.w, (viewport.h / scale) - cameraWindow.h);
+        }
+
+        /// <summary>
+        /// How far the camera window may travel across the level on each axis, before the
+        /// viewport's own reveal is counted against it.
+        /// </summary>
+        /// <remarks>
+        /// On an axis the level exceeds, <see cref="cameraWindow"/> is capped to the design size
+        /// rather than the full map, so it is the window - not the whole map - that fits the
+        /// viewport, and this is the range the anchor slides that window through: exactly where
+        /// the legacy bounded-pixel camera put it.
+        /// </remarks>
+        /// <returns>Travel available horizontally and vertically.</returns>
+        private Vector CameraScrollable()
+        {
+            return Vect(
+                MathF.Max(0f, cameraBounds.w - cameraWindow.w),
+                MathF.Max(0f, cameraBounds.h - cameraWindow.h));
+        }
+
+        /// <summary>
+        /// Whether moving the camera in this viewport would move the picture at all.
+        /// </summary>
+        /// <param name="snapshot">The viewport to measure against.</param>
+        /// <returns><see langword="true"/> when the level runs past the viewport on either axis.</returns>
+        private bool CameraCanTravel(ViewportLayoutSnapshot snapshot)
+        {
+            if (cameraBounds.w <= 0f || cameraBounds.h <= 0f)
+            {
+                return false;
+            }
+
+            Vector slack = CameraSlack(snapshot);
+            Vector scrollable = CameraScrollable();
+            return GameplayCamera.HasTravel(scrollable.X, slack.X)
+                || GameplayCamera.HasTravel(scrollable.Y, slack.Y);
+        }
+
+        /// <summary>
         /// Fits the camera to the level for the current viewport, holding it centered when the
         /// whole level is already visible.
         /// </summary>
@@ -449,31 +503,18 @@ namespace CutTheRopeDX.GameMain
             }
 
             CTRRectangle viewport = snapshot.VisibleBounds;
-
-            // The fit scales cameraWindow, never the whole map, so the scale - and with it how
-            // much world beyond the window the viewport exposes - is settled before any anchor is
-            // chosen. Computing it here lets the anchor be made against that exposed slack.
-            float scale = MathF.Min(viewport.w / cameraWindow.w, viewport.h / cameraWindow.h);
-            float slackX = (viewport.w / scale) - cameraWindow.w;
-            float slackY = (viewport.h / scale) - cameraWindow.h;
-
-            // On an axis the level exceeds, cameraWindow is capped to the design size rather than
-            // the full map, so it is the window - not the whole map - that fits the viewport; the
-            // anchor slides that window through the map's scrollable range first, exactly where
-            // the legacy bounded-pixel camera put it, before the fit's own anchor distributes
-            // whatever slack remains on an axis the level does not exceed.
-            float scrollableX = MathF.Max(0f, cameraBounds.w - cameraWindow.w);
-            float scrollableY = MathF.Max(0f, cameraBounds.h - cameraWindow.h);
+            Vector slack = CameraSlack(snapshot);
+            Vector scrollable = CameraScrollable();
 
             // The anchor is read from where the tracking has driven the camera, which nothing here
             // writes back to. A fit that took its anchor from its own previous result would
             // subtract the viewport's slack afresh on every pass and walk the camera off the level.
-            float anchorX = GameplayCamera.Anchor(camera.pos.X, cameraBounds.x, scrollableX, slackX);
-            float anchorY = GameplayCamera.Anchor(camera.pos.Y, cameraBounds.y, scrollableY, slackY);
+            float anchorX = GameplayCamera.Anchor(camera.pos.X, cameraBounds.x, scrollable.X, slack.X);
+            float anchorY = GameplayCamera.Anchor(camera.pos.Y, cameraBounds.y, scrollable.Y, slack.Y);
 
             CTRRectangle window = new(
-                cameraBounds.x + (scrollableX * anchorX),
-                cameraBounds.y + (scrollableY * anchorY),
+                cameraBounds.x + (scrollable.X * anchorX),
+                cameraBounds.y + (scrollable.Y * anchorY),
                 cameraWindow.w,
                 cameraWindow.h);
 

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.cs
@@ -1317,6 +1317,18 @@ namespace CutTheRopeDX.GameMain
         public bool ignoreTouches;
 
         /// <summary>
+        /// Whether the opening camera pan is still travelling toward the level and swallowing
+        /// input on the way.
+        /// </summary>
+        /// <remarks>
+        /// This is the predicate the port already suppressed spiders and star timers with, so the
+        /// pan is treated as over at the same moment it hands input back - the last hundred pixels
+        /// are a settle the player is already free to act through, not part of the preview.
+        /// </remarks>
+        private bool IntroPanIsRunning =>
+            camera.type == CAMERATYPE.CAMERASPEEDPIXELS && ignoreTouches;
+
+        /// <summary>
         /// Whether the loaded level uses night-specific behavior.
         /// </summary>
         public bool nightLevel;

--- a/src/CutTheRopeDX.Core/GameMain/GameplayCamera.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameplayCamera.cs
@@ -1,35 +1,35 @@
+using CutTheRopeDX.Framework.Helpers;
+
 namespace CutTheRopeDX.GameMain
 {
     /// <summary>
-    /// Gameplay camera policy: whether the camera follows the action, and where it sits when it
-    /// does not.
+    /// Gameplay camera policy: where the camera sits inside the range the level gives it.
     /// </summary>
     internal static class GameplayCamera
     {
         /// <summary>
-        /// Returns whether the camera should stop following the tracked point because the
-        /// viewport already contains the whole level.
+        /// Returns where along an axis's scrollable range the camera should sit, as a fraction.
         /// </summary>
-        /// <param name="levelWidth">Level width in world units.</param>
-        /// <param name="levelHeight">Level height in world units.</param>
-        /// <param name="viewportWidth">Viewport width in logical units.</param>
-        /// <param name="viewportHeight">Viewport height in logical units.</param>
-        /// <returns>
-        /// <see langword="true"/> when the camera should center and hold still.
-        /// </returns>
-        public static bool ScrollIsLocked(
-            float levelWidth,
-            float levelHeight,
-            float viewportWidth,
-            float viewportHeight)
+        /// <remarks>
+        /// The fit only ever scales the camera window - the design box, or the level when it is
+        /// smaller - so a viewport shaped differently from that box exposes world beyond it. That
+        /// exposed slack is world the level no longer has to scroll to show. Once it covers the
+        /// whole scrollable range the picture has nowhere left to go, and following the tracked
+        /// point would only slide a view that already contains the level; the axis holds centered
+        /// instead. The test is per axis because a level can exceed the box on one and not the
+        /// other, and it is made against the slack the fit actually produces rather than against
+        /// the viewport's aspect, which says nothing about how far the level still has to travel.
+        /// </remarks>
+        /// <param name="tracked">Where the tracking has driven the camera on this axis.</param>
+        /// <param name="origin">World coordinate of the level's near edge on this axis.</param>
+        /// <param name="scrollable">How far the camera window can travel across the level.</param>
+        /// <param name="slack">World the viewport exposes beyond the camera window.</param>
+        /// <returns>The anchor, 0 to 1, where 0.5 is centered.</returns>
+        public static float Anchor(float tracked, float origin, float scrollable, float slack)
         {
-            float levelAspect = levelWidth / levelHeight;
-            float viewportAspect = viewportWidth / viewportHeight;
-
-            // Both landscape and the viewport proportionally wider than the level: every part of
-            // the level is on screen at once, so following anything would move a picture that has
-            // nowhere left to go.
-            return levelAspect > 1f && viewportAspect > 1f && viewportAspect > levelAspect;
+            return scrollable <= slack
+                ? 0.5f
+                : CTRMathHelper.FIT_TO_BOUNDARIES((tracked - origin) / scrollable, 0f, 1f);
         }
     }
 }

--- a/src/CutTheRopeDX.Core/GameMain/GameplayCamera.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameplayCamera.cs
@@ -27,9 +27,21 @@ namespace CutTheRopeDX.GameMain
         /// <returns>The anchor, 0 to 1, where 0.5 is centered.</returns>
         public static float Anchor(float tracked, float origin, float scrollable, float slack)
         {
-            return scrollable <= slack
-                ? 0.5f
-                : CTRMathHelper.FIT_TO_BOUNDARIES((tracked - origin) / scrollable, 0f, 1f);
+            return HasTravel(scrollable, slack)
+                ? CTRMathHelper.FIT_TO_BOUNDARIES((tracked - origin) / scrollable, 0f, 1f)
+                : 0.5f;
+        }
+
+        /// <summary>
+        /// Whether an axis has anywhere left to go: whether the level runs past what the viewport
+        /// already exposes on it.
+        /// </summary>
+        /// <param name="scrollable">How far the camera window can travel across the level.</param>
+        /// <param name="slack">World the viewport exposes beyond the camera window.</param>
+        /// <returns><see langword="true"/> when moving the camera would move the picture.</returns>
+        public static bool HasTravel(float scrollable, float slack)
+        {
+            return scrollable > slack;
         }
     }
 }

--- a/src/CutTheRopeDX.Tests/CameraFitTests.cs
+++ b/src/CutTheRopeDX.Tests/CameraFitTests.cs
@@ -40,13 +40,27 @@ namespace CutTheRopeDX.Tests
         }
 
         [Theory]
-        [InlineData(1920f, 1440f, 3413f, 1440f, true)]   // level 1.33 wide, viewport 2.37: fits
-        [InlineData(1920f, 1440f, 1440f, 2560f, false)]  // portrait viewport: does not fit
-        [InlineData(960f, 2880f, 2560f, 1440f, false)]   // tall level: does not fit
-        public void ScrollLocksWhenTheViewportAlreadyContainsTheLevel(
-            float levelW, float levelH, float viewW, float viewH, bool expected)
+        // Nothing to scroll, or the viewport already exposes everything there was: hold centered.
+        [InlineData(0f, 0f, 0.5f)]
+        [InlineData(1040f, 1040f, 0.5f)]
+        [InlineData(1040f, 2000f, 0.5f)]
+        // Travel left to do, so the anchor follows the tracked position through it.
+        [InlineData(1040f, 0f, 0.25f)]
+        [InlineData(1040f, 520f, 0.25f)]
+        public void TheAnchorFollowsTheTrackedPositionOnlyWhileTheLevelStillHasTravel(
+            float scrollable, float slack, float expected)
         {
-            Assert.Equal(expected, GameplayCamera.ScrollIsLocked(levelW, levelH, viewW, viewH));
+            // Tracked a quarter of the way through a level whose near edge is at -520.
+            Assert.Equal(expected, GameplayCamera.Anchor(-260f, -520f, scrollable, slack), 0.001);
+        }
+
+        [Theory]
+        [InlineData(-2000f, 0f)]
+        [InlineData(2000f, 1f)]
+        public void TheAnchorStaysInsideTheLevelWhenTheTrackedPositionLeavesIt(
+            float tracked, float expected)
+        {
+            Assert.Equal(expected, GameplayCamera.Anchor(tracked, -520f, 1040f, 0f), 0.001);
         }
     }
 }

--- a/src/CutTheRopeDX.Tests/GameplayLayoutCharacterizationTests.cs
+++ b/src/CutTheRopeDX.Tests/GameplayLayoutCharacterizationTests.cs
@@ -30,29 +30,45 @@ namespace CutTheRopeDX.Tests
         }
 
         [Fact]
-        public void CameraStartsAtTheOriginForANonScrollingLevel()
+        public void CameraStartsAtTheLevelOriginForANonScrollingLevel()
         {
             _ = HeadlessGame.Boot();
             GameScene scene = HeadlessGame.LoadLevel(0, 0);
 
             Camera2D camera = ReadCamera(scene);
 
-            Assert.Equal(0f, camera.pos.X, 0.01);
+            // The tracked position is a world coordinate, so a level narrower than the design box
+            // starts it at the level's own left edge rather than at world zero. The region that
+            // ends up drawn is unaffected: the fit spends the horizontal slack about that edge,
+            // which is what CameraStaysAtTheDesignOriginForANonScrollingLevel pins.
+            Assert.Equal(800f, camera.pos.X, 0.01);
             Assert.Equal(0f, camera.pos.Y, 0.01);
-            Assert.Equal(0f, camera.target.X, 0.01);
+            Assert.Equal(800f, camera.target.X, 0.01);
             Assert.Equal(0f, camera.target.Y, 0.01);
         }
 
         [Fact]
-        public void ScreenToWorldAddsTheCameraPositionToday()
+        public void CameraStaysAtTheDesignOriginForANonScrollingLevel()
         {
             _ = HeadlessGame.Boot();
             GameScene scene = HeadlessGame.LoadLevel(0, 0);
 
             Camera2D camera = ReadCamera(scene);
 
-            Assert.Equal(640f, 640f + camera.pos.X, 0.01);
-            Assert.Equal(360f, 360f + camera.pos.Y, 0.01);
+            Assert.Equal(0f, camera.RenderPos.X, 0.01);
+            Assert.Equal(0f, camera.RenderPos.Y, 0.01);
+        }
+
+        [Fact]
+        public void ScreenToWorldIsTheIdentityForANonScrollingLevel()
+        {
+            _ = HeadlessGame.Boot();
+            GameScene scene = HeadlessGame.LoadLevel(0, 0);
+
+            Camera2D camera = ReadCamera(scene);
+
+            Assert.Equal(640f, camera.ScreenToWorldX(640f), 0.01);
+            Assert.Equal(360f, camera.ScreenToWorldY(360f), 0.01);
         }
 
         [Theory]
@@ -78,9 +94,11 @@ namespace CutTheRopeDX.Tests
         }
 
         [Theory]
-        [InlineData(0, 0, 0f, 0f, 0f, 0f)]
+        // X is the level's own left edge, not world zero: these maps are narrower than the design
+        // box and sit centered on it, and the tracked position is a world coordinate.
+        [InlineData(0, 0, 800f, 0f, 800f, 0f)]
         // The tall level is still moving toward the bottom of its 2880-unit map at frame 60.
-        [InlineData(0, 14, 0f, 381.6959f, 0f, 1440f)]
+        [InlineData(0, 14, 800f, 381.6959f, 800f, 1440f)]
         public void CameraPositionAfterSixtyFramesIsPinned(
             int pack,
             int level,

--- a/src/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
+++ b/src/CutTheRopeDX.Tests/Interactions/SceneProbe.cs
@@ -95,6 +95,16 @@ namespace CutTheRopeDX.Tests.Interactions
             return Field<bool>(scene, "timeFrozen");
         }
 
+        /// <summary>Whether the opening camera pan is still in flight.</summary>
+        /// <param name="scene">Scene to read.</param>
+        /// <returns><see langword="true"/> while the pan is still travelling.</returns>
+        public static bool IsIntroPanRunning(this GameScene scene)
+        {
+            PropertyInfo property = typeof(GameScene).GetProperty("IntroPanIsRunning", Instance)
+                ?? throw new MissingMemberException(nameof(GameScene), "IntroPanIsRunning");
+            return (bool)property.GetValue(scene);
+        }
+
         /// <summary>The gameplay particle animation pool.</summary>
         /// <param name="scene">Scene to read.</param>
         /// <returns>The scene-owned particle pool.</returns>

--- a/src/CutTheRopeDX.Tests/IntroPanHoldTests.cs
+++ b/src/CutTheRopeDX.Tests/IntroPanHoldTests.cs
@@ -1,3 +1,5 @@
+using System;
+
 using CutTheRopeDX.GameMain;
 using CutTheRopeDX.Tests.Interactions;
 
@@ -27,9 +29,42 @@ namespace CutTheRopeDX.Tests
         }
 
         [Fact]
-        public void GameplayResumesOnceTheIntroPanHandsInputBack()
+        public void GameplayResumesOnceTheIntroPanHasComeToRest()
         {
             Assert.True(FallAfter(PannedHeight, frames: 240) > 1f);
+        }
+
+        [Fact]
+        public void TheHoldLastsUntilThePanStopsRatherThanUntilInputComesBack()
+        {
+            GameScene scene = FreeCandyLevel(PannedHeight);
+            float start = scene.Candy().WholeBody.Point.pos.Y;
+
+            int inputBack = -1;
+            int panStopped = -1;
+            int firstMovement = -1;
+            for (int frame = 0; frame < 600 && firstMovement < 0; frame++)
+            {
+                HeadlessGame.StepFrames(scene, 1);
+                if (inputBack < 0 && !scene.ignoreTouches)
+                {
+                    inputBack = frame;
+                }
+                if (panStopped < 0 && !scene.IsIntroPanRunning())
+                {
+                    panStopped = frame;
+                }
+                if (MathF.Abs(scene.Candy().WholeBody.Point.pos.Y - start) > 0.001f)
+                {
+                    firstMovement = frame;
+                }
+            }
+
+            // Input is handed back a hundred pixels out, so there is a real stretch of pan left
+            // to run after it - and the candy stays put for all of it, moving on the first step
+            // after the picture comes to rest.
+            Assert.True(panStopped > inputBack + 1, $"pan stopped at {panStopped}, input back at {inputBack}");
+            Assert.Equal(panStopped + 1, firstMovement);
         }
 
         [Fact]

--- a/src/CutTheRopeDX.Tests/IntroPanHoldTests.cs
+++ b/src/CutTheRopeDX.Tests/IntroPanHoldTests.cs
@@ -34,6 +34,45 @@ namespace CutTheRopeDX.Tests
             Assert.True(FallAfter(PannedHeight, frames: 240) > 1f);
         }
 
+        [Theory]
+        // Every map shape in the shipped campaign, at the aspect the game was authored for. The
+        // rule that stages a pan is measured against the viewport now rather than against the
+        // design box; at this aspect it has to land exactly where the design-box comparison did.
+        [InlineData(320, 480, false)]
+        [InlineData(640, 480, false)]
+        [InlineData(320, 700, true)]
+        [InlineData(320, 960, true)]
+        [InlineData(640, 960, true)]
+        public void TheDesignAspectStagesAPanForExactlyTheLevelsItAlwaysDid(
+            int mapWidth, int mapHeight, bool panned)
+        {
+            GameScene scene = Scenario.New()
+                .MapSize(mapWidth, mapHeight)
+                .Candy(mapWidth / 2, 60)
+                .OmNom(mapWidth / 2, mapHeight - 60)
+                .Build();
+
+            Assert.Equal(panned, scene.IsIntroPanRunning());
+        }
+
+        [Theory]
+        // 16:9 exposes one design box of a two-box-tall level, so there is a level to preview.
+        [InlineData(2560, 1440, false)]
+        // Taller, but still not enough to hold 2880 world units at once.
+        [InlineData(720, 1280, false)]
+        // Tall enough that the level is scaled down until all of it is on screen. A pan here could
+        // not move the picture, so staging one would only hold the player away from a level they
+        // can already see in full.
+        [InlineData(400, 1280, true)]
+        public void ThePanIsStagedOnlyWhenTheViewportCannotAlreadyHoldTheLevel(
+            int width, int height, bool skipped)
+        {
+            float fall = 0f;
+            LayoutSurfaces.WithSurface(width, height, () => fall = FallAfter(PannedHeight, frames: 30));
+
+            Assert.Equal(skipped, fall > 1f);
+        }
+
         [Fact]
         public void TheHoldLastsUntilThePanStopsRatherThanUntilInputComesBack()
         {

--- a/src/CutTheRopeDX.Tests/IntroPanHoldTests.cs
+++ b/src/CutTheRopeDX.Tests/IntroPanHoldTests.cs
@@ -1,0 +1,75 @@
+using CutTheRopeDX.GameMain;
+using CutTheRopeDX.Tests.Interactions;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    /// <summary>
+    /// Covers the hold on gameplay while the opening camera pan is still crossing the level.
+    /// </summary>
+    public sealed class IntroPanHoldTests
+    {
+        /// <summary>Authored height that fills the design box exactly, so no pan is staged.</summary>
+        private const int UnpannedHeight = 480;
+
+        /// <summary>Authored height of a level two design boxes tall, which is panned across.</summary>
+        private const int PannedHeight = 960;
+
+        [Fact]
+        public void NothingMovesWhileTheIntroPanIsStillRunning()
+        {
+            // The same unroped candy in a level small enough to need no pan falls straight away,
+            // so the level below is held rather than merely having nothing to do.
+            Assert.True(FallAfter(UnpannedHeight, frames: 30) > 1f);
+
+            Assert.Equal(0f, FallAfter(PannedHeight, frames: 30), 0.001);
+        }
+
+        [Fact]
+        public void GameplayResumesOnceTheIntroPanHandsInputBack()
+        {
+            Assert.True(FallAfter(PannedHeight, frames: 240) > 1f);
+        }
+
+        [Fact]
+        public void TheRestartFadeFinishesOverTheIntroPanRatherThanWaitingForIt()
+        {
+            GameScene scene = FreeCandyLevel(PannedHeight);
+            scene.AnimateLevelRestart();
+
+            // Long enough for both dim phases and the scene swap between them, and far short of
+            // the pan this level stages - which is the point: the fade must not be held by it.
+            HeadlessGame.StepFrames(scene, 40);
+
+            Assert.Equal(0f, scene.gameplayFlow.DimTime, 0.001);
+            Assert.Equal(RestartPhase.Playing, scene.gameplayFlow.Phase);
+        }
+
+        /// <summary>
+        /// Builds a level whose candy hangs from nothing, and reports how far it fell.
+        /// </summary>
+        /// <param name="mapHeight">Authored map height, which decides whether a pan is staged.</param>
+        /// <param name="frames">Frames to advance.</param>
+        /// <returns>World units the candy descended.</returns>
+        private static float FallAfter(int mapHeight, int frames)
+        {
+            GameScene scene = FreeCandyLevel(mapHeight);
+            float start = scene.Candy().WholeBody.Point.pos.Y;
+            HeadlessGame.StepFrames(scene, frames);
+            return scene.Candy().WholeBody.Point.pos.Y - start;
+        }
+
+        /// <summary>Builds a level whose candy hangs from nothing.</summary>
+        /// <param name="mapHeight">Authored map height, which decides whether a pan is staged.</param>
+        /// <returns>The loaded scene.</returns>
+        private static GameScene FreeCandyLevel(int mapHeight)
+        {
+            return Scenario.New()
+                .MapSize(320, mapHeight)
+                .Candy(160, 60)
+                .OmNom(160, mapHeight - 60)
+                .Build();
+        }
+    }
+}

--- a/src/CutTheRopeDX.Tests/WideLevelCameraTrackingTests.cs
+++ b/src/CutTheRopeDX.Tests/WideLevelCameraTrackingTests.cs
@@ -1,0 +1,86 @@
+using System.Reflection;
+
+using CutTheRopeDX.Framework.Helpers;
+using CutTheRopeDX.GameMain;
+using CutTheRopeDX.Tests.Interactions;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    /// <summary>
+    /// Covers a level wider than the design box. Such a level is laid out centered on the box, so
+    /// its left edge is at a negative world X, and the design box alone never shows all of it -
+    /// the camera has to travel, and the positions it must reach are not the ones a range measured
+    /// from world zero would offer.
+    /// </summary>
+    public sealed class WideLevelCameraTrackingTests
+    {
+        /// <summary>
+        /// Authored sizes and the camera positions that show each level's left and right edges.
+        /// The second is proportionally narrower than a 16:9 viewport, which is the shape a fit
+        /// that reasoned from aspect alone would wrongly call already-visible and hold still.
+        /// </summary>
+        /// <returns>Map width, map height, left-edge and right-edge camera positions.</returns>
+        public static TheoryData<int, int, float, float> WideLevels()
+        {
+            return new TheoryData<int, int, float, float>
+            {
+                { 1400, 480, -820f, 820f },
+                { 1200, 853, -520f, 520f },
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(WideLevels))]
+        public void TheIntroPanStartsAtTheLevelsFarEdgeEvenWhenThatIsNegative(
+            int mapWidth, int mapHeight, float leftEdge, float rightEdge)
+        {
+            GameScene scene = WideLevel(mapWidth, mapHeight, candyX: mapWidth - 40);
+
+            Camera2D camera = ReadCamera(scene);
+
+            // Candy on the right half, so the pan starts from the left edge - which on a level
+            // this wide is off to the negative side of the design box.
+            Assert.Equal(leftEdge, camera.pos.X, 0.01);
+            Assert.Equal(leftEdge, camera.RenderPos.X, 0.01);
+            Assert.True(rightEdge > leftEdge);
+        }
+
+        [Theory]
+        [MemberData(nameof(WideLevels))]
+        public void TrackingReachesTheLevelsFarEdgeFromTheOppositeStart(
+            int mapWidth, int mapHeight, float leftEdge, float rightEdge)
+        {
+            GameScene scene = WideLevel(mapWidth, mapHeight, candyX: 40);
+
+            Camera2D camera = ReadCamera(scene);
+            Assert.Equal(rightEdge, camera.pos.X, 0.01);
+
+            HeadlessGame.StepFrames(scene, 400);
+
+            // The candy is past the left edge of what the camera can show, so the tracking pins
+            // against that edge - and the whole traverse must actually be available to it, in the
+            // drawn position as much as in the tracked one.
+            Assert.Equal(leftEdge, camera.pos.X, 0.01);
+            Assert.Equal(leftEdge, camera.RenderPos.X, 0.01);
+        }
+
+        private static GameScene WideLevel(int mapWidth, int mapHeight, int candyX)
+        {
+            return Scenario.New()
+                .MapSize(mapWidth, mapHeight)
+                .Candy(candyX, 60)
+                .Rope(candyX, 30, length: 40)
+                .OmNom(mapWidth / 2, mapHeight - 60)
+                .Build();
+        }
+
+        private static Camera2D ReadCamera(GameScene scene)
+        {
+            return (Camera2D)typeof(GameScene)
+                .GetField("camera", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(scene);
+        }
+    }
+}


### PR DESCRIPTION
## Description

The gameplay camera stopped following the candy on levels bigger than the design box, and the opening pan across one was a hazard rather than a preview.

## What changed

### The camera follows the candy again on large levels

Two separate bugs:

- Its travel range was measured from world zero, but a level wider than the design box is laid out centered on it, so its left edge is at a negative X. The camera stopped following at the level's midpoint and could never reach its left half. It now measures that range from the level's own edge.
- `ScrollIsLocked` compared the level's aspect against the viewport's and concluded a 1.41-wide level was already fully visible on a 1.78-wide screen. It is not - the fit scales the design box, not the level - so the camera parked dead centre showing only the middle of the map. Replaced by a per-axis check against the slack the fit actually produces.

### Gameplay waits for the opening pan

The simulation used to run through it, so a candy could fall - or be eaten, or drift out of a claw - before the player had seen where it was. On a two-box-tall level it fell 183 world units before the pan finished. The hold ends when the pan stops, not when input comes back a hundred pixels earlier.

### A pan is staged only when there is something to pan across

That decision used to compare the level against the design box; it now asks whether the camera can actually move in the viewport it has. A tall level on a tall window is already fully visible, so it starts playable instead of previewing a picture that cannot move. The same 320x960 level:

| Surface   | Visible world height | Level | Pan     |
|-----------|----------------------|-------|---------|
| 2560x1440 | 1440                 | 2880  | staged  |
| 720x1280  | 1707                 | 2880  | staged  |
| 400x1280  | 3072                 | 2880  | skipped |

At the design aspect the rule stages a pan for exactly the levels it always did, so the campaign is unchanged there.

### The restart fade is exempt from the hold

It is presentation, not gameplay, and has to fade in over the pan, otherwise, a restarted level sits behind a full-strength dim for the pan's whole length.