### PR TITLE
feat: Implement Paddington-themed animation

### DIFF
--- a/content/images/char_supports_xmas.json
+++ b/content/images/char_supports_xmas.json
@@ -23,7 +23,7 @@
         "image": "char_supports_xmas.png",
         "format": "RGBA8888",
         "size": { "w": 406, "h": 720 },
-        "scale": "0.78",
+        "scale": "1",
         "smartupdate": "$TexturePacker:SmartUpdate:1e2fdaa71ec5661390e664481e1e95fd:a40c260290277428eca02adb3ec3dffe:6665b543fa963ce3fc958e5d8e34dff3$"
     }
 }

--- a/src/CutTheRopeDX.Core/GameMain/FlashXmlTargetAnimationBackend.cs
+++ b/src/CutTheRopeDX.Core/GameMain/FlashXmlTargetAnimationBackend.cs
@@ -168,6 +168,9 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Whether this skin should start by playing its greeting animation.</summary>
         public bool StartsWithGreeting => SkinDefinition.StartWithGreeting;
 
+        /// <inheritdoc />
+        public bool HasScriptedGreeting => false;
+
         /// <summary>Skin definition that backs this target's animations.</summary>
         public OmNomSkinDefinition SkinDefinition { get; }
 

--- a/src/CutTheRopeDX.Core/GameMain/GameScene.cs
+++ b/src/CutTheRopeDX.Core/GameMain/GameScene.cs
@@ -99,19 +99,29 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         public void ShowGreeting()
         {
+            // A scripted greeting - Om Nom tipping the Paddington hat - plays alone: the chat
+            // greeting would leave the classic skin with no animation at all, since it has no
+            // directional turns, and the hat tip would never run to hand the hat over.
+            bool scriptedGreeting = targetAnimationController?.HasScriptedGreeting == true;
+
             // On a two-Om-Nom level, randomly greet with the mutual chat instead of the wave.
             // TryShowChatGreeting returns false for diagonal/coincident pairs, falling back here.
-            if (targets.Count == 2 && RND_RANGE(0, 1) == 0 && TryShowChatGreeting())
+            if (!scriptedGreeting && targets.Count == 2 && RND_RANGE(0, 1) == 0 && TryShowChatGreeting())
             {
                 return;
             }
 
             // General greeting: the primary Om Nom waves.
             targetAnimationController?.PlayGreeting();
-            CTRSoundMgr.PlayOmNomSound(Resources.Snd.MonsterGreeting, targetAnimationController?.SkinDefinition);
-            if (SpecialEvents.IsXmas && Preferences.GetIntForKey("PREFS_SELECTED_OMNOM") == 0)
+            // A scripted greeting is unvoiced: the hat tip carries neither the wave sound nor the
+            // Christmas bell that otherwise rings over the seasonal greeting.
+            if (!scriptedGreeting)
             {
-                CTRSoundMgr.PlaySound(Resources.Snd.XmasBell);
+                CTRSoundMgr.PlayOmNomSound(Resources.Snd.MonsterGreeting, targetAnimationController?.SkinDefinition);
+                if (SpecialEvents.IsXmas && Preferences.GetIntForKey("PREFS_SELECTED_OMNOM") == 0)
+                {
+                    CTRSoundMgr.PlaySound(Resources.Snd.XmasBell);
+                }
             }
         }
 

--- a/src/CutTheRopeDX.Core/GameMain/ITargetAnimationBackend.cs
+++ b/src/CutTheRopeDX.Core/GameMain/ITargetAnimationBackend.cs
@@ -51,6 +51,13 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Whether this skin plays the greeting animation on initialization instead of idle.</summary>
         bool StartsWithGreeting { get; }
 
+        /// <summary>
+        /// Whether the greeting is a scripted one-shot that owns the whole moment: it must not be
+        /// swapped for the two-Om-Nom chat greeting, and it carries no <c>monster_greeting</c> of
+        /// its own. Om Nom tipping the Paddington hat is one; the ordinary wave is not.
+        /// </summary>
+        bool HasScriptedGreeting { get; }
+
         /// <summary>Whether this backend is driven by Flash XML animation exports.</summary>
         bool UsesFlashXmlAnimations { get; }
 

--- a/src/CutTheRopeDX.Core/GameMain/LevelResourceScanner.cs
+++ b/src/CutTheRopeDX.Core/GameMain/LevelResourceScanner.cs
@@ -257,8 +257,19 @@ namespace CutTheRopeDX.GameMain
                 // skin animates from its own Flash XML and never asks for them.
                 if (hasClassicTarget)
                 {
-                    _ = resources.Add(Resources.Img.CharGreetingXmas);
-                    _ = resources.Add(Resources.Img.CharIdleXmas);
+                    // In January Om Nom tips the Paddington hat instead, and keeps his idle
+                    // variations on the base sheet, so neither Christmas sheet is asked for.
+                    if (SpecialEvents.IsJanuary)
+                    {
+                        // The suitcase belongs to the hat tip, so it is classic-only too.
+                        _ = resources.Add(Resources.Img.CharAnimationsPaddington);
+                        _ = resources.Add(Resources.Img.CharSupportsXmas);
+                    }
+                    else
+                    {
+                        _ = resources.Add(Resources.Img.CharGreetingXmas);
+                        _ = resources.Add(Resources.Img.CharIdleXmas);
+                    }
                 }
 
                 _ = resources.Add(Resources.Img.XmasLights);

--- a/src/CutTheRopeDX.Core/GameMain/LoadObjects/LoadTarget.cs
+++ b/src/CutTheRopeDX.Core/GameMain/LoadObjects/LoadTarget.cs
@@ -11,6 +11,16 @@ namespace CutTheRopeDX.GameMain
 {
     internal sealed partial class GameScene
     {
+        /// <summary>Quad holding Paddington's suitcase on the Christmas support sheet.</summary>
+        private const int PaddingtonSupportQuad = 1;
+
+        /// <summary>
+        /// Downward nudge applied to the suitcase so Om Nom sits on its lid rather than inside it.
+        /// The iOS release offsets by 32/64/128 px across its resolution tiers, all of which are
+        /// 32 px in its 205 px quad space; scaled onto this port's 640 px quads that is 100.
+        /// </summary>
+        private const float PaddingtonSupportOffsetY = 100f;
+
         /// <summary>
         /// Loads Om Nom from XML node data
         /// Sets up Om Nom animations, blink animation, and greeting if needed
@@ -26,17 +36,33 @@ namespace CutTheRopeDX.GameMain
             int pack = ((CTRRootController)Application.SharedRootController()).GetPack();
             int sittingPlatform = PackConfig.GetSittingPlatform(pack);
 
-            // Clamp quad index to valid range; fall back to first quad for invalid values.
-            CTRTexture2D supportTexture = Application.GetTexture(Resources.Img.CharSupports);
-            int quadIndex = (sittingPlatform >= 0 && sittingPlatform < supportTexture.quadRects.Length) ? sittingPlatform : 0;
+            int targetType = ParseIntOrZero(xmlNode.Attribute("targetType")?.Value ?? string.Empty);
 
-            support = Image.Image_createWithResIDQuad(Resources.Img.CharSupports, quadIndex);
+            bool isClassicSkin = OmNomSkinRegistry.IsClassicSkin(
+                OmNomSkinRegistry.ResolveTargetSkinIndex(
+                    targetType,
+                    OmNomSkinRegistry.GetSelectedSkinIndex(),
+                    OmNomSkinRegistry.TotalSkinCount));
+            bool isPaddington = SpecialEvents.IsJanuary && isClassicSkin;
+
+            bool isPrimaryTarget = targets.Count == 0;
+            bool paddingtonGreetingPending =
+                isPaddington && isPrimaryTarget && !nightLevel && CTRRootController.IsShowGreeting();
+
+            // Paddington seats Om Nom on the bear's suitcase instead of the pack's usual platform.
+            string supportResource = isPaddington ? Resources.Img.CharSupportsXmas : Resources.Img.CharSupports;
+            int requestedQuad = isPaddington ? PaddingtonSupportQuad : sittingPlatform;
+
+            // Clamp quad index to valid range; fall back to first quad for invalid values.
+            CTRTexture2D supportTexture = Application.GetTexture(supportResource);
+            int quadIndex = (requestedQuad >= 0 && requestedQuad < supportTexture.quadRects.Length) ? requestedQuad : 0;
+
+            support = Image.Image_createWithResIDQuad(supportResource, quadIndex);
             support.DoRestoreCutTransparency();
             support.anchor = 18;
 
-            int targetType = ParseIntOrZero(xmlNode.Attribute("targetType")?.Value ?? string.Empty);
             ITargetAnimationBackend targetAnimationBackend = TargetAnimationBackendFactory.CreateForTarget(
-                targetType, nightLevel, SpecialEvents.IsXmas);
+                targetType, nightLevel, SpecialEvents.IsXmas, isPaddington, paddingtonGreetingPending);
             TargetAnimationController controller = TargetAnimationController.Create(targetAnimationBackend);
             GameObject targetObj = controller.TargetObject;
             targetBaseScaleX = controller.GetTargetBaseScaleX();
@@ -53,6 +79,10 @@ namespace CutTheRopeDX.GameMain
             int sourceY = ParseCoordinateIntOrZero(yAttribute);
             float transformedY = (sourceY * scale) + offsetY + mapOffsetY;
             targetObj.y = support.y = transformedY;
+            if (isPaddington)
+            {
+                support.y += PaddingtonSupportOffsetY;
+            }
 
             // Mouth hitbox, center-relative so skins of any size keep the same mouth line.
             // Desktop: derived from classic char_animations (640x640): bb = (264, 350, 108, 2).

--- a/src/CutTheRopeDX.Core/GameMain/OriginalTargetAnimationBackend.cs
+++ b/src/CutTheRopeDX.Core/GameMain/OriginalTargetAnimationBackend.cs
@@ -54,8 +54,29 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Timeline ID for the second Christmas idle variation.</summary>
         public const int XmasIdleVariationTwoTimeline = 13;
 
+        /// <summary>Timeline ID for the Paddington hat-tip greeting animation.</summary>
+        public const int PaddingtonGreetingTimeline = 14;
+
         /// <summary>Timeline ID for the night-level sleeping animation.</summary>
         public const int SleepingTimeline = 15;
+
+        /// <summary>First frame of the Paddington greeting animation.</summary>
+        private const int PaddingtonGreetingStartFrame = 0;
+
+        /// <summary>Last frame of the Paddington greeting animation.</summary>
+        private const int PaddingtonGreetingEndFrame = 38;
+
+        /// <summary>
+        /// Frame delay for the Paddington greeting. The greeting runs at 24 fps rather than the
+        /// 20 fps every other original-backend animation uses.
+        /// </summary>
+        private const float PaddingtonGreetingFrameDelay = 1f / 24f;
+
+        /// <summary>
+        /// Quad holding the hat on its own, with no Om Nom. It is the prop left standing beside
+        /// Om Nom once he has tipped his hat and set it down.
+        /// </summary>
+        private const int PaddingtonHatQuad = 39;
 
         /// <summary>First frame of the night-level sleeping animation.</summary>
         private const int SleepAnimStartFrame = 0;
@@ -112,6 +133,18 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Whether this backend should use Christmas animation variants.</summary>
         private readonly bool isXmas;
 
+        /// <summary>Whether this backend should use the Paddington greeting and hat prop.</summary>
+        private bool IsPaddington { get; }
+
+        /// <summary>Hat prop revealed once the Paddington greeting has finished, or <see langword="null"/>.</summary>
+        private readonly Image padHat;
+
+        /// <summary>Whether a Paddington greeting is scheduled for this level.</summary>
+        private readonly bool paddingtonGreetingPending;
+
+        /// <summary>Whether the Paddington greeting has been started at least once.</summary>
+        private bool _paddingtonGreetingStarted;
+
         /// <summary>Blink overlay animation attached to the target.</summary>
         private readonly Animation blink;
 
@@ -138,7 +171,15 @@ namespace CutTheRopeDX.GameMain
         /// </summary>
         /// <param name="isNightLevel">Whether sleep animations should be configured.</param>
         /// <param name="isXmas">Whether Christmas animation variants should be configured.</param>
-        public OriginalTargetAnimationBackend(bool isNightLevel, bool isXmas)
+        /// <param name="isPaddington">Whether the Paddington greeting and hat prop should be configured.</param>
+        /// <param name="paddingtonGreetingPending">Whether a Paddington greeting is scheduled for this level.
+        /// When it is, Om Nom waits wearing the hat until the greeting fires; when it is not, the hat is
+        /// already set down beside him and he starts on the normal idle loop.</param>
+        public OriginalTargetAnimationBackend(
+            bool isNightLevel,
+            bool isXmas,
+            bool isPaddington = false,
+            bool paddingtonGreetingPending = false)
         {
             target = CharAnimations.CharAnimations_createWithResID(Resources.Img.CharAnimations);
             target.DoRestoreCutTransparency();
@@ -146,10 +187,19 @@ namespace CutTheRopeDX.GameMain
 
             this.isNightLevel = isNightLevel;
             this.isXmas = isXmas;
+            IsPaddington = isPaddington;
+            this.paddingtonGreetingPending = isPaddington && paddingtonGreetingPending;
 
             ConfigureTargetResources();
             ConfigureTargetTimelines();
             ConfigureTargetTransitions();
+
+            if (IsPaddington)
+            {
+                padHat = CreatePaddingtonHat();
+                padHat.visible = !this.paddingtonGreetingPending;
+                AttachPaddingtonGreetingHandoff();
+            }
 
             blink = CreateBlinkAnimation();
             if (isNightLevel)
@@ -185,6 +235,14 @@ namespace CutTheRopeDX.GameMain
             target.PlayTimeline(IdleLoopTimeline);
             target.GetTimeline(IdleLoopTimeline).delegateTimelineDelegate = timelineDelegate;
             target.SetPauseAtIndexforAnimation(MouthClosingTimeline, MouthOpeningTimeline);
+
+            if (paddingtonGreetingPending)
+            {
+                // Hold on the first greeting frame so Om Nom is already wearing the hat when the
+                // level fades in, and only tips it once the delayed greeting call arrives.
+                target.PlayAnimationtimeline(Resources.Img.CharAnimationsPaddington, PaddingtonGreetingTimeline);
+                target.GetAnimation(Resources.Img.CharAnimationsPaddington)?.StopCurrentTimeline();
+            }
         }
 
         /// <inheritdoc />
@@ -196,24 +254,10 @@ namespace CutTheRopeDX.GameMain
                     target.PlayTimeline(IdleLoopTimeline);
                     break;
                 case TargetAnimationState.IdleVariationOne:
-                    if (isXmas)
-                    {
-                        target.PlayAnimationtimeline(Resources.Img.CharIdleXmas, XmasIdleVariationOneTimeline);
-                    }
-                    else
-                    {
-                        target.PlayTimeline(IdleVariationOneTimeline);
-                    }
+                    target.PlayTimeline(IdleVariationOneTimeline);
                     break;
                 case TargetAnimationState.IdleVariationTwo:
-                    if (isXmas)
-                    {
-                        target.PlayAnimationtimeline(Resources.Img.CharIdleXmas, XmasIdleVariationTwoTimeline);
-                    }
-                    else
-                    {
-                        target.PlayTimeline(IdleVariationTwoTimeline);
-                    }
+                    target.PlayTimeline(IdleVariationTwoTimeline);
                     break;
                 case TargetAnimationState.IdleVariationThree:
                     break;
@@ -241,7 +285,12 @@ namespace CutTheRopeDX.GameMain
                     }
                     break;
                 case TargetAnimationState.Greeting:
-                    if (isXmas)
+                    if (IsPaddington)
+                    {
+                        target.PlayAnimationtimeline(Resources.Img.CharAnimationsPaddington, PaddingtonGreetingTimeline);
+                        _paddingtonGreetingStarted = true;
+                    }
+                    else if (isXmas)
                     {
                         target.PlayAnimationtimeline(Resources.Img.CharGreetingXmas, XmasGreetingTimeline);
                     }
@@ -271,18 +320,33 @@ namespace CutTheRopeDX.GameMain
         /// <inheritdoc />
         public void PlayRandomIdleVariant(Func<int, int, int> rng)
         {
-            if (rng(0, 1) == 1)
+            // The Christmas idle sheet adds two more variations to the two the base sheet already
+            // has, and Om Nom picks between all four. Paddington drops back to the base pair: the
+            // Christmas idles show him in the Santa hat he has just swapped for the bear's.
+            bool hasXmasIdleVariations = isXmas && !IsPaddington;
+
+            switch (rng(0, hasXmasIdleVariations ? 3 : 1))
             {
-                Play(TargetAnimationState.IdleVariationOne);
-            }
-            else
-            {
-                Play(TargetAnimationState.IdleVariationTwo);
+                case 0:
+                    Play(TargetAnimationState.IdleVariationOne);
+                    break;
+                case 1:
+                    Play(TargetAnimationState.IdleVariationTwo);
+                    break;
+                case 2:
+                    target.PlayAnimationtimeline(Resources.Img.CharIdleXmas, XmasIdleVariationOneTimeline);
+                    break;
+                default:
+                    target.PlayAnimationtimeline(Resources.Img.CharIdleXmas, XmasIdleVariationTwoTimeline);
+                    break;
             }
         }
 
         /// <inheritdoc />
         public bool StartsWithGreeting => false;
+
+        /// <inheritdoc />
+        public bool HasScriptedGreeting => IsPaddington;
 
         /// <inheritdoc />
         public bool UsesFlashXmlAnimations => false;
@@ -349,6 +413,15 @@ namespace CutTheRopeDX.GameMain
         public void UpdateAdditionalOverlays(float delta)
         {
             _ = delta;
+
+            // The greeting hands off to the idle loop by disabling the Paddington animation, which
+            // is the moment Om Nom has finished setting the hat down next to him.
+            if (_paddingtonGreetingStarted
+                && padHat?.visible == false
+                && target.GetAnimation(Resources.Img.CharAnimationsPaddington)?.visible == false)
+            {
+                padHat.visible = true;
+            }
         }
 
         /// <inheritdoc />
@@ -369,8 +442,11 @@ namespace CutTheRopeDX.GameMain
         /// <inheritdoc />
         public void SyncAdditionalOverlayPosition(float x, float y)
         {
-            _ = x;
-            _ = y;
+            if (padHat != null)
+            {
+                padHat.x = x;
+                padHat.y = y;
+            }
         }
 
         /// <inheritdoc />
@@ -405,6 +481,11 @@ namespace CutTheRopeDX.GameMain
             if (zz2?.visible == true)
             {
                 zz2.Draw();
+            }
+            // Drawn after Om Nom so the hat reads as sitting in front of him.
+            if (padHat?.visible == true)
+            {
+                padHat.Draw();
             }
         }
 
@@ -466,6 +547,10 @@ namespace CutTheRopeDX.GameMain
                 target.AddImage(Resources.Img.CharGreetingXmas);
                 target.AddImage(Resources.Img.CharIdleXmas);
             }
+            if (IsPaddington)
+            {
+                target.AddImage(Resources.Img.CharAnimationsPaddington);
+            }
         }
 
         /// <summary>
@@ -488,6 +573,17 @@ namespace CutTheRopeDX.GameMain
                 target.AddAnimationWithIDDelayLoopFirstLast(Resources.Img.CharGreetingXmas, XmasGreetingTimeline, DefaultFrameDelay, Timeline.LoopType.TIMELINE_NO_LOOP, 0, 33);
                 target.AddAnimationWithIDDelayLoopFirstLast(Resources.Img.CharIdleXmas, XmasIdleVariationOneTimeline, DefaultFrameDelay, Timeline.LoopType.TIMELINE_NO_LOOP, 0, 30);
                 target.AddAnimationWithIDDelayLoopFirstLast(Resources.Img.CharIdleXmas, XmasIdleVariationTwoTimeline, DefaultFrameDelay, Timeline.LoopType.TIMELINE_NO_LOOP, 31, 61);
+            }
+
+            if (IsPaddington)
+            {
+                target.AddAnimationWithIDDelayLoopFirstLast(
+                    Resources.Img.CharAnimationsPaddington,
+                    PaddingtonGreetingTimeline,
+                    PaddingtonGreetingFrameDelay,
+                    Timeline.LoopType.TIMELINE_NO_LOOP,
+                    PaddingtonGreetingStartFrame,
+                    PaddingtonGreetingEndFrame);
             }
 
             target.AddAnimationWithIDDelayLoopFirstLast(MouthOpeningTimeline, DefaultFrameDelay, Timeline.LoopType.TIMELINE_NO_LOOP, 19, 27);
@@ -547,6 +643,43 @@ namespace CutTheRopeDX.GameMain
         /// Scale, rotation, and alpha are driven each frame by <see cref="AdvanceZzzState"/>.
         /// </summary>
         /// <returns>Configured ZZZ image, initially hidden.</returns>
+        /// <summary>
+        /// Creates the Paddington hat prop that stands beside Om Nom after the greeting.
+        /// </summary>
+        /// <returns>Hat prop image, sharing Om Nom's anchor so it lands where he set it down.</returns>
+        /// <summary>
+        /// Hands off from the hat tip in a single callback, the way the iOS release does: it reveals
+        /// the hat, drops Om Nom back onto the base sheet and restarts his idle loop together.
+        /// </summary>
+        /// <remarks>
+        /// Splitting those apart blanks the hat for a frame. The greeting's last frame is the only
+        /// one that draws Om Nom beside the hat, and the sheet that replaces it is hatless, so any
+        /// gap between the sheet swap and the prop appearing shows Om Nom empty-handed.
+        /// </remarks>
+        private void AttachPaddingtonGreetingHandoff()
+        {
+            Timeline greeting = target
+                .GetAnimation(Resources.Img.CharAnimationsPaddington)
+                .GetTimeline(PaddingtonGreetingTimeline);
+
+            greeting.OnFinished = () =>
+            {
+                padHat.visible = true;
+                target.PlayTimeline(IdleLoopTimeline);
+            };
+        }
+
+        private Image CreatePaddingtonHat()
+        {
+            Image hat = Image.Image_createWithResIDQuad(Resources.Img.CharAnimationsPaddington, PaddingtonHatQuad);
+            hat.DoRestoreCutTransparency();
+            // The hat is drawn straight at Om Nom's position rather than parented to him, so it has
+            // to carry his anchor to land where the greeting's own last frame left it. AddImage
+            // gives the greeting sheet the same anchor for the same reason.
+            hat.parentAnchor = hat.anchor = target.anchor;
+            return hat;
+        }
+
         private static Image CreateZzzOverlay()
         {
             Image zzz = Image.Image_createWithResID(Resources.Img.FxSleep);

--- a/src/CutTheRopeDX.Core/GameMain/Resources.cs
+++ b/src/CutTheRopeDX.Core/GameMain/Resources.cs
@@ -325,6 +325,7 @@ namespace CutTheRopeDX.GameMain
             public const string CharAnimations = "char_animations";
             public const string CharAnimationsSmooth = "char_animations_smooth";
             public const string CharAnimationsSleeping = "char_animations_sleeping";
+            public const string CharAnimationsPaddington = "char_animations_paddington";
             public const string FxSleep = "fx_sleep";
             public const string FxBubbles = "fx_bubbles";
             public const string FxCutChain = "fx_cut_chain";
@@ -343,6 +344,7 @@ namespace CutTheRopeDX.GameMain
             public const string ObjAnt = "obj_ant";
             public const string ObjBee = "obj_bee";
             public const string CharSupports = "char_supports";
+            public const string CharSupportsXmas = "char_supports_xmas";
             public const string CharAnimations2 = "char_animations2";
             public const string CharAnimations3 = "char_animations3";
             public const string ObjVinil = "obj_vinil";

--- a/src/CutTheRopeDX.Core/GameMain/TargetAnimationBackendFactory.cs
+++ b/src/CutTheRopeDX.Core/GameMain/TargetAnimationBackendFactory.cs
@@ -12,8 +12,15 @@ namespace CutTheRopeDX.GameMain
         /// defers to the player's selected skin.</param>
         /// <param name="isNightLevel">Whether the current level uses night-mode animation variants.</param>
         /// <param name="isXmas">Whether the current level uses Christmas animation variants.</param>
+        /// <param name="isPaddington">Whether the current level uses the Paddington greeting and hat prop.</param>
+        /// <param name="paddingtonGreetingPending">Whether a Paddington greeting is scheduled for this level.</param>
         /// <returns>The original backend for the classic skin, or a Flash XML backend for XML-backed skins.</returns>
-        public static ITargetAnimationBackend CreateForTarget(int targetType, bool isNightLevel, bool isXmas)
+        public static ITargetAnimationBackend CreateForTarget(
+            int targetType,
+            bool isNightLevel,
+            bool isXmas,
+            bool isPaddington = false,
+            bool paddingtonGreetingPending = false)
         {
             int skinIndex = OmNomSkinRegistry.ResolveTargetSkinIndex(
                 targetType,
@@ -21,7 +28,7 @@ namespace CutTheRopeDX.GameMain
                 OmNomSkinRegistry.TotalSkinCount);
 
             return OmNomSkinRegistry.IsClassicSkin(skinIndex)
-                ? new OriginalTargetAnimationBackend(isNightLevel, isXmas)
+                ? new OriginalTargetAnimationBackend(isNightLevel, isXmas, isPaddington, paddingtonGreetingPending)
                 : new FlashXmlTargetAnimationBackend(OmNomSkinRegistry.GetXmlSkinDefinition(skinIndex));
         }
     }

--- a/src/CutTheRopeDX.Core/GameMain/TargetAnimationController.cs
+++ b/src/CutTheRopeDX.Core/GameMain/TargetAnimationController.cs
@@ -100,6 +100,9 @@ namespace CutTheRopeDX.GameMain
         /// <summary>Whether this skin plays the greeting animation on initialization instead of idle.</summary>
         public bool StartsWithGreeting => backend.StartsWithGreeting;
 
+        /// <summary>Whether the greeting is a scripted one-shot that plays alone and without the wave sound.</summary>
+        public bool HasScriptedGreeting => backend.HasScriptedGreeting;
+
         /// <summary>
         /// Plays the excited animation.
         /// </summary>

--- a/src/CutTheRopeDX.Tests/PaddingtonGreetingTests.cs
+++ b/src/CutTheRopeDX.Tests/PaddingtonGreetingTests.cs
@@ -1,0 +1,238 @@
+using System.Reflection;
+
+using CutTheRopeDX.Framework.Visual;
+using CutTheRopeDX.GameMain;
+
+using Xunit;
+
+namespace CutTheRopeDX.Tests
+{
+    /// <summary>
+    /// Covers the Paddington hat-tip greeting. Om Nom starts a January level already wearing the
+    /// bear's hat, tips it once the delayed greeting fires, then sets it down beside him where it
+    /// stays for the rest of the level.
+    /// </summary>
+    public sealed class PaddingtonGreetingTests
+    {
+        /// <summary>
+        /// The sheet holds 40 quads, but the last is the hat on its own - the prop left standing
+        /// after the greeting - so the animation itself runs 0-38.
+        /// </summary>
+        private const int GreetingFrameCount = 39;
+
+
+        /// <summary>The greeting runs at 24 fps, not the 20 fps the rest of the sheet uses.</summary>
+        private const float GreetingFrameDelay = 1f / 24f;
+
+        [Fact]
+        public void TheGreetingRunsEveryFrameExceptTheStandaloneHat()
+        {
+            OriginalTargetAnimationBackend backend = Paddington(greetingPending: true);
+
+            Track frames = GreetingTrack(backend);
+
+            // No trailing hand-off keyframe: the switch back to the idle loop happens in the
+            // timeline's finished callback so it lands together with the hat appearing.
+            Assert.Equal(GreetingFrameCount, frames.keyFramesCount);
+        }
+
+        [Fact]
+        public void TheHatAppearsInTheSameBreathAsOmNomReturningToIdle()
+        {
+            // The last greeting frame is the only one drawing Om Nom beside the hat, and the sheet
+            // that replaces it is hatless - so if these two ever split, he flashes empty-handed.
+            OriginalTargetAnimationBackend backend = Paddington(greetingPending: true);
+            CharAnimations target = (CharAnimations)backend.TargetObject;
+            Image hat = HatOf(backend);
+
+            backend.Play(TargetAnimationState.Greeting);
+            GreetingTimelineOf(backend).OnFinished();
+
+            Assert.True(hat.visible);
+            Assert.False(target.GetAnimation(Resources.Img.CharAnimationsPaddington).visible);
+            Assert.Equal(OriginalTargetAnimationBackend.IdleLoopTimeline, target.GetCurrentTimelineIndex());
+        }
+
+        [Fact]
+        public void TheGreetingRunsFasterThanTheRestOfTheSheet()
+        {
+            OriginalTargetAnimationBackend backend = Paddington(greetingPending: true);
+
+            Track frames = GreetingTrack(backend);
+
+            // The first frame lands at time zero; every frame after it carries the delay.
+            Assert.Equal(GreetingFrameDelay, frames.keyFrames[1].timeOffset, 5);
+        }
+
+        [Fact]
+        public void GreetingPlaysTheHatTipRatherThanTheChristmasGreeting()
+        {
+            OriginalTargetAnimationBackend backend = Paddington(greetingPending: true);
+            CharAnimations target = (CharAnimations)backend.TargetObject;
+
+            backend.Play(TargetAnimationState.Greeting);
+
+            Assert.True(target.GetAnimation(Resources.Img.CharAnimationsPaddington).visible);
+            Assert.False(target.GetAnimation(Resources.Img.CharGreetingXmas).visible);
+        }
+
+        [Fact]
+        public void PaddingtonIdlesNeverReachForTheChristmasSheet()
+        {
+            OriginalTargetAnimationBackend backend = Paddington(greetingPending: false);
+            CharAnimations target = (CharAnimations)backend.TargetObject;
+
+            // The Christmas idles show the Santa hat Om Nom has swapped for the bear's, so the
+            // picker must not even offer them - and every draw it does offer stays on the base sheet.
+            int offeredMax = -1;
+            backend.PlayRandomIdleVariant((_, max) =>
+            {
+                offeredMax = max;
+                return 0;
+            });
+            Assert.Equal(1, offeredMax);
+
+            for (int draw = 0; draw <= offeredMax; draw++)
+            {
+                int pick = draw;
+                backend.PlayRandomIdleVariant((_, _) => pick);
+
+                Assert.False(target.GetAnimation(Resources.Img.CharIdleXmas).visible);
+            }
+        }
+
+        [Fact]
+        public void TheHolidayEventAddsTheChristmasIdlesRatherThanReplacingTheBaseOnes()
+        {
+            // Off-Paddington December: the iOS release picks from four idles - the base sheet's two
+            // plus the Christmas sheet's two - so asking for four draws has to reach both sheets.
+            _ = HeadlessGame.Boot();
+            OriginalTargetAnimationBackend backend = new(isNightLevel: false, isXmas: true);
+            CharAnimations target = (CharAnimations)backend.TargetObject;
+
+            bool reachedChristmasSheet = false;
+            bool reachedBaseSheet = false;
+            for (int draw = 0; draw <= 3; draw++)
+            {
+                backend.PlayRandomIdleVariant((_, _) => draw);
+
+                if (target.GetAnimation(Resources.Img.CharIdleXmas).visible)
+                {
+                    reachedChristmasSheet = true;
+                }
+                else
+                {
+                    reachedBaseSheet = true;
+                }
+            }
+
+            Assert.True(reachedChristmasSheet);
+            Assert.True(reachedBaseSheet);
+        }
+
+        [Fact]
+        public void OutsideTheHolidayTheIdlePickerOnlyOffersTheBasePair()
+        {
+            _ = HeadlessGame.Boot();
+            OriginalTargetAnimationBackend backend = new(isNightLevel: false, isXmas: false);
+
+            int highestDrawOffered = -1;
+            backend.PlayRandomIdleVariant((_, max) =>
+            {
+                highestDrawOffered = max;
+                return 0;
+            });
+
+            Assert.Equal(1, highestDrawOffered);
+        }
+
+        [Fact]
+        public void TheHatIsOutOfSightUntilOmNomHasSetItDown()
+        {
+            OriginalTargetAnimationBackend backend = Paddington(greetingPending: true);
+
+            Assert.False(HatOf(backend).visible);
+        }
+
+        [Fact]
+        public void AlreadyGreetedTheHatIsStandingThereFromTheStart()
+        {
+            // Re-entering a level whose greeting has been spent: no hat tip is coming, so the hat
+            // has to be beside Om Nom already rather than waiting for an animation that never runs.
+            OriginalTargetAnimationBackend backend = Paddington(greetingPending: false);
+
+            Assert.True(HatOf(backend).visible);
+        }
+
+        [Fact]
+        public void TheHatHangsOffOmNomsOwnAnchor()
+        {
+            // It is drawn at his position rather than parented to him, so a mismatched anchor
+            // leaves it floating away from him by the quad's trim offset.
+            OriginalTargetAnimationBackend backend = Paddington(greetingPending: true);
+
+            Assert.Equal(backend.TargetObject.anchor, HatOf(backend).anchor);
+        }
+
+        [Fact]
+        public void TheHatTipIsScriptedSoItPlaysAloneAndUnvoiced()
+        {
+            // Drives two things in ShowGreeting: no monster_greeting over the hat tip, and no
+            // substituting the chat greeting - which the classic skin cannot animate at all, so it
+            // would swallow the hat tip and strand Om Nom holding the hat he never sets down.
+            Assert.True(Paddington(greetingPending: true).HasScriptedGreeting);
+        }
+
+        [Fact]
+        public void TheOrdinaryWaveIsNotScripted()
+        {
+            _ = HeadlessGame.Boot();
+
+            Assert.False(new OriginalTargetAnimationBackend(isNightLevel: false, isXmas: true).HasScriptedGreeting);
+        }
+
+        [Fact]
+        public void OffSeasonThereIsNoHatAtAll()
+        {
+            _ = HeadlessGame.Boot();
+            OriginalTargetAnimationBackend backend = new(isNightLevel: false, isXmas: true);
+
+            Assert.Null(HatOf(backend));
+        }
+
+        private static OriginalTargetAnimationBackend Paddington(bool greetingPending)
+        {
+            _ = HeadlessGame.Boot();
+            return new OriginalTargetAnimationBackend(
+                isNightLevel: false,
+                isXmas: true,
+                isPaddington: true,
+                paddingtonGreetingPending: greetingPending);
+        }
+
+        private static Timeline GreetingTimelineOf(OriginalTargetAnimationBackend backend)
+        {
+            Animation greeting = ((CharAnimations)backend.TargetObject)
+                .GetAnimation(Resources.Img.CharAnimationsPaddington);
+            Assert.NotNull(greeting);
+
+            Timeline timeline = greeting.GetTimeline(OriginalTargetAnimationBackend.PaddingtonGreetingTimeline);
+            Assert.NotNull(timeline);
+            return timeline;
+        }
+
+        private static Track GreetingTrack(OriginalTargetAnimationBackend backend)
+        {
+            Track frames = GreetingTimelineOf(backend).GetTrack(Track.TrackType.TRACK_ACTION);
+            Assert.NotNull(frames);
+            return frames;
+        }
+
+        private static Image HatOf(OriginalTargetAnimationBackend backend)
+        {
+            return (Image)typeof(OriginalTargetAnimationBackend)
+                .GetField("padHat", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(backend);
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Port the Paddington-themed animation from *Cut the Rope: Holiday Gift*. The animation features a briefcase as Om Nom's sitting platform and a hat that hangs throughout the gameplay session. It appears in January for all boxes, as January was the month of the Paddington collaboration with *Cut the Rope*.
- Fix missing idle animation variants for the original holiday animations.