### PR TITLE
fix: Stop the service worker answering every in-scope URL with the shell

### DIFF
--- a/src/CutTheRopeDX.Browser/wwwroot/service-worker.published.js
+++ b/src/CutTheRopeDX.Browser/wwwroot/service-worker.published.js
@@ -131,12 +131,8 @@ async function onFetch(event) {
         return fetch(request);
     }
 
-    // A navigation to any in-scope URL is this single page.
-    if (request.mode === "navigate") {
-        const cached = await caches.match(new URL("index.html", scopeUrl));
-        return cached ?? fetch(request);
-    }
-
+    // Assets answer for themselves even when they are what the address bar was pointed at, so
+    // opening one directly still shows that file rather than the page.
     const contentHash = contentHashes.get(request.url);
     if (contentHash !== undefined) {
         return serveContent(request, contentHash);
@@ -145,6 +141,19 @@ async function onFetch(event) {
     const shellHash = shellHashes.get(request.url);
     if (shellHash !== undefined) {
         return serveShell(request, shellHash);
+    }
+
+    if (request.mode === "navigate") {
+        // index.html carries <base href="./">, which resolves against the URL it was navigated
+        // to rather than the one it is stored at. Serving it under a deeper path would point
+        // every relative asset at a directory that does not exist, so anything below the scope
+        // root goes back to the start URL instead of being answered with a shell that cannot
+        // load. There are no routes here for such a URL to have meant.
+        if (new URL(request.url).pathname !== scopeUrl.pathname) {
+            return Response.redirect(scopeUrl.href, 302);
+        }
+        const cached = await caches.match(new URL("index.html", scopeUrl));
+        return cached ?? fetch(request);
     }
 
     return fetch(request);


### PR DESCRIPTION
## Description

The published worker tested `request.mode === "navigate"` before anything else, so every in-scope navigation got the cached `index.html` regardless of what was asked for. Opening `/cuttherope-dx/pwa.js` returned the page instead of the file that was sitting in the shell cache.

Worse, `index.html` carries `<base href="./">`, which resolves against the URL it was navigated to. Served under `/cuttherope-dx/foo/bar` its base became `/cuttherope-dx/foo/`, so `main.js`, `_framework/` and `content/` all resolved to a directory that does not exist and 404'd - a blank page with nothing pointing at the cause. Without a worker, Pages would have 404'd that URL honestly.

## What's changed

- Content and shell lookups now run before the navigate branch, so a navigation aimed at a real asset is answered with that asset.
- The navigate fallback only serves the shell at the scope root; anything deeper redirects to the start URL, the only thing it could have meant on a page with no routes.